### PR TITLE
block manastone cast outside classic zones

### DIFF
--- a/utils/sql/git/required/2023_09_23_block_manastone_casts.sql
+++ b/utils/sql/git/required/2023_09_23_block_manastone_casts.sql
@@ -1,0 +1,15 @@
+INSERT INTO blocked_spells (spellid, type, zoneid, x, y, z, x_diff, y_diff, z_diff, message, description)
+SELECT
+    (SELECT id FROM spells_new WHERE id = (SELECT clickeffect FROM items WHERE name = "Manastone" LIMIT 1) LIMIT 1) AS spell_id,
+    1 AS type,
+    zone.id AS zoneid,
+    0 AS x,
+    0 AS y,
+    0 AS z,
+    0 AS x_diff,
+    0 AS y_diff,
+    0 AS z_diff,
+    'Manastone unable to be used message sent to client here' AS message,
+    'Manastone internal message here' AS description
+FROM zone
+WHERE expansion != 1 OR long_name IN ('Plane of Hate', 'Plane of Sky', 'Plane of Fear');

--- a/utils/sql/git/required/2023_09_23_block_manastone_casts.sql
+++ b/utils/sql/git/required/2023_09_23_block_manastone_casts.sql
@@ -2,7 +2,7 @@ INSERT INTO blocked_spells (spellid, type, zoneid, x, y, z, x_diff, y_diff, z_di
 SELECT
     (SELECT id FROM spells_new WHERE id = (SELECT clickeffect FROM items WHERE name = "Manastone" LIMIT 1) LIMIT 1) AS spell_id,
     1 AS type,
-    zone.id AS zoneid,
+    zone.zoneidnumber AS zoneid,
     0 AS x,
     0 AS y,
     0 AS z,


### PR DESCRIPTION
Can leave out `OR long_name IN ('Plane of Hate', 'Plane of Sky', 'Plane of Fear')` if you want to keep those in until kunark launch.

Edit

```
    'Manastone unable to be used message sent to client here' AS message,
    'Manastone internal message here' AS description
```
    
To whatever you want.