### PR TITLE
IPathfinder to also Utilize Config->MapDir 

### DIFF
--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -18,32 +18,26 @@
  *
 */
 
-#include <fstream>
 #include "file_util.h"
+
+#include <string>
+#include <sys/stat.h>
 
 #ifdef _WINDOWS
 #include <direct.h>
-#include <conio.h>
-#include <iostream>
-#include <dos.h>
-#include <windows.h>
-#include <process.h>
-#else
-
-#include <unistd.h>
-#include <sys/stat.h>
-
 #endif
 
 /**
  * @param name
  * @return
  */
-bool FileUtil::exists(const std::string &name)
+bool FileUtil::exists(const std::string& name)
 {
-	std::ifstream f(name.c_str());
-
-	return f.good();
+	struct stat st {};
+	if (stat(name.c_str(), &st) == 0) { // exists
+		return true;
+	}
+	return false;
 }
 
 /**
@@ -51,15 +45,13 @@ bool FileUtil::exists(const std::string &name)
  */
 void FileUtil::mkdir(const std::string& directory_name)
 {
-
+	bool dir_exists = exists(directory_name);
 #ifdef _WINDOWS
-	struct _stat st;
-	if (_stat(directory_name.c_str(), &st) == 0) // exists
+	if (dir_exists)
 		return;
 	_mkdir(directory_name.c_str());
 #else
-	struct stat st{};
-	if (stat(directory_name.c_str(), &st) == 0) { // exists
+	if (dir_exists) {
 		return;
 	}
 	::mkdir(directory_name.c_str(), 0755);

--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -18,7 +18,6 @@
  *
 */
 
-#include "file_util.h"
 
 #include <string>
 #include <sys/stat.h>
@@ -26,6 +25,8 @@
 #ifdef _WINDOWS
 #include <direct.h>
 #endif
+
+#include "file_util.h"
 
 /**
  * @param name

--- a/common/file_util.h
+++ b/common/file_util.h
@@ -24,7 +24,7 @@
 
 class FileUtil {
 public:
-	static bool exists(const std::string &name);
+	static bool exists(const std::string& name);
 	static void mkdir(const std::string& directory_name);
 };
 

--- a/zone/pathfinder_interface.cpp
+++ b/zone/pathfinder_interface.cpp
@@ -9,8 +9,6 @@
 #include <sys/stat.h>
 
 IPathfinder *IPathfinder::Load(const std::string &zone) {
-	struct stat statbuffer;
-
 	std::string maps_dir;
 	if (FileUtil::exists("maps")) {
 		maps_dir = "maps/";
@@ -27,13 +25,13 @@ IPathfinder *IPathfinder::Load(const std::string &zone) {
 		}
 	}
 
-	std::string navmesh_path = StringFormat("%s%s.nav", maps_dir, zone.c_str());
-	if (stat(navmesh_path.c_str(), &statbuffer) == 0) {
+	std::string navmesh_path = StringFormat("%s%s.nav", maps_dir.c_str(), zone.c_str());
+	if (FileUtil::exists(navmesh_path)) {
 		return new PathfinderNavmesh(navmesh_path);
 	}
 
-	std::string old_navmesh_path = StringFormat("%s%s.path", maps_dir, zone.c_str());
-	if (stat(old_navmesh_path.c_str(), &statbuffer) == 0) {
+	std::string old_navmesh_path = StringFormat("%s%s.path", maps_dir.c_str(), zone.c_str());
+	if (FileUtil::exists(old_navmesh_path)) {
 		return new PathfinderWaypoint(old_navmesh_path);
 	}
 	

--- a/zone/pathfinder_interface.cpp
+++ b/zone/pathfinder_interface.cpp
@@ -5,15 +5,26 @@
 #include "pathfinder_waypoint.h"
 #include "../common/global_define.h"
 #include "../common/eqemu_logsys.h"
+#include "../common/file_util.h"
 #include <sys/stat.h>
 
 IPathfinder *IPathfinder::Load(const std::string &zone) {
 	struct stat statbuffer;
 
-	// this always defaults to: "Maps/" if not specified in the config file
-	std::string maps_dir = Config->MapDir;
-	if (maps_dir[maps_dir.length() - 1] != '/') {
-		maps_dir += "/";
+	std::string maps_dir;
+	if (FileUtil::exists("maps")) {
+		maps_dir = "maps/";
+	}
+	else if (FileUtil::exists("Maps")) {
+		maps_dir = "Maps/";
+	}
+	else {
+		// this always defaults to: "Maps/" if not specified in the config file
+		maps_dir = Config->MapDir;
+		const auto& dir_len = maps_dir.length();
+		if (dir_len > 0 && maps_dir[dir_len - 1] != '/') {
+			maps_dir += "/";
+		}
 	}
 
 	std::string navmesh_path = StringFormat("%s%s.nav", maps_dir, zone.c_str());

--- a/zone/pathfinder_interface.cpp
+++ b/zone/pathfinder_interface.cpp
@@ -9,12 +9,19 @@
 
 IPathfinder *IPathfinder::Load(const std::string &zone) {
 	struct stat statbuffer;
-	std::string navmesh_path = StringFormat("Maps/%s.nav", zone.c_str());
+
+	// this always defaults to: "Maps/" if not specified in the config file
+	std::string maps_dir = Config->MapDir;
+	if (maps_dir[maps_dir.length() - 1] != '/') {
+		maps_dir += "/";
+	}
+
+	std::string navmesh_path = StringFormat("%s%s.nav", maps_dir, zone.c_str());
 	if (stat(navmesh_path.c_str(), &statbuffer) == 0) {
 		return new PathfinderNavmesh(navmesh_path);
 	}
 
-	std::string old_navmesh_path = StringFormat("Maps/%s.path", zone.c_str());
+	std::string old_navmesh_path = StringFormat("%s%s.path", maps_dir, zone.c_str());
 	if (stat(old_navmesh_path.c_str(), &statbuffer) == 0) {
 		return new PathfinderWaypoint(old_navmesh_path);
 	}

--- a/zone/water_map.cpp
+++ b/zone/water_map.cpp
@@ -3,20 +3,12 @@
 #include "water_map.h"
 #include "water_map_v1.h"
 #include "water_map_v2.h"
+#include "../common/file_util.h"
 
 #include <algorithm>
 #include <cctype>
 #include <stdio.h>
 #include <string.h>
-
-/**
- * @param name
- * @return
- */
-inline bool file_exists(const std::string& name) {
-	std::ifstream f(name.c_str());
-	return f.good();
-}
 
 /**
  * @param zone_name
@@ -26,10 +18,10 @@ WaterMap* WaterMap::LoadWaterMapfile(std::string zone_name) {
 	std::transform(zone_name.begin(), zone_name.end(), zone_name.begin(), ::tolower);
 
 	std::string filename;
-	if (file_exists("maps")) {
+	if (FileUtil::exists("maps")) {
 		filename = "maps/";
 	}
-	else if (file_exists("Maps")) {
+	else if (FileUtil::exists("Maps")) {
 		filename = "Maps/";
 	}
 	else {

--- a/zone/water_map.cpp
+++ b/zone/water_map.cpp
@@ -27,16 +27,20 @@ WaterMap* WaterMap::LoadWaterMapfile(std::string zone_name) {
 
 	std::string filename;
 	if (file_exists("maps")) {
-		filename = "maps";
+		filename = "maps/";
 	}
 	else if (file_exists("Maps")) {
-		filename = "Maps";
+		filename = "Maps/";
 	}
 	else {
 		filename = Config->MapDir;
+		const auto& dir_len = filename.length();
+		if (dir_len > 0 && filename[dir_len - 1] != '/') {
+			filename += "/";
+		}
 	}
 
-	std::string file_path = filename + "/" + zone_name + std::string(".wtr");
+	std::string file_path = filename + zone_name + std::string(".wtr");
 	FILE *f = fopen(file_path.c_str(), "rb");
 	if(f) {
 		char magic[10];


### PR DESCRIPTION
- consolidating FileUtil code & includes
  - tested by: making sure a directory is correctly identified or not, and `mkdir`/`_mkdir` succeed
- making IPathfinder::Load also search in the `Config->MapDir`