### PR TITLE
mistwalker fix

### DIFF
--- a/utils/sql/git/required/2023_09_24_mistwalker_pet_fix.sql
+++ b/utils/sql/git/required/2023_09_24_mistwalker_pet_fix.sql
@@ -1,0 +1,1 @@
+UPDATE pets SET petcontrol=2 WHERE type="Mistwalker";

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1621,7 +1621,12 @@ void Mob::AI_Process() {
 					CastToNPC()->DoClassAttacks(victim);
 			}
 			AI_EngagedCastCheck();
-		}	//end is within combat range
+			// despawn mistwalker pet after 1 round of combat
+			if (IsPet() && GetNPCTypeID() == 635) {
+				Depop();
+			}
+			//end is within combat range
+		}
 		else
 		{
 			// Target is outside of melee range


### PR DESCRIPTION
this will make mistwalker summon a controllable pet that depops after 1 round of its combat

The other solution is a temp pet found in this PR https://github.com/SecretsOTheP/EQMacEmu/pull/23

If you don't want to modify the database then we can create something like I did here https://github.com/SecretsOTheP/EQMacEmu/pull/26