### PR TITLE
Include all rulesets in hardcore death message

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1336,13 +1336,25 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 	{
 		if (GetLevel() >= RuleI(Quarm, HardcoreDeathBroadcastLevel))
 		{
+			std::string rulesets = "Hardcore";
+
+			if (IsSoloOnly())
+			{
+				rulesets.append(" Solo");
+			}
+
+			if (IsSelfFound())
+			{
+				rulesets.append(" Self Found");
+			}
+
 			if (killerMob)
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died to %s! They were level %i.", GetCleanName(), killerMob->GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died to %s! They were level %i.", rulesets, GetCleanName(), killerMob->GetCleanName(), GetLevel());
 			}
 			else
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died! They were level %i.", GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died! They were level %i.", rulesets, GetCleanName(), GetLevel());
 			}
 		}
 	}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1336,13 +1336,25 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 	{
 		if (GetLevel() >= RuleI(Quarm, HardcoreDeathBroadcastLevel))
 		{
+			std::string rulesets = "Hardcore";
+
+			if (IsSoloOnly()) 
+			{
+				rulesets.append(" Solo");
+			}
+
+			if (IsSelfFound()) 
+			{
+				rulesets.append(" Self Found");
+			}
+
 			if (killerMob)
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died to %s! They were level %i.", GetCleanName(), killerMob->GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died to %s! They were level %i.", rulesets, GetCleanName(), killerMob->GetCleanName(), GetLevel());
 			}
 			else
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died! They were level %i.", GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died! They were level %i.", rulesets, GetCleanName(), GetLevel());
 			}
 		}
 	}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3257,9 +3257,9 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 	{
 		if (damage > 0 && spell_id != SPELL_UNKNOWN)
 		{
-			if (attacker && attacker->IsClient() && attacker != this) {
-				attacker->Message_StringID(MT_WornOff, YOUR_HIT_DOT, GetCleanName(), itoa(damage),
-					spells[spell_id].name);
+			if (attacker && attacker->IsClient() && attacker != this) 
+			{
+				attacker->Message_StringID(MT_WornOff, YOUR_HIT_DOT, GetCleanName(), itoa(damage), spells[spell_id].name);
 			}
 		}
 	}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1336,25 +1336,13 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 	{
 		if (GetLevel() >= RuleI(Quarm, HardcoreDeathBroadcastLevel))
 		{
-			std::string rulesets = "Hardcore";
-
-			if (IsSoloOnly()) 
-			{
-				rulesets.append(" Solo");
-			}
-
-			if (IsSelfFound()) 
-			{
-				rulesets.append(" Self Found");
-			}
-
 			if (killerMob)
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died to %s! They were level %i.", rulesets, GetCleanName(), killerMob->GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died to %s! They were level %i.", GetCleanName(), killerMob->GetCleanName(), GetLevel());
 			}
 			else
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died! They were level %i.", rulesets, GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died! They were level %i.", GetCleanName(), GetLevel());
 			}
 		}
 	}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1336,25 +1336,13 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 	{
 		if (GetLevel() >= RuleI(Quarm, HardcoreDeathBroadcastLevel))
 		{
-			std::string rulesets = "Hardcore";
-
-			if (IsSoloOnly())
-			{
-				rulesets.append(" Solo");
-			}
-
-			if (IsSelfFound())
-			{
-				rulesets.append(" Self Found");
-			}
-
 			if (killerMob)
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died to %s! They were level %i.", rulesets, GetCleanName(), killerMob->GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died to %s! They were level %i.", GetCleanName(), killerMob->GetCleanName(), GetLevel());
 			}
 			else
 			{
-				worldserver.SendEmoteMessage(0, 0, 15, "[%s] %s has died! They were level %i.", rulesets, GetCleanName(), GetLevel());
+				worldserver.SendEmoteMessage(0, 0, 15, "[Hardcore] %s has died! They were level %i.", GetCleanName(), GetLevel());
 			}
 		}
 	}


### PR DESCRIPTION
Updated hardcore death broadcast message to include all of the character's challenge rulesets so we know exactly how impressed and sad to be for them.

Before: `[Hardcore] Larry has died! They were level 28.`

After: `[Hardcore Self Found] Larry has died! They were level 28.`

Idea suggested in Discord [here](https://discord.com/channels/1133452007412334643/1138575471366377603/1164687250727116832) 

Regarding lines 32xx: My IDE corrected an inconsistency in the End of Line characters. Those lines had CRLF (\r\n) while the rest of the file had only LF (\n\). My IDE made those consistent. In noticing this [we also decided](https://discord.com/channels/1133452007412334643/1161485739293429830/1165155057885524019) moving the curlies and putting the nested method call on one line was more consistent as well

