### PR TITLE
Feature: Kill Steal Tracking & Logging

### DIFF
--- a/common/json/json.h
+++ b/common/json/json.h
@@ -1007,6 +1007,7 @@ Json::Value obj_value(Json::objectValue); // {}
   JSONCPP_STRING getComment(CommentPlacement placement) const;
 
   JSONCPP_STRING toStyledString() const;
+  JSONCPP_STRING toOptimizedString() const;
 
   const_iterator begin() const;
   const_iterator end() const;

--- a/common/json/jsoncpp.cpp
+++ b/common/json/jsoncpp.cpp
@@ -3865,6 +3865,11 @@ JSONCPP_STRING Value::toStyledString() const {
   return writer.write(*this);
 }
 
+JSONCPP_STRING Value::toOptimizedString() const {
+  FastWriter writer;
+  return writer.write(*this);
+}
+
 Value::const_iterator Value::begin() const {
   switch (type_) {
   case arrayValue:

--- a/utils/sql/git/required/2023_11_25_qs_player_ks_log.sql
+++ b/utils/sql/git/required/2023_11_25_qs_player_ks_log.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `qs_player_ks_log` (
+  `npc_type_id` int(11) unsigned DEFAULT 0,
+  `zone_id` int(11) unsigned DEFAULT 0,
+  `killed_by_id` int(11) unsigned DEFAULT 0,
+  `killed_by_group_id` int(11) unsigned DEFAULT 0,
+  `killed_by_raid_id` int(11) unsigned DEFAULT 0,
+  `initial_engage_ids` text DEFAULT '{}',
+  `npc_lootables` text DEFAULT '{}',
+  `time` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2095,6 +2095,7 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 
 	
 	hate_list.ReportDmgTotals(this, corpse, xp, faction, dmg_amt);
+
 	BuffFadeAll();
 
 	WipeHateList();
@@ -2393,6 +2394,11 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 
 void NPC::GiveExp(Client* give_exp_client, bool &xp)
 {
+	bool needsLogging = false;
+	if (hate_list.EvaluateKillerIsInitialEngager(give_exp_client, needsLogging) == false && needsLogging) {
+		hate_list.LogInitialEngageIdResult(give_exp_client);
+	}
+
 	Group *kg = entity_list.GetGroupByClient(give_exp_client);
 	Raid *kr = entity_list.GetRaidByClient(give_exp_client);
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2394,8 +2394,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 
 void NPC::GiveExp(Client* give_exp_client, bool &xp)
 {
-	bool needsLogging = false;
-	if (hate_list.EvaluateKillerIsInitialEngager(give_exp_client, needsLogging) == false && needsLogging) {
+	if (hate_list.KillerIsNotInitialEngager(give_exp_client)) {
 		hate_list.LogInitialEngageIdResult(give_exp_client);
 	}
 

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -37,6 +37,23 @@
 extern QueryServ* QServ;
 extern Zone *zone;
 
+void SInitialEngageEntry::Reset() {
+	m_raidId = 0;
+	m_groupId = 0;
+	m_ids.clear();
+}
+
+std::string SInitialEngageEntry::ToJson() const {
+	Json::Value json;
+	json["raidId"] = m_raidId;
+	json["groupId"] = m_groupId;
+	json["ids"] = Json::Value(Json::arrayValue);
+	for (auto it = m_ids.begin(); it != m_ids.end(); ++it) {
+		json["ids"].append(*it);
+	}
+	return json.toStyledString();
+}
+
 HateList::HateList()
 {
 	owner = nullptr;
@@ -49,6 +66,8 @@ HateList::HateList()
 	aggroTime = 0xFFFFFFFF;
 	aggroDeaggroTime = 0xFFFFFFFF;
 	ignoreStuckCount = 0;
+	m_hasInitialEngageIds = false;
+	m_initialEngageEntry = {};
 }
 
 HateList::~HateList()
@@ -162,6 +181,8 @@ void HateList::Wipe(bool from_memblur)
 	}
 
 	ignoreStuckCount = 0;
+	m_initialEngageEntry.Reset();
+	m_hasInitialEngageIds = false;
 }
 
 void HateList::HandleFTEEngage(Client* client) {
@@ -678,6 +699,174 @@ Mob* HateList::GetClosestNPC(Mob *hater)
 	return close_entity;
 }
 
+// record the initial client ids for the hate list
+void HateList::RecordInitialClientHateIds(Mob* const ent) {
+	if (m_hasInitialEngageIds) {
+		return;
+	}
+
+	auto clientExistsIter = std::find_if(
+		list.begin(),
+		list.end(),
+		[](const tHateEntry* e) {
+			return e->ent != nullptr && (e->ent->IsClient() || e->ent->IsPlayerOwned());
+		}
+	);
+	if (clientExistsIter != std::end(list)) {
+		return;
+	}
+
+	if (ent->IsClient() || ent->IsPlayerOwned()) {
+		Client* const client = ent->IsClient() ? ent->CastToClient() : ent->GetOwner()->CastToClient();
+		m_initialEngageEntry.m_ids.push_back(client->CharacterID());
+		if (client->HasPet()) {
+			m_initialEngageEntry.m_ids.push_back(client->GetPetID());
+		}
+
+		auto raid = client->GetRaid();
+		auto group = client->GetGroup();
+		if (raid) {
+			m_initialEngageEntry.m_raidId = raid->GetID();
+			for (const auto& raidMember : raid->members) {
+				if (raidMember.member == nullptr) {
+					continue;
+				}
+
+				const auto& memberId = raidMember.member->CharacterID();
+				if (memberId == client->CharacterID()) {
+					continue;
+				}
+
+				m_initialEngageEntry.m_ids.push_back(memberId);
+				if (raidMember.member->HasPet()) {
+					m_initialEngageEntry.m_ids.push_back(raidMember.member->GetPetID());
+				}
+			}
+		}
+		else if (group) {
+			m_initialEngageEntry.m_groupId = group->GetID();
+			for (const auto groupMember : group->members) {
+				if (groupMember == nullptr) {
+					continue;
+				}
+
+				auto memberClient = groupMember->CastToClient();
+				if (memberClient == nullptr) {
+					continue;
+				}
+
+				const auto& memberId = memberClient->CharacterID();
+				if (memberId == client->CharacterID()) {
+					continue;
+				}
+
+				m_initialEngageEntry.m_ids.push_back(memberId);
+				if (memberClient->HasPet()) {
+					m_initialEngageEntry.m_ids.push_back(memberClient->GetPetID());
+				}
+			}
+		}
+
+		m_hasInitialEngageIds = true;
+	}
+}
+
+// update the initial engage ids for the hatelist if any new clients are in the same raid or group as the initial engagers
+void HateList::UpdateInitialClientHateIds(Mob* const ent) {
+	if (m_hasInitialEngageIds == false) {
+		return;
+	}
+
+	if (ent->IsClient() == false && ent->IsPlayerOwned() == false) {
+		return;
+	}
+
+	Client* const client = ent->IsClient() ? ent->CastToClient() : ent->GetOwner()->CastToClient();
+	auto raid = client->GetRaid();
+	auto group = client->GetGroup();
+
+	bool clientExistsInInitialEngage = std::find(m_initialEngageEntry.m_ids.begin(), m_initialEngageEntry.m_ids.end(), client->CharacterID()) != std::end(m_initialEngageEntry.m_ids);
+	if (clientExistsInInitialEngage) {
+		// joined a raid or group after the initial engage
+		if (raid && m_initialEngageEntry.m_raidId == 0) {
+			m_initialEngageEntry.m_raidId = raid->GetID();
+		}
+		else if (group && m_initialEngageEntry.m_groupId == 0) {
+			m_initialEngageEntry.m_groupId = group->GetID();
+		}
+
+		// what do we do in this case?
+		// => client is in the initial engage list but is not in the same raid or group as the initial engagers
+		// => such as if the client was in a raid or group and then left it
+		return;
+	}
+
+	bool isValidRaidOrGroup = (raid && raid->GetID() == m_initialEngageEntry.m_raidId) || (group && group->GetID() == m_initialEngageEntry.m_groupId);
+	if (isValidRaidOrGroup == false) {
+		return;
+	}
+
+	if (client->HasPet() &&
+			std::find(m_initialEngageEntry.m_ids.begin(), m_initialEngageEntry.m_ids.end(), client->GetPetID()) == std::end(m_initialEngageEntry.m_ids)
+	) {
+		m_initialEngageEntry.m_ids.push_back(client->GetPetID());
+	}
+
+	if (clientExistsInInitialEngage == false) {
+		m_initialEngageEntry.m_ids.push_back(client->CharacterID());
+	}
+}
+
+bool HateList::EvaluateKillerIsInitialEngager(Mob* const ent, bool& needsLogging) {
+	if (m_hasInitialEngageIds == false) {
+		return false;
+	}
+
+	if (ent->IsClient() == false && ent->IsPlayerOwned() == false) {
+		return false;
+	}
+
+	Client* const client = ent->IsClient() ? ent->CastToClient() : ent->GetOwner()->CastToClient();
+	if (client->HasPet() &&
+			std::find(m_initialEngageEntry.m_ids.begin(), m_initialEngageEntry.m_ids.end(), client->GetPetID()) != std::end(m_initialEngageEntry.m_ids)
+	) {
+		return true;
+	}
+
+	if (std::find(m_initialEngageEntry.m_ids.begin(), m_initialEngageEntry.m_ids.end(), client->CharacterID()) != std::end(m_initialEngageEntry.m_ids)) {
+		return true;
+	}
+
+	needsLogging = true;
+	return false;
+}
+
+void HateList::LogInitialEngageIdResult(Client* const killedBy) {
+	if (m_hasInitialEngageIds == false) {
+		return;
+	}
+
+	std::stringstream ss;
+	ss << "Initial Engage Ids: ";
+	for (const auto& id : m_initialEngageEntry.m_ids) {
+		ss << id << " ";
+	}
+
+	ss << "Raid Id: " << m_initialEngageEntry.m_raidId << " Group Id: " << m_initialEngageEntry.m_groupId;
+
+	if (killedBy->IsClient()) {
+		ss << " Killed By: " << killedBy->CastToClient()->GetName();
+	}
+	Log(Logs::General, Logs::Aggro, "%s", ss.str().c_str());
+
+	if (owner == nullptr || owner->IsNPC() == false) {
+		return;
+	}
+
+	auto npc = owner->CastToNPC();
+	QServ->QSLogKillSteal(npc, zone->GetZoneID(), killedBy, m_initialEngageEntry);
+}
+
 // this will process negative hate values fine (e.g. jolt)
 void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAddIfNotExist)
 {
@@ -689,6 +878,8 @@ void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAd
 
 	if(ent->IsClient() && ent->CastToClient()->IsDead())
 		return;
+
+	UpdateInitialClientHateIds(ent);
 
 	tHateEntry *p = Find(ent);
 	if (p)
@@ -716,6 +907,7 @@ void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAd
 			if (owner->CastToNPC()->IsAnimal())
 				in_hate = 1;
 
+			RecordInitialClientHateIds(ent);
 		}
 
 		p = new tHateEntry;
@@ -877,6 +1069,9 @@ bool HateList::RemoveEnt(Mob *ent)
 		}
 		aggroDeaggroTime = Timer::GetCurrentTime();
 		aggroTime = 0xFFFFFFFF;
+
+		m_initialEngageEntry.Reset();
+		m_hasInitialEngageIds = false;
 	}
 	else
 	{

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -912,16 +912,7 @@ void HateList::LogInitialEngageIdResult(Client* const killedBy) {
 	}
 
 	std::stringstream ss;
-	ss << "Initial Engage Ids: ";
-	for (const auto& id : m_initialEngageEntry.m_ids) {
-		ss << id << " ";
-	}
-
-	ss << "Raid Id: " << m_initialEngageEntry.m_raidId << " Group Id: " << m_initialEngageEntry.m_groupId;
-
-	if (killedBy->IsClient()) {
-		ss << " Killed By: " << killedBy->CastToClient()->GetName();
-	}
+	ss << "KillSteal Detected => Killed By: " << killedBy->GetName();
 	Log(Logs::General, Logs::Aggro, "%s", ss.str().c_str());
 
 	auto npc = owner->CastToNPC();

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -34,6 +34,16 @@ struct tHateEntry
 	uint32 last_hate;
 };
 
+struct SInitialEngageEntry {
+	std::vector<uint32> m_ids;
+	uint32 m_raidId;
+	uint32 m_groupId;
+
+	SInitialEngageEntry() : m_raidId(0), m_groupId(0) {}
+	void Reset();
+	std::string ToJson() const;
+};
+
 class HateList
 {
 public:
@@ -123,10 +133,16 @@ public:
 	void HandleFTEEngage(Client* client);
 	void HandleFTEDisengage();
 
+	bool EvaluateKillerIsInitialEngager(Mob* const ent, bool& needsLogging);
+	void LogInitialEngageIdResult(Client* const killedBy = nullptr);
+
 protected:
 	tHateEntry* Find(Mob *ent);
 	int32 GetHateBonus(tHateEntry *entry, bool combatRange, bool firstInRange = false, float distSquared = -1.0f);
 	int32 GetEntPetDamage(Mob* ent);
+	void RecordInitialClientHateIds(Mob* const ent);
+	void UpdateInitialClientHateIds(Mob* const ent);
+
 private:
 	std::list<tHateEntry*> list;
 	Mob *owner;
@@ -141,6 +157,8 @@ private:
 	bool hasFeignedHaters;
 	bool hasLandHaters;
 	uint32 ignoreStuckCount;
+	bool m_hasInitialEngageIds;
+	SInitialEngageEntry m_initialEngageEntry;
 };
 
 #endif

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -35,13 +35,16 @@ struct tHateEntry
 };
 
 struct SInitialEngageEntry {
-	std::vector<uint32> m_ids;
 	uint32 m_raidId;
 	uint32 m_groupId;
+	std::vector<uint32> m_ids;
+	std::vector<uint32> m_disbanded;
 
 	SInitialEngageEntry() : m_raidId(0), m_groupId(0) {}
 	void Reset();
 	std::string ToJson() const;
+	void AddEngagerIds(const std::vector<uint32>& ids);
+	void EngagerIdsAreHistory(const std::vector<uint32>& ids);
 };
 
 class HateList
