### PR TITLE
Remove the ability to /split for self found characters.

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -101,6 +101,12 @@ void Group::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinu
 		return;
 	}
 
+	if (share && splitter->IsSelfFound()) {
+		splitter->Message(CC_Red, "The /split function is not allowed in a self found group.");
+		SendEndLootErrorPacket(splitter);
+		return;
+	}
+
 	uint8 member_count = 0;
 
 	for (uint32 i = 0; i < MAX_GROUP_MEMBERS; i++) {

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -103,7 +103,6 @@ void Group::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinu
 
 	if (share && splitter->IsSelfFound()) {
 		splitter->Message(CC_Red, "The /split function is not allowed in a self found group.");
-		SendEndLootErrorPacket(splitter);
 		return;
 	}
 


### PR DESCRIPTION
Self found should not be allowed to manually /split in any case.

Added a simple check to see if it's a manual /split. if it is check to see if the splitter is self found. Return if it is.