### PR TITLE
Update Readme with Quarm Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 follow instructions on EQEmu (https://github.com/EQEmu/Server/blob/master/README.md) as other than login we are using compatible EQEmu code.
 
 Quest Git:
-https://github.com/EQMacEmu/quests
+https://github.com/SecretsOTheP/quests
 
 Map Git:
 https://github.com/EQMacEmu/Maps
 
 Database:
-https://github.com/EQMacEmu/Server/tree/main/utils/sql/database_full
+https://github.com/SecretsOTheP/EQMacEmu/tree/main/utils/sql/database_full


### PR DESCRIPTION
The links were pointing to the takp versions, hopefully this can help make things more clear for future people.

Wasn't 100% sure on the Maps one, so didn't change it