### PR TITLE
eq_stream_factory Close fixes

### DIFF
--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -101,12 +101,12 @@ class EQStreamFactory : private Timeoutable {
 		void ProcessLoopOld();
 		void WriterLoopNew();
 		void WriterLoopOld();
-		void Stop() { StopReader(); StopWriterNew(); StopWriterOld(); }
-		void StopReader() { std::lock_guard<std::mutex> lock(MReaderRunning); ReaderRunning = false; }
-		void StopWriterNew() { std::unique_lock<std::mutex>(MWriterRunningNew); WriterRunningNew=false; MWriterRunningNew.unlock(); WriterWorkNew.notify_one(); }
-		void StopWriterOld() { std::unique_lock<std::mutex>(MWriterRunningOld); WriterRunningOld=false; MWriterRunningOld.unlock(); WriterWorkOld.notify_one(); }
-		void SignalWriterNew() { WriterWorkNew.notify_one(); }
-		void SignalWriterOld() { WriterWorkOld.notify_one(); }
+		void Stop();
+		void StopReader();
+		void StopWriterNew();
+		void StopWriterOld();
+		void SignalWriterNew();
+		void SignalWriterOld();
 };
 
 #endif


### PR DESCRIPTION
- moving various Stop & Signal functions to .cpp
- terminate crash fixes:
  - for joining threads, need to make sure they're still joinable
  - typo for StopWriterNew, StopWriterOld these weren't using the unique_lock

Tested by:
repro: Sending interrupt signal to zone process, verifying there is a crash
fix: Sending interrupt signal to zone process, verifying no longer crashing

Also tested by sending interrupt signal to world process to make sure it isn't crashing as well