### PR TITLE
Convert PoDs to be a merchant that sell enchanted silver bars

### DIFF
--- a/utils/sql/git/required/2023_10_15_pod_merchant.sql
+++ b/utils/sql/git/required/2023_10_15_pod_merchant.sql
@@ -1,0 +1,19 @@
+UPDATE npc_types
+SET class = 41, -- merchant
+	merchant_id = 55158
+WHERE ID = 55158; -- Priest of Discord
+
+-- Add enchanted silver bar to their inventory for sale
+-- Already set to have a cost of 500 which is the same for normal silver bar
+-- Normal silver bar ID = 16500
+INSERT INTO merchantlist(merchantid, slot, item) 
+VALUES(55158, 0, 16504); -- enchanted silver bar
+
+-- Below are some handy queries for testing the inserts
+
+-- SELECT Name, price, slots FROM items WHERE Name LIKE "%silver bar%";
+
+-- SELECT merchantlist.merchantid, npcs.name, merchantlist.item, items.Name FROM merchantlist AS merchantlist
+-- JOIN npc_types AS npcs ON npcs.merchant_id = merchantlist.merchantid
+-- JOIN items AS items ON items.id = merchantlist.item
+-- WHERE merchantlist.item = 16504;


### PR DESCRIPTION
This is on the [Remaining Dev Tasks list](https://discord.com/channels/1133452007412334643/1144852018855415828/1145055397766496336)

This PR is a proof of concept with a few questions attached to it.

Enchanted Silver Bars are the main ones that are being asked about in discord so far, but it seems like we might need to add all of the enchanted items that are used in tradeskills.  [Discord Link](https://discord.com/channels/1133452007412334643/1138575471366377603/1162786677320843385)

[More discussion](https://discord.com/channels/1133452007412334643/1138575471366377603/1162984183577198612)  that's spurred a few questions:

- What does the slot column mean for merchantlist? For silver bar I see multiple values across different merchants - 0, 12, 35 and more

- Perhaps this could actually be a quest rather than making the PoD a merchant?  That might be more fun/immersive?

- Should there be a percentage markup on the sale of enchanted items? 20% was suggested

- Should we make it so the only people that can shop at the PoD are SF and SSF characters?




