### PR TITLE
Re-enable dropped items for SSF and fix exploit

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2872,10 +2872,15 @@ void Client::Handle_OP_ClickObject(const EQApplicationPacket *app)
 			else if ((IsSelfFound() || IsSoloOnly()))
 			{
 				// If the client is self found or solo, don't allow them to pick up the item, unless they are the one that dropped it
-				//if(object->GetCharacterDropperID() != this->CharacterID())
-				//{
+				// Also make sure they dropped it while SSF
+				if(object->GetCharacterDropperID() != this->CharacterID())
+				{
 					msg = "You cannot pick up dropped items because you are performing a self found or solo challenge.";
-				//}
+				}
+				else if(!object->IsSSFRuleSet())
+				{
+					msg = "You cannot pick up dropped items from yourself before you accepted the challenge.";
+				}
 				// The else case does not set a msg because they are allowed to pick it up if they dropped it
 			}
 			if (!msg.empty())


### PR DESCRIPTION
Exploit was that if a player dropped the items before they flagged ssf, then they could pick them up after respawning as ssf.  That's no longer possible