### PR TITLE
mistwalker temp pet

### DIFF
--- a/utils/sql/git/required/2023_09_24_mistwalker_temp_pet.sql
+++ b/utils/sql/git/required/2023_09_24_mistwalker_temp_pet.sql
@@ -1,0 +1,2 @@
+UPDATE spells_new SET effectid1=152, max1=3 WHERE id=759;
+UPDATE pets SET temp=1 WHERE type="Mistwalker";


### PR DESCRIPTION
change `max1` to whatever value for number of seconds the pet should be active.

I noticed in testing that at 3 seconds sometimes the pet wouldn't get a round in before poofing. May be need 4? Idk value you want to use.

The other solution is the pre-nerf change found here https://github.com/SecretsOTheP/EQMacEmu/pull/22