### PR TITLE
Fix issue in Character Creation with All-or-Nothing Expansion Races/C…

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -1149,7 +1149,7 @@ bool Client::OPCharCreate(char *name, CharCreate_Struct *cc)
 	Log(Logs::Detail, Logs::WorldServer, "Beard: %d  Beardcolor: %d", cc->beard, cc->beardcolor);
 
 	/* Validate the char creation struct */
-		if(!CheckCharCreateInfo(cc)) {
+		if(!Client::CheckCharCreateInfo(cc)) {
 			Log(Logs::Detail, Logs::WorldServer,"CheckCharCreateInfo did not validate the request (bad race/class/stats)");
 			return false;
 		}
@@ -1262,14 +1262,14 @@ bool Client::OPCharCreate(char *name, CharCreate_Struct *cc)
 }
 
 // returns true if the request is ok, false if there's an error
-bool CheckCharCreateInfo(CharCreate_Struct *cc)
+bool Client::CheckCharCreateInfo(CharCreate_Struct *cc)
 {
 	if (!cc)
 		return false;
 
 	Log(Logs::Detail, Logs::WorldServer, "Validating char creation info...");
 
-	int currentExpansions = RuleI(Character, DefaultExpansions);
+	int currentExpansions = GetExpansion(); // Get expansion value from account table
 
 	RaceClassCombos class_combo;
 	bool found = false;
@@ -1279,7 +1279,7 @@ bool CheckCharCreateInfo(CharCreate_Struct *cc)
 				character_create_race_class_combos[i].Race == cc->race &&
 				character_create_race_class_combos[i].Deity == cc->deity &&
 				character_create_race_class_combos[i].Zone == cc->start_zone &&
-			(currentExpansions & character_create_race_class_combos[i].ExpansionRequired == character_create_race_class_combos[i].ExpansionRequired || character_create_race_class_combos[i].ExpansionRequired == 0)) {
+			((currentExpansions & character_create_race_class_combos[i].ExpansionRequired) == character_create_race_class_combos[i].ExpansionRequired || character_create_race_class_combos[i].ExpansionRequired == 0)) {
 			class_combo = character_create_race_class_combos[i];
 			found = true;
 			break;

--- a/world/client.h
+++ b/world/client.h
@@ -68,6 +68,7 @@ public:
 	inline uint32		GetClientVersionBit() { return m_ClientVersionBit; }
 	inline bool			GetSessionLimit();
 
+
 private:
 
 	uint32	ip;
@@ -103,6 +104,7 @@ private:
 	bool HandleEnterWorldPacket(const EQApplicationPacket *app);
 	bool HandleDeleteCharacterPacket(const EQApplicationPacket *app);
 	bool HandleChecksumPacket(const EQApplicationPacket *app);
+	bool CheckCharCreateInfo(CharCreate_Struct *cc);
 
 	EQStreamInterface* const eqs;
 
@@ -110,7 +112,5 @@ private:
 	uint8	charcount;
 	bool	mule;
 };
-
-bool CheckCharCreateInfo(CharCreate_Struct *cc);
 
 #endif


### PR DESCRIPTION
…lasses

This update:
1. Fixes an order of operations issue with the bitwise AND check on allowed expansions for char_create combos
2. Pulls the currentExpansion from the player's account table in database instead of the Character:DefaultExpansions rule
3. Moves the CheckCharCreateInfo function in client.cpp and client.h to the Client local namespace instead of the global namespace

The overall effect this solves is that you can now set the current expansion to Kunark and prevent Beastlords and Vah Shir from the Luclin expansion (or any other combinations from the char_create_combos table in db) from being erroneously permitted during the character creation process when they are out of the server's current expansion era.