### PR TITLE
Chat targetname preservation & PlayerLogChat target isolation

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -823,8 +823,10 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		sem->type = chan_num;
 
 		// => to: preserve the targetname if it's not empty
+		//     => tells for example will have a targetname already
 		// => to: use the guild name if the channel is guild
-		// => to: use the target name if the channel is not guild
+		// => to: use the zone short name if the channel is auction, ooc, or shout
+		// => to: use the target name if the channel is not guild, auction, ooc, shout, broadcast, raid, or petition
 		bool targetNameIsEmpty = targetname == nullptr || strlen(targetname) == 0;
 		char logTargetName[64] = { 0 };
 		if (targetNameIsEmpty) {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -828,16 +828,35 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		bool targetNameIsEmpty = targetname == nullptr || strlen(targetname) == 0;
 		char logTargetName[64] = { 0 };
 		if (targetNameIsEmpty) {
-			if (chan_num != ChatChannel_Guild) {
-				const char* temp = (!GetTarget()) ? "" : GetTarget()->GetName();
-				strncpy(logTargetName, temp, 64);
-				logTargetName[63] = 0;
-			}
-			else {
-				std::string guildName = GetGuildName();
-				const char* temp = guildName.c_str();
-				strncpy(logTargetName, temp, 64);
-				logTargetName[63] = 0;
+			switch (chan_num) {
+				case ChatChannel_Guild: {
+					std::string guildName = GetGuildName();
+					const char* temp = guildName.c_str();
+					strncpy(logTargetName, temp, 64);
+					logTargetName[63] = 0;
+				}
+				break;
+
+				case ChatChannel_Auction:
+				case ChatChannel_OOC:
+				case ChatChannel_Shout: {
+					const char* temp = zone->GetShortName();
+					strncpy(logTargetName, temp, 64);
+					logTargetName[63] = 0;
+				}
+				break;
+
+				case ChatChannel_Broadcast:
+				case ChatChannel_Raid:
+				case ChatChannel_Petition:
+					break;
+
+				default: {
+					const char* temp = (!GetTarget()) ? "" : GetTarget()->GetName();
+					strncpy(logTargetName, temp, 64);
+					logTargetName[63] = 0;
+				}
+				break;
 			}
 		}
 		else {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -746,7 +746,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 
 	Log(Logs::Detail, Logs::ZoneServer, "Client::ChannelMessageReceived() Channel:%i message:'%s'", chan_num, message);
 
-	if (targetname == nullptr || strlen(targetname) == 0) {
+	if (targetname == nullptr) {
 		targetname = (!GetTarget()) ? "" : GetTarget()->GetName();
 	}
 
@@ -822,11 +822,36 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		sem->minstatus = this->Admin();
 		sem->type = chan_num;
 
-		if (sem->groupid == 0 && targetname != 0)
+		// => to: preserve the targetname if it's not empty
+		// => to: use the guild name if the channel is guild
+		// => to: use the target name if the channel is not guild
+		bool targetNameIsEmpty = targetname == nullptr || strlen(targetname) == 0;
+		char logTargetName[64] = { 0 };
+		if (targetNameIsEmpty) {
+			if (chan_num != ChatChannel_Guild) {
+				const char* temp = (!GetTarget()) ? "" : GetTarget()->GetName();
+				strncpy(logTargetName, temp, 64);
+				logTargetName[63] = 0;
+			}
+			else {
+				std::string guildName = GetGuildName();
+				const char* temp = guildName.c_str();
+				strncpy(logTargetName, temp, 64);
+				logTargetName[63] = 0;
+			}
+		}
+		else {
+			strncpy(logTargetName, targetname, 64);
+			logTargetName[63] = 0;
+		}
+
+		// => if groupid is not 0, sem->to has already been filled with the group members
+		if (sem->groupid == 0 && strlen(logTargetName) != 0)
 		{
-			strncpy(sem->to, targetname, 64);
+			strncpy(sem->to, logTargetName, 64);
 			sem->to[63] = 0;
 		}
+		// ----------------------------------------------
 
 		if (GetName() != 0)
 		{

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -842,9 +842,11 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 				case ChatChannel_Auction:
 				case ChatChannel_OOC:
 				case ChatChannel_Shout: {
-					const char* temp = zone->GetShortName();
-					strncpy(logTargetName, temp, 64);
-					logTargetName[63] = 0;
+					if (zone) {
+						const char* temp = zone->GetShortName();
+						strncpy(logTargetName, temp, 64);
+						logTargetName[63] = 0;
+					}
 				}
 				break;
 


### PR DESCRIPTION
- revert `targetname` isolated change, preserving `targetname` conditional as it was before
- retrieve `logTargetName` independently in the `PlayerLogChat` process
  - new: a guild message `logTargetName` will be the name of the guild
  - new: auction, ooc, shout `logTargetName` is the zone shortname

Tested by:
- before fix: creating 2 guilds, having a client from another guild target the other client in different guild, sending guild message to other client, seeing that the other client receives a guild message from the non-member client
- after fix: verified original functionality is restored, and no target based guild messages
- `/say` w/ & w/out a target, verified `to` in `qs_player_speech` table
- `/tt`, `/tell`, verified `to` always the recipient
- `/gu`, verified `to` is always guild name, and doesn't send to other target's guilds
- `/g`, verified `to` contains csv of members
- `#commands`, verified `to` contains target (essentially just `/say` channel for my test case) 
- `/auction`, `/ooc`, `/shout`, verified `to` contains zone shortname
- verified raid chat has no `to`