### PR TITLE
Allow normies to pick up items dropped by sf and ssf players

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2867,9 +2867,6 @@ void Client::Handle_OP_ClickObject(const EQApplicationPacket *app)
 			else if ((IsSelfFound() || IsSoloOnly()) && object->GetCharacterDropperID() != this->CharacterID()) {
 				msg = "You cannot pick up dropped player items because you are performing a self found or solo challenge.";
 			}
-			else if (object->IsSSFRuleSet()) {
-				msg = "You cannot pick up this item because it was dropped by a player performing a self found or solo challenge.";
-			}
 			if (!msg.empty())
 			{
 				Message(CC_Red, msg.c_str());


### PR DESCRIPTION
Allow normies to pick up items dropped by sf and ssf players

The community consensus is this should be allowed.  

Example 
 - An SSF or SF necro manages to get an SSOY.  
 - They can't use the item, but don't want it to go to waste. 
 - They gift the item to another player by dropping it on the ground

This solution is nice because we still have trading disabled for SSF and SF players, but allows gifting of items to normies.