@@ -133,7 +136,7 @@ public:
 	void HandleFTEEngage(Client* client);
 	void HandleFTEDisengage();
 
-	bool EvaluateKillerIsInitialEngager(Mob* const ent, bool& needsLogging);
+	bool KillerIsNotInitialEngager(Mob* const ent);
 	void LogInitialEngageIdResult(Client* const killedBy = nullptr);
 
 protected:

--- a/zone/queryserv.cpp
+++ b/zone/queryserv.cpp
@@ -466,7 +466,7 @@ void QueryServ::QSLogKillSteal(NPC* const npc, uint32 zoneid, Client* const clie
 		groupid,
 		raidid,
 		engageEntry.ToJson().c_str(),
-		loot.toStyledString().c_str()
+		loot.toOptimizedString().c_str()
 	);
 	SendQuery(query);
 }

--- a/zone/queryserv.h
+++ b/zone/queryserv.h
@@ -53,6 +53,7 @@ class QueryServ {
 		void QSBazaarAudit(const char *seller, const char *buyer, const char *itemName, int itemid, int quantity, int totalCost);
 		void QSCoinMove(uint32 from_id, uint32 to_id, uint32 npcid, int32 to_slot, uint32 amount, uint32 cointype = 0);
 		void QSGroundSpawn(uint32 characterid, int16 itemid, uint8 quantity, int16 in_bag, uint16 zoneid, bool dropped, bool forced = false);
+		void QSLogKillSteal(NPC* const npc, uint32 zoneid, Client* const client, const SInitialEngageEntry& engageids);
 };
 
 #endif /* QUERYSERV_ZONE_H */


