### PR TITLE
Backstab min damage fix

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -374,6 +374,8 @@ void Client::DoBackstab(Mob* defender)
 			minHit = level * 2;
 		else if (level > 50)
 			minHit = level * 3 / 2;
+		else
+			minHit = level;
 	}
 
 	int assassinateDmg = TryAssassinate(defender, EQ::skills::SkillBackstab);


### PR DESCRIPTION
Backstab was granted a minimum damage in November 1999.  We had the level 51-59 and 60+ minimums in but 1-50 escaped my notice for whatever reason.