### PR TITLE
Add solo, self found, hardcore flags to the who all list data

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -392,6 +392,9 @@ struct ServerClientList_Struct {
 	bool	AFK;
 	bool	Trader;
 	int8	Revoked;
+	bool	selffound;
+	bool	hardcore;
+	bool	solo;
 };
 
 struct ServerClientListKeepAlive_Struct {

--- a/world/cliententry.cpp
+++ b/world/cliententry.cpp
@@ -192,6 +192,9 @@ void ClientListEntry::Update(ZoneServer* iZS, ServerClientList_Struct* scl, int8
 	pAFK = scl->AFK;
 	pTrader = scl->Trader;
 	pRevoked = scl->Revoked;
+	pSelfFound = scl->selffound;
+	pHardcore = scl->hardcore;
+	pSolo = scl->solo;
 
 	// Fields from the LFG Window
 	if((scl->LFGFromLevel != 0) && (scl->LFGToLevel != 0)) {

--- a/world/cliententry.h
+++ b/world/cliententry.h
@@ -93,6 +93,9 @@ public:
 	inline bool		AFK() const { return pAFK;  }
 	inline bool		Trader() const { return pTrader; }
 	inline int8		Revoked() const { return pRevoked; }
+	inline bool		IsSelfFound() const { return pSelfFound; }
+	inline bool		IsHardcore() const { return pHardcore; }
+	inline bool		IsSolo() const { return pSolo; }
 
 	inline bool TellQueueFull() const { return tell_queue.size() >= RuleI(World, TellQueueSize); }
 	inline bool TellQueueEmpty() const { return tell_queue.empty(); }
@@ -148,6 +151,9 @@ private:
 	bool	pAFK;
 	bool	pTrader;
 	int8	pRevoked;
+	bool	pSelfFound;
+	bool	pHardcore;
+	bool	pSolo;
 
 	// Tell Queue -- really a vector :D
 	std::vector<ServerChannelMessage_Struct *> tell_queue;

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -32,6 +32,7 @@
 #include "../zone/string_ids.h"
 
 #include <set>
+#include <cstring>  // For strlen and strncat
 
 extern ConsoleList		console_list;
 extern ZSList			zoneserver_list;
@@ -876,6 +877,40 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 
 				char plname[64] = { 0 };
 				strcpy(plname, cle->name());
+
+				// Append the SSFHC flags after the name if there's room
+				if(cle->IsSelfFound() || cle->IsHardcore() || cle->IsSolo())
+				{
+					// Start with the base append string
+					std::string appendStr = " -";
+
+					if(cle->IsSolo())
+						appendStr += "s";
+					if (cle->IsSelfFound())
+						appendStr += "sf";
+					if (cle->IsHardcore())
+						appendStr += "hc";
+
+					appendStr += "-";
+
+					// Calculate the remaining space in the buffer
+					size_t remainingSpace = 63 - strlen(plname); // 63 because we need one char for null-terminator
+					// Append appendStr to plname if there's enough space
+					if (remainingSpace >= appendStr.length()) {
+						// Append should look like this:
+						strncat(plname, appendStr.c_str(), remainingSpace);
+
+						// To prepend:
+						// char tempBuffer[64];
+						// // First, copy appendStr to tempBuffer
+						// strcpy(tempBuffer, appendStr.c_str());
+						// // Then concatenate plname to tempBuffer
+						// strncat(tempBuffer, plname, remainingSpace);
+						// // Copy back the combined string to plname
+						// strncpy(plname, tempBuffer, 64);
+						// plname[63] = '\0'; // Ensure null-termination
+					}
+				}
 
 				char placcount[30] = { 0 };
 				if (admin >= cle->Admin() && admin >= AccountStatus::QuestTroupe)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1401,6 +1401,10 @@ void Client::UpdateWho(uint8 remove) {
 	scl->Trader = this->IsTrader();
 	scl->Revoked = this->GetRevoked();
 
+	scl->selffound = this->IsSelfFound();
+	scl->hardcore = this->IsHardcore();
+	scl->solo = this->IsSoloOnly();
+
 	worldserver.SendPacket(pack);
 	safe_delete(pack);
 }


### PR DESCRIPTION
Added this after the player name.  Seemed like this way the only way to add it cleanly with the other option being potentially the account name, but I believe the client automatically adds some text when that's set which would make it not very clean looking (ACC Name: ) - something like this

Not sure how to add it to the normal /who command yet, maybe not possible?

Current format:

[1 Warrior] Zhane -ssfhc- (Wood Elf) gfaydark