### PR TITLE
Feature: Kill Steal Tracking & Logging (Zoning Handling)

### DIFF
--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -891,7 +891,7 @@ void HateList::UpdateInitialClientHateIds(Mob* const ent) {
 	m_initialEngageEntry.AddEngagerIds(engagerIds);
 }
 
-// remove when the client or client's pet is removed from the hatelist
+// remove when the client is removed from the hatelist
 void HateList::RemoveInitialClientHateIds(Mob* const ent) {
 	if (m_initialEngageEntry.HasInitialEngageIds() == false) {
 		return;

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -35,15 +35,19 @@ struct tHateEntry
 };
 
 struct SInitialEngageEntry {
+	bool m_hasInitialEngageIds;
 	uint32 m_raidId;
 	uint32 m_groupId;
 	std::vector<uint32> m_ids;
 	std::vector<uint32> m_disbanded;
 
-	SInitialEngageEntry() : m_raidId(0), m_groupId(0) {}
+	SInitialEngageEntry() : m_hasInitialEngageIds(false), m_raidId(0), m_groupId(0) {}
 	void Reset();
 	std::string ToJson() const;
+	void SetHasInitialEngageIds(bool hasInitialEngageIds);
+	bool HasInitialEngageIds() const;
 	void AddEngagerIds(const std::vector<uint32>& ids);
+	void RemoveEngagerIds(const std::vector<uint32>& ids);
 	void EngagerIdsAreHistory(const std::vector<uint32>& ids);
 };
 
@@ -145,6 +149,7 @@ protected:
 	int32 GetEntPetDamage(Mob* ent);
 	void RecordInitialClientHateIds(Mob* const ent);
 	void UpdateInitialClientHateIds(Mob* const ent);
+	void RemoveInitialClientHateIds(Mob* const ent);
 
 private:
 	std::list<tHateEntry*> list;
@@ -160,7 +165,6 @@ private:
 	bool hasFeignedHaters;
 	bool hasLandHaters;
 	uint32 ignoreStuckCount;
-	bool m_hasInitialEngageIds;
 	SInitialEngageEntry m_initialEngageEntry;
 };
 


### PR DESCRIPTION
- functionality to be able to erase & reset initial engage `m_ids`, `m_disbanded` when a client zones
  - whether by dieing, fd or otherwise
  - allows other engagers to not be marked as potential ks
    - whoever makes the next (solo/group/raid) hit is the next valid initial engager
- removed the PetID tracking as this isn't needed
  - just need to keep track of root client CharacterID

Tested By:
- All prior test cases in previous pull request (https://github.com/SecretsOTheP/EQMacEmu/pull/66)
- Additional:
  - 1st solo client engages mob, 2nd solo client engages same mob, (1) dies & zones, (2) kills mob: no ks is determined & no log
  - 1st solo client engages mob, 2nd solo client engages same mob, (1) runs to zone, (2) kills mob: no ks is determined & no log
  - 1 solo mage client engages & sends pet, 2 grouped clients engage mob, solo mage client zones & then zones back: no ks is determined & no log
- building on msvc, gnu & playing the game