### PR TITLE
EQOldStream & EQStream updates & processing separation (eq_stream & eq_stream_factory) & lag issue fix

### DIFF
--- a/common/eq_stream.cpp
+++ b/common/eq_stream.cpp
@@ -1104,7 +1104,7 @@ void EQStream::Process(const unsigned char *buffer, const uint32 length)
 {
 static unsigned char newbuffer[2048];
 uint32 newlength=0;
-	if (EQProtocolPacket::ValidateCRC(buffer,length,Key)) {
+	//if (EQProtocolPacket::ValidateCRC(buffer,length,Key)) {
 		if (compressed) {
 			newlength=EQProtocolPacket::Decompress(buffer,length,newbuffer,2048);
 		} else {
@@ -1119,11 +1119,11 @@ uint32 newlength=0;
 		ProcessPacket(p);
 		delete p;
 		ProcessQueue();
-	} else {
-		Log(Logs::Detail, Logs::Netcode, _L "Incoming packet failed checksum" __L);
+	//} else {
+	//	Log(Logs::Detail, Logs::Netcode, _L "Incoming packet failed checksum" __L);
 		//_SendDisconnect();
 		//SetState(CLOSED);
-	}
+	//}
 }
 
 long EQStream::GetNextAckToSend()

--- a/common/eq_stream.cpp
+++ b/common/eq_stream.cpp
@@ -1120,7 +1120,12 @@ static unsigned char newbuffer[2048];
 		delete p;
 		ProcessQueue();
 	} else {
-		Log(Logs::Detail, Logs::Netcode, _L "Incoming packet failed checksum" __L);
+		/*std::string s = {};
+		for (uint32 i = 0; i < length; i++) {
+			int value = buffer[i];
+			s += fmt::format("{:02x} ", value);
+		}*/
+		Log(Logs::Detail, Logs::Netcode, _L "Incoming packet failed checksum: %s" __L);
 		//_SendDisconnect();
 		//SetState(CLOSED);
 	}
@@ -1316,11 +1321,10 @@ EQStream::SeqOrder EQStream::CompareSequence(uint16 expected_seq , uint16 seq)
 }
 
 void EQStream::SetState(EQStreamState state) {
-	MState.lock();
+	std::lock_guard<std::mutex> lock(MState);
 	Log(Logs::Detail, Logs::Netcode, _L "Changing state from %d to %d" __L, State, state);
 	State=state;
 	stale_count=0;
-	MState.unlock();
 }
 
 
@@ -2733,17 +2737,15 @@ void EQOldStream::CheckTimeout(uint32 now, uint32 timeout) {
 }
 
 void EQOldStream::SetState(EQStreamState state) {
-	MState.lock();
+	std::lock_guard<std::mutex> lock(MState);
 
 	if(pm_state == CLOSED)
 	{
-		MState.unlock();
 		return;
 	}
 
 	Log(Logs::Detail, Logs::Netcode, _L "Changing state from %d to %d" __L, pm_state, state);
 	pm_state=state;
-	MState.unlock();
 }
 
 void EQOldStream::SetStreamType(EQStreamType type)

