### PR TITLE
qs_player_speech logging additions

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -939,9 +939,11 @@ struct ServerMailMessageHeader_Struct {
 };
 
 struct Server_Speech_Struct {
-	char	to[64];
+	char	to[325]; // store up to 5 names of size 64, and 4 commas + 1 null terminator
 	char	from[64];
 	uint32	guilddbid;
+	uint32	groupid;
+	uint32	characterid;
 	int16	minstatus;
 	uint32	type;
 	char	message[0];

--- a/queryserv/database.cpp
+++ b/queryserv/database.cpp
@@ -93,7 +93,9 @@ void Database::LogPlayerSpeech(
 	const char *message,
 	uint16 minstatus,
 	uint32 guilddbid,
-	uint8 type
+	uint8 type,
+	uint32 characterid,
+	uint32 groupid
 )
 {
 
@@ -107,8 +109,9 @@ void Database::LogPlayerSpeech(
 	std::string query = StringFormat(
 		"INSERT INTO `qs_player_speech` "
 		"SET `from` = '%s', `to` = '%s', `message`='%s', "
-		"`minstatus`='%i', `guilddbid`='%i', `type`='%i'",
-		escapedFrom, escapedTo, escapedMessage, minstatus, guilddbid, type
+		"`minstatus`='%i', `guilddbid`='%i', `type`='%i', "
+		"`characterid`='%i', `groupid`='%i'",
+		escapedFrom, escapedTo, escapedMessage, minstatus, guilddbid, type, characterid, groupid
 	);
 	safe_delete_array(escapedFrom);
 	safe_delete_array(escapedTo);

--- a/queryserv/database.h
+++ b/queryserv/database.h
@@ -51,7 +51,7 @@ public:
 
 	void LogMerchantTransaction(QSMerchantLogTransaction_Struct* QS, uint32 Items);
 
-	void LogPlayerSpeech(const char* from, const char* to, const char* message, uint16 minstatus, uint32 guilddbid, uint8 type);
+	void LogPlayerSpeech(const char* from, const char* to, const char* message, uint16 minstatus, uint32 guilddbid, uint8 type, uint32 charcterid, uint32 groupid);
 	void LogPlayerItemDelete(QSPlayerLogItemDelete_Struct* QS, uint32 Items);
 	void LogPlayerItemMove(QSPlayerLogItemMove_Struct* QS, uint32 Items);
 	void LogPlayerLootRecords(QSPlayerLootRecords_struct* QS, uint32 Items);

--- a/queryserv/worldserver.cpp
+++ b/queryserv/worldserver.cpp
@@ -72,7 +72,7 @@ void WorldServer::Process()
 				Server_Speech_Struct *SSS = (Server_Speech_Struct *)pack->pBuffer;
 				std::string          tmp1 = SSS->from;
 				std::string          tmp2 = SSS->to;
-				database.LogPlayerSpeech(tmp1.c_str(), tmp2.c_str(), SSS->message, SSS->minstatus, SSS->guilddbid, SSS->type);
+				database.LogPlayerSpeech(tmp1.c_str(), tmp2.c_str(), SSS->message, SSS->minstatus, SSS->guilddbid, SSS->type, SSS->characterid, SSS->groupid);
 				break;
 			}
 			case ServerOP_QSPlayerLogItemDeletes: {

--- a/utils/sql/git/required/2023_11_22_qs_player_speech_additions.sql
+++ b/utils/sql/git/required/2023_11_22_qs_player_speech_additions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `qs_player_speech` CHANGE COLUMN `to` `to` VARCHAR(325) NOT NULL COLLATE 'utf8_general_ci' AFTER `from`, ADD COLUMN `characterid` INT(11) NOT NULL AFTER `type`, ADD COLUMN `groupid` INT(11) NOT NULL AFTER `characterid`;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -746,7 +746,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 
 	Log(Logs::Detail, Logs::ZoneServer, "Client::ChannelMessageReceived() Channel:%i message:'%s'", chan_num, message);
 
-	if (targetname == nullptr) {
+	if (targetname == nullptr || strlen(targetname) == 0) {
 		targetname = (!GetTarget()) ? "" : GetTarget()->GetName();
 	}
 
@@ -805,10 +805,24 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		else
 			sem->guilddbid = 0;
 
+		auto group = GetGroup();
+		if (group && chan_num == ChatChannel_Group) {
+			sem->groupid = group->GetID();
+			std::string groupMembers = group->GetMemberNamesAsCsv({ GetName() });
+			strncpy(sem->to, groupMembers.c_str(), 325);
+			sem->to[324] = 0;
+		}
+		else {
+			sem->groupid = 0;
+		}
+
+		sem->characterid = CharacterID();
+
 		strcpy(sem->message, message);
 		sem->minstatus = this->Admin();
 		sem->type = chan_num;
-		if (targetname != 0)
+
+		if (sem->groupid == 0 && targetname != 0)
 		{
 			strncpy(sem->to, targetname, 64);
 			sem->to[63] = 0;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -9740,8 +9740,10 @@ void command_qtest(Client *c, const Seperator *sep){
 			sem->minstatus = c->Admin();
 			sem->type = 1;
 			strncpy(sem->to, c->GetTarget()->GetCleanName(), 64);
-			strncpy(sem->to, c->GetCleanName(), 64);
+			strncpy(sem->from, c->GetCleanName(), 64);
 			sem->guilddbid = c->GuildID();
+			sem->characterid = c->CharacterID();
+			sem->groupid = 0;
 			worldserver.SendPacket(pack);
 			safe_delete(pack);
 		}

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -1268,3 +1268,21 @@ bool Group::HasOOZMember(std::string& member)
 
 	return false;
 }
+
+std::string Group::GetMemberNamesAsCsv(const std::vector<std::string>& excludes)
+{
+	std::string names;
+	for (uint8 i = 0; i < MAX_GROUP_MEMBERS; ++i) {
+		if (membername[i][0] == '\0')
+			continue;
+
+		if (std::find(excludes.begin(), excludes.end(), membername[i]) != excludes.end())
+			continue;
+
+		if (!names.empty())
+			names += ",";
+
+		names += membername[i];
+	}
+	return names;
+}

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -95,6 +95,7 @@ public:
 	const char *GetClientNameByIndex(uint8 index);
 	void	SetLevels();
 	bool	HasOOZMember(std::string& member);
+	std::string GetMemberNamesAsCsv(const std::vector<std::string>& excludes = {});
 
 	Mob* members[MAX_GROUP_MEMBERS];
 	char	membername[MAX_GROUP_MEMBERS][64];


### PR DESCRIPTION
- additions to log information for:
  - up to 5 group members
  - groupid
  - characterid

requires: `utils/sql/git/required/2023_11_22_qs_player_speech_additions.sql` applied

note: https://github.com/SecretsOTheP/EQMacEmu/compare/main...chazix:EQMacEmu:qs-player-speech-additions?expand=1#diff-8541f36e60ccf19a8ff067c78dd04929f95503850299a869b54fd28e49fb8ed1R749
- The `targetname` wasn't being propagated as `nullptr` when I would target a player client. It was being propagated as an empty string of length 0

Tested by:
- forming a group of 6 clients locally; tested with these steps from 2->6 clients as they were joining
- having each one send a message to the group
- verifying the functionality was applied in the db