### PR TITLE
Allow self found players to buff normies (non self found)

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1061,7 +1061,7 @@ bool Mob::IsBeneficialAllowed(Mob *target)
 					return false;
 				}
 
-				if (c1->IsSelfFound() == true || c2->IsSelfFound() == true)
+				if (c2->IsSelfFound() == true)
 				{
 					bool can_get_experience = c1->IsInLevelRange(c2->GetLevel2());
 					bool compatible = c1->IsSelfFound() == c2->IsSelfFound();


### PR DESCRIPTION
The community has agreed that self found players should be able to buff "normies" aka non-self found players.

[Link To Discord Discussion](https://discord.com/channels/1133452007412334643/1137154675267883079/1160431493894639647)

Tested logic with [github.com/Vanifac](https://github.com/Vanifac/), have not tested on server, but seems like a simple change.

```
C1 - not self found  C2 - not self found  - skips the block (doesn't fail)
C1 - self found C2 - not self found - skips the block (doesn't fail)
C1 - not self found C2 - self found - fails - not allowed - returns false
C1 - self found C2 - self found - returns false if they are not in level range
```

This keeps in the restriction that normies can not buff self found players