--- a/common/eq_stream.h
+++ b/common/eq_stream.h
@@ -457,7 +457,7 @@ class EQOldStream : public EQStreamInterface {
 				
 		// parce/make packets
 		void ParceEQPacket(uint16 dwSize, uchar* pPacket);
-		void MakeEQPacket(EQProtocolPacket* app, bool ack_req=true); //Make a fragment eq packet and put them on the SQUEUE/RSQUEUE
+		void MakeEQPacket(EQProtocolPacket* app, bool ack_req=true, bool outboundAlreadyLocked=false); //Make a fragment eq packet and put them on the SQUEUE/RSQUEUE
 		void MakeClosePacket();
 		// Add ack to packet if requested
 		void AddAck(EQOldPacket *pack)

--- a/common/eq_stream.h
+++ b/common/eq_stream.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <queue>
 #include <deque>
+#include <mutex>
 
 #ifndef WIN32
 #include <netinet/in.h>
@@ -231,14 +232,13 @@ class EQStream : public EQStreamInterface {
 		uint16 stale_count;
 
 		uint8 active_users;	//how many things are actively using this
-		Mutex MInUse;
+		std::mutex MInUse;
 
 		EQStreamState State;
-		Mutex MState;
+		std::mutex MState;
 
 		uint32 LastPacket;
 		uint32 LastSent;
-		Mutex MVarlock;
 
 		// Ack sequence tracking.
 		long NextAckToSend;
@@ -249,7 +249,7 @@ class EQStream : public EQStreamInterface {
 		void SetNextAckToSend(uint32);
 		void SetLastAckSent(uint32);
 
-		Mutex MAcks;
+		std::mutex MAcks;
 
 		// Packets waiting to be sent (all protected by MOutboundQueue)
 		std::queue<EQProtocolPacket *> NonSequencedQueue;
@@ -258,7 +258,7 @@ class EQStream : public EQStreamInterface {
 		uint16 SequencedBase;	//the sequence number of SequencedQueue[0]
 		bool stream_startup;
 		long NextSequencedSend;	//index into SequencedQueue
-		Mutex MOutboundQueue;
+		std::mutex MOutboundQueue;
 
 		//a buffer we use for compression/decompression
 		unsigned char _tempBuffer[2048];
@@ -266,13 +266,13 @@ class EQStream : public EQStreamInterface {
 		// Packets waiting to be processed
 		std::vector<EQRawApplicationPacket *> InboundQueue;
 		std::map<unsigned short,EQProtocolPacket *> PacketQueue;		//not mutex protected, only accessed by caller of Process()
-		Mutex MInboundQueue;
+		std::mutex MInboundQueue;
 
 		static uint16 MaxWindowSize;
 
 		int32 BytesWritten;
 
-		Mutex MRate;
+		std::mutex MRate;
 		int32 RateThreshold;
 		int32 DecayRate;
 
@@ -331,7 +331,7 @@ class EQStream : public EQStreamInterface {
 		virtual void Close();
 		virtual uint32 GetRemoteIP() const { return remote_ip; }
 		virtual uint16 GetRemotePort() const { return remote_port; }
-		virtual void ReleaseFromUse() { MInUse.lock(); if(active_users > 0) active_users--; MInUse.unlock(); }
+		virtual void ReleaseFromUse() { std::lock_guard<std::mutex> lock(MInUse); if(active_users > 0) active_users--; }
 		virtual void RemoveData() { InboundQueueClear(); OutboundQueueClear(); PacketQueueClear(); /*if (CombinedAppPacket) delete CombinedAppPacket;*/ }
 		virtual bool CheckState(EQStreamState state) { return GetState() == state; }
 		virtual std::string Describe() const { return("Direct EQStream"); }
@@ -348,10 +348,10 @@ class EQStream : public EQStreamInterface {
 		// whether or not the stream has been assigned (we passed our stream match)
 		void SetActive(bool val) { streamactive = val; }
 
-		virtual bool IsInUse() { bool flag; MInUse.lock(); flag=(active_users>0); MInUse.unlock(); return flag; }
-		inline void PutInUse() { MInUse.lock(); active_users++; MInUse.unlock(); }
+		virtual bool IsInUse() { bool flag; std::lock_guard<std::mutex> lock(MInUse); flag=(active_users>0); return flag; }
+		inline void PutInUse() { std::lock_guard<std::mutex> lock(MInUse); active_users++; }
 
-		inline EQStreamState GetState() { EQStreamState s; MState.lock(); s=State; MState.unlock(); return s; }
+		inline EQStreamState GetState() { EQStreamState s; std::lock_guard<std::mutex> lock(MState); s=State; return s; }
 
 		static SeqOrder CompareSequence(uint16 expected_seq , uint16 seq);
 
@@ -423,17 +423,16 @@ class EQOldStream : public EQStreamInterface {
 		~EQOldStream();
 
 	protected:
-		Mutex MResendQueue;
-		Mutex MOutboundQueue;
-		Mutex MInboundQueue;
+		std::mutex MOutboundQueue;
+		std::mutex MInboundQueue;
 		uint32 remote_ip;
 		uint16 remote_port;
 		EQStreamState State;
-		Mutex MState;
+		std::mutex MState;
 		EQStreamType StreamType;
 
 		uint8 active_users;	//how many things are actively using this
-		Mutex MInUse;
+		std::mutex MInUse;
 
 	public:
 		bool IsTooMuchPending()
@@ -524,12 +523,11 @@ class EQOldStream : public EQStreamInterface {
 		int listening_socket;
 		uint16 arsp_response;
 
-		Mutex MRate;
+		std::mutex MRate;
 		int32 RateThreshold;
 		int32 DecayRate;
 
 		uint32 LastPacket;
-		Mutex MVarlock;
 		bool sent_Fin;
 		
 		int32	datarate_sec;	// bytes/1000ms
@@ -543,15 +541,15 @@ class EQOldStream : public EQStreamInterface {
 		virtual EQApplicationPacket *PopPacket();
 		virtual uint32 GetRemoteIP() const { return remote_ip; }
 		virtual uint16 GetRemotePort() const { return remote_port; }
-		virtual void ReleaseFromUse() { MInUse.lock(); if(active_users > 0) active_users--; MInUse.unlock(); }
+		virtual void ReleaseFromUse() { std::lock_guard<std::mutex> lock(MInUse); if(active_users > 0) active_users--; }
 		virtual void RemoveData();
 		virtual bool CheckState(EQStreamState state) { return GetState() == state; }
 		virtual std::string Describe() const { return("Direct EQOldStream"); }
-		virtual bool IsInUse() { bool flag; MInUse.lock(); flag=(active_users>0); MInUse.unlock(); return flag; }
+		virtual bool IsInUse() { bool flag; std::lock_guard<std::mutex> lock(MInUse); flag=(active_users>0); return flag; }
 		bool IsWriting() { return isWriting; }
 		void SetWriting(bool var) { isWriting = var; } 
-		inline void PutInUse() { MInUse.lock(); active_users++; MInUse.unlock(); }
-		inline EQStreamState GetState() { EQStreamState s; MState.lock(); s=pm_state; MState.unlock(); return s; }
+		inline void PutInUse() { std::lock_guard<std::mutex> lock(MInUse); active_users++; }
+		inline EQStreamState GetState() { EQStreamState s; std::lock_guard<std::mutex> lock(MState); s=pm_state; return s; }
 		void	SendPacketQueue(bool Block = true);
 		void	FinalizePacketQueue();
 		void	ClearPacketQueue();

--- a/common/eq_stream.h
+++ b/common/eq_stream.h
@@ -424,7 +424,9 @@ class EQOldStream : public EQStreamInterface {
 
 	protected:
 		std::mutex MOutboundQueue;
+		std::mutex MOutboundOldQueue;
 		std::mutex MInboundQueue;
+		std::mutex MInboundOldQueue;
 		uint32 remote_ip;
 		uint16 remote_port;
 		EQStreamState State;

--- a/common/eq_stream.h
+++ b/common/eq_stream.h
@@ -423,9 +423,7 @@ class EQOldStream : public EQStreamInterface {
 		~EQOldStream();
 
 	protected:
-		std::mutex MOutboundQueue;
 		std::mutex MOutboundOldQueue;
-		std::mutex MInboundQueue;
 		std::mutex MInboundOldQueue;
 		uint32 remote_ip;
 		uint16 remote_port;

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -6,6 +6,7 @@
 #include <queue>
 #include <map>
 #include <mutex>
+#include <condition_variable>
 
 #include "../common/eq_stream.h"
 #include "../common/condition.h"

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -21,11 +21,11 @@ class RecvBuffer {
 		bool isnew;
 		uint32 length;
 		std::unique_ptr<unsigned char[]> buffer;
-		std::pair<ULONG, USHORT> streamkey;
+		std::pair<unsigned long, unsigned short> streamkey;
 		sockaddr_in from;
 
 	public:
-		RecvBuffer(bool isnew, uint32 len, const unsigned char* buf, std::pair<ULONG, USHORT> key, sockaddr_in& f) : isnew(isnew), length(len), streamkey(key), from(f) {
+		RecvBuffer(bool isnew, uint32 len, const unsigned char* buf, std::pair<unsigned long, unsigned short> key, sockaddr_in& f) : isnew(isnew), length(len), streamkey(key), from(f) {
 				buffer.reset(new unsigned char[len]);
 				memcpy(buffer.get(), buf, len);
 		}

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -33,7 +33,7 @@ class RecvBuffer {
 		bool IsNew() const { return isnew; }
 		unsigned char* Buffer() const { return buffer.get(); }
 		uint32 Length() const { return length; }
-		const std::pair<ULONG, USHORT>& StreamKey() const { return streamkey; }
+		const std::pair<unsigned long, unsigned short>& StreamKey() const { return streamkey; }
 		const sockaddr_in& From() const { return from; }
 };
 

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -18,19 +18,23 @@ class Timer;
 
 class RecvBuffer {
 	private:
+		bool isnew;
 		uint32 length;
 		std::unique_ptr<unsigned char[]> buffer;
+		std::pair<ULONG, USHORT> streamkey;
 		sockaddr_in from;
 
 	public:
-		RecvBuffer(uint32 len, const unsigned char* buf, sockaddr_in& f) : length(len), from(f) {
+		RecvBuffer(bool isnew, uint32 len, const unsigned char* buf, std::pair<ULONG, USHORT> key, sockaddr_in& f) : isnew(isnew), length(len), streamkey(key), from(f) {
 				buffer.reset(new unsigned char[len]);
 				memcpy(buffer.get(), buf, len);
 		}
 
+		bool IsNew() const { return isnew; }
 		unsigned char* Buffer() const { return buffer.get(); }
 		uint32 Length() const { return length; }
-		sockaddr_in& From() { return from; }
+		const std::pair<ULONG, USHORT>& StreamKey() const { return streamkey; }
+		const sockaddr_in& From() const { return from; }
 };
 
 class EQStreamFactory : private Timeoutable {

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <mutex>
 #include <condition_variable>
+#include <thread>
 
 #include "../common/eq_stream.h"
 #include "../common/condition.h"

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -62,6 +62,7 @@ class EQStreamFactory : private Timeoutable {
 
 		std::map<std::pair<uint32, uint16>, std::shared_ptr<EQOldStream>> OldStreams;
 
+		std::thread ReaderThread;
 		std::thread ProcessNewThread;
 		std::thread WriterNewThread;
 		std::thread ProcessOldThread;


### PR DESCRIPTION
- converted Mutex -> std::mutex, std::lock_guard, std::unique_lock
- converted Conditional -> std::condition_variable
- converted to use std::thread
- separated all mutex into corresponding EQOldStream & EQStream
- separated thread functionality into corresponding EQOldStream & EQStream
  - ReaderThread
  - ProcessNewThread
  - WriterNewThread
  - ProcessOldThread
  - WriterOldThread
- fix for UCS
- fix for lag encountered when EQ is unfocused (https://github.com/SecretsOTheP/EQMacEmu/pull/56/commits/2be836b3fc19f16fc0812908e83752e1ba0bb17f)
- tested by: compiling on mscv & gnu, verifying cpu usage is acceptable, running & playing on both windows & linux environments