### PR TITLE
Light Blue Con Exp Fixes

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -506,7 +506,7 @@ public:
 
 	inline uint32 GetEXP() const { return m_pp.exp; }
 
-	void	AddEXP(uint32 in_add_exp, uint8 conlevel = 0xFF, Mob* killed_mob = nullptr, int16 avg_level = 0, bool is_split = false);
+	void	AddEXP(uint32 in_add_exp, uint8 conlevel = 0xFF, Mob* killed_mob = nullptr, int16 avg_level = 0, bool is_split = false, int16 highest_level = 0);
 	void	SetEXP(uint32 set_exp, uint32 set_aaxp, bool resexp=false, bool is_split = false);
 	void	AddQuestEXP(uint32 in_add_exp, bool bypass_cap = false);
 	void	AddEXPPercent(uint8 percent, uint8 level = 1);


### PR DESCRIPTION
Light blue exp was broken in group splits because it was not properly calculating the level difference between the highest group member and the killed NPC for group members other than the highest level guy.  This would result in only the highest level guy getting the higher amounts of light blue exp and the lower level players would only get 20%.

Also when calculating raid exp, the con color was being determined on an individual basis instead of using the highest level player in the raid, which was resulting in lower level players getting exp from light blue kills as if they were dark blue.