### PR DESCRIPTION
- Functionality to track initial engage ids, and determine if a kill steal has occurred
  - if a kill steal has occur, this will log to the: `qs_player_ks_log`
- example data:
```
npc_type_id;zone_id;killed_by_id;killed_by_group_id;killed_by_raid_id;initial_engage_ids;npc_lootables;time

4517;4;50373;0;0;{"groupId":0,"disbanded":[],"ids":[50378],"raidId":0}
;{"copper":0,"gold":0,"items":[13067,13070],"platinum":0,"silver":0}
;2023-11-25 02:12:24

4507;4;50373;0;0;{"groupId":4,"disbanded":[50378,50373],"ids":[],"raidId":0}
;{"copper":0,"gold":0,"items":[13408,13071],"platinum":0,"silver":0}
;2023-11-25 02:17:04
```

- Edge case situation:
  - if 2 members are in a group
    - 1 member leaves while engaged
      - both members would no longer be in a group
      - both members proceed to get added to `disbanded`, either member could be marked as the `killed_by_id`
        - second data example shows this

Tested By:
- 1st solo client engages first, 2nd solo client engages second & killsteals: 2nd client marked as ks & logs
- 3 clients grouping/raiding & killing legit: no ks is determined & no log
- 3 clients grouping/raiding & engage, 1 client leaves & killsteals: client that left marked as ks & logs
- 3 clients grouping/raiding, 2 engaged while 1 is in another zone, other client zones in engages & kills: no ks is determined & no log
- 3 clients grouping/raiding, 1 client is a mage, mage sends pet to attack & engages, mage dismisses pet, summons new pet & engages: no ks is determined & no log
- building on msvc, gnu & playing the game