### PR TITLE
banish to book from guild instance (instead of bind)

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -258,6 +258,7 @@ RULE_BOOL(Quarm, EnforceClassicEraHardCaps, true) // Classic behavior is true, L
 RULE_INT(Quarm, AOEThrottlingMaxAOETargets, 50) // This will curb nonsense with performance issues relating to amount of targets if the amount of clients exceeds 300 in a single zone.
 RULE_INT(Quarm, AOEThrottlingMaxClients, 300) // This will curb nonsense with performance issues relating to amount of targets if the amount of clients exceeds 300 in a single zone.
 RULE_INT(Quarm, EnableLuclinEraShieldACOvercap, false)
+RULE_INT(Quarm, ClientInstanceBootGraceMS, 60000)
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Map )

--- a/utils/sql/git/required/2024_01_18_alter_zone_table_add_banish_fields.sql
+++ b/utils/sql/git/required/2024_01_18_alter_zone_table_add_banish_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `zone`
+ADD `banish_zone_id` INT(4) DEFAULT 0 NOT NULL,
+ADD `banish_x` FLOAT DEFAULT 0.0 NOT NULL,
+ADD `banish_y` FLOAT DEFAULT 0.0 NOT NULL,
+ADD `banish_z` FLOAT DEFAULT 0.0 NOT NULL,
+ADD `banish_heading` FLOAT DEFAULT 0.0 NOT NULL;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -150,6 +150,7 @@ Client::Client(EQStreamInterface* ieqs)
 	mend_reset_timer(60000),
 	underwater_timer(1000),
 	zoning_timer(5000),
+	instance_boot_grace_timer(RuleI(Quarm, ClientInstanceBootGraceMS)),
 	m_Proximity(FLT_MAX, FLT_MAX, FLT_MAX), //arbitrary large number
 	m_ZoneSummonLocation(-2.0f,-2.0f,-2.0f,-2.0f),
 	m_AutoAttackPosition(0.0f, 0.0f, 0.0f, 0.0f),
@@ -222,6 +223,7 @@ Client::Client(EQStreamInterface* ieqs)
 	door_check_timer.Disable();
 	mend_reset_timer.Disable();
 	zoning_timer.Disable();
+	instance_boot_grace_timer.Disable();
 	instalog = false;
 	m_pp.autosplit = false;
 	// initialise haste variable

--- a/zone/client.h
+++ b/zone/client.h
@@ -520,6 +520,7 @@ public:
 	bool	IsInLevelRange(uint8 maxlevel);
 
 	void GoToBind(uint8 bindnum = 0);
+	void BootFromGuildInstance();
 	void GoToSafeCoords(uint16 zone_id, uint32 zone_guild_id);
 	void Gate();
 	void SetBindPoint(int to_zone = -1, const glm::vec3& location = glm::vec3());

--- a/zone/client.h
+++ b/zone/client.h
@@ -1076,6 +1076,8 @@ public:
 	void CorpseSummoned(Corpse *corpse);
 	void CorpseSummonOnPositionUpdate();
 
+	inline bool InstanceBootGraceTimerExpired() { return instance_boot_grace_timer.Check(); }
+
 protected:
 	friend class Mob;
 	void CalcItemBonuses(StatBonuses* newbon);
@@ -1264,6 +1266,7 @@ private:
 	Timer underwater_timer;
 
 	Timer zoning_timer;
+	Timer instance_boot_grace_timer;
 
     glm::vec3 m_Proximity;
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1916,6 +1916,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	QueuePacket(outapp);
 	safe_delete(outapp);
 
+	instance_boot_grace_timer.Start();
 	SetAttackTimer();
 	conn_state = ZoneInfoSent;
 	zoneinpacket_timer.Start();

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -942,6 +942,7 @@ Zone::~Zone() {
 	entity_list.Clear();
 	ClearBlockedSpells();
 
+	safe_delete(zone_banish_point);
 	safe_delete(qGlobals);
 	safe_delete_array(map_name);
 	safe_delete(Nexus_Scion_Timer);
@@ -1039,6 +1040,7 @@ bool Zone::Init(bool iStaticZone) {
 	//load up the zone's doors (prints inside)
 	zone->LoadZoneDoors(zone->GetShortName());
 	zone->LoadBlockedSpells(zone->GetZoneID());
+	zone->LoadZoneBanishPoint(zone->GetShortName());
 
 	//clear trader items if we are loading the bazaar
 	if(strncasecmp(short_name,"bazaar",6)==0) {
@@ -2037,6 +2039,11 @@ void Zone::SetGraveyard(uint32 zoneid, const glm::vec4& graveyardPosition) {
 	m_Graveyard = graveyardPosition;
 }
 
+void Zone::LoadZoneBanishPoint(const char* zone) {
+	zone_banish_point = new ZoneBanishPoint();
+	database.GetZoneBanishPoint(zone_banish_point, zone);
+}
+
 void Zone::LoadBlockedSpells(uint32 zoneid)
 {
 	if(!blocked_spells)
@@ -2738,7 +2745,7 @@ bool Zone::CanDoCombat(Mob* current, Mob* other, bool process)
 			bool bCanEngage = CanClientEngage(current->CastToClient(), other);
 			if (!bCanEngage)
 			{
-				current->CastToClient()->GoToBind();
+				current->CastToClient()->BootFromGuildInstance();
 				return false;
 			}
 		}
@@ -2747,7 +2754,7 @@ bool Zone::CanDoCombat(Mob* current, Mob* other, bool process)
 			bool bCanEngage = CanClientEngage(other->CastToClient(), current);
 			if (!bCanEngage)
 			{
-				other->CastToClient()->GoToBind();
+				other->CastToClient()->BootFromGuildInstance();
 				return false;
 			}
 		}

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -834,6 +834,7 @@ Zone::Zone(uint32 in_zoneid, const char* in_short_name, uint32 in_guildid)
 	lootvar = 0;
 
 	memset(&last_quake_struct, 0, sizeof(ServerEarthquakeImminent_Struct));
+	memset(&zone_banish_point, 0, sizeof(ZoneBanishPoint));
 
 	short_name = strcpy(new char[strlen(in_short_name)+1], in_short_name);
 	std::string tmp = short_name;
@@ -942,7 +943,6 @@ Zone::~Zone() {
 	entity_list.Clear();
 	ClearBlockedSpells();
 
-	safe_delete(zone_banish_point);
 	safe_delete(qGlobals);
 	safe_delete_array(map_name);
 	safe_delete(Nexus_Scion_Timer);
@@ -2040,7 +2040,6 @@ void Zone::SetGraveyard(uint32 zoneid, const glm::vec4& graveyardPosition) {
 }
 
 void Zone::LoadZoneBanishPoint(const char* zone) {
-	zone_banish_point = new ZoneBanishPoint();
 	database.GetZoneBanishPoint(zone_banish_point, zone);
 }
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2740,7 +2740,7 @@ bool Zone::CanDoCombat(Mob* current, Mob* other, bool process)
 {
 	if (current && other && zone->GetGuildID() != GUILD_NONE)
 	{
-		if (current->IsClient())
+		if (current->IsClient() && current->CastToClient()->InstanceBootGraceTimerExpired())
 		{
 			bool bCanEngage = CanClientEngage(current->CastToClient(), other);
 			if (!bCanEngage)
@@ -2749,7 +2749,7 @@ bool Zone::CanDoCombat(Mob* current, Mob* other, bool process)
 				return false;
 			}
 		}
-		if (other->IsClient())
+		if (other->IsClient() && other->CastToClient()->InstanceBootGraceTimerExpired())
 		{
 			bool bCanEngage = CanClientEngage(other->CastToClient(), current);
 			if (!bCanEngage)

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -49,6 +49,16 @@ struct ZonePoint
 	uint16 target_zone_id;
 	uint32 client_version_mask;
 };
+
+struct ZoneBanishPoint
+{
+	float x;
+	float y;
+	float z;
+	float heading;
+	uint16 target_zone_id;
+};
+
 struct ZoneClientAuth_Struct {
 	uint32	ip;			// client's IP address
 	uint32	wid;		// client's WorldID#
@@ -144,6 +154,8 @@ public:
 
 	bool RemoveSpawnEntry(uint32 spawnid);
 	bool RemoveSpawnGroup(uint32 in_id);
+
+	ZoneBanishPoint* GetZoneBanishPoint() { return zone_banish_point; }
 
 	bool	Process();
 	void	Despawn(uint32 spawngroupID);
@@ -252,6 +264,7 @@ public:
 	bool	HasGraveyard();
 	void	SetGraveyard(uint32 zoneid, const glm::vec4& graveyardPosition);
 
+	void		LoadZoneBanishPoint(const char* zone);
 	void		LoadBlockedSpells(uint32 zoneid);
 	void		ClearBlockedSpells();
 	bool		IsSpellBlocked(uint32 spell_id, const glm::vec3& location);
@@ -342,6 +355,8 @@ private:
 
 	int	totalBS;
 	ZoneSpellsBlocked *blocked_spells;
+
+	ZoneBanishPoint* zone_banish_point;
 
 	int		totalAAs;
 	SendAA_Struct **aas;	//array of AA structs

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -155,7 +155,7 @@ public:
 	bool RemoveSpawnEntry(uint32 spawnid);
 	bool RemoveSpawnGroup(uint32 in_id);
 
-	ZoneBanishPoint* GetZoneBanishPoint() { return zone_banish_point; }
+	ZoneBanishPoint& GetZoneBanishPoint() { return zone_banish_point; }
 
 	bool	Process();
 	void	Despawn(uint32 spawngroupID);
@@ -356,7 +356,7 @@ private:
 	int	totalBS;
 	ZoneSpellsBlocked *blocked_spells;
 
-	ZoneBanishPoint* zone_banish_point;
+	ZoneBanishPoint zone_banish_point;
 
 	int		totalAAs;
 	SendAA_Struct **aas;	//array of AA structs

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4077,11 +4077,10 @@ int16 ZoneDatabase::GetTimerFromSkill(EQ::skills::SkillType skillid)
 	return timer;
 }
 
-bool ZoneDatabase::GetZoneBanishPoint(ZoneBanishPoint* into_zbp, const char* dest_zone) {
-	std::string query = StringFormat("SELECT zone, pos_x, pos_y, pos_z, heading, dest_zone "
-		"FROM doors WHERE dest_zone LIKE '%s%%' "
+bool ZoneDatabase::GetZoneBanishPoint(ZoneBanishPoint& into_zbp, const char* dest_zone) {
+	std::string query = StringFormat("SELECT banish_zone_id, banish_x, banish_y, banish_z, banish_heading "
+		"FROM zone WHERE short_name = '%s' "
 		"AND ((%.2f >= min_expansion AND %.2f < max_expansion) OR (min_expansion = 0 AND max_expansion = 0)) "
-		"AND guildzonedoor = 1 "
 		"LIMIT 1",
 		dest_zone, RuleR(World, CurrentExpansion), RuleR(World, CurrentExpansion));
 
@@ -4091,11 +4090,11 @@ bool ZoneDatabase::GetZoneBanishPoint(ZoneBanishPoint* into_zbp, const char* des
 	}
 
 	auto row = results.begin();
-	into_zbp->target_zone_id = database.GetZoneID(row[0]);
-	into_zbp->x = atof(row[1]);
-	into_zbp->y = atof(row[2]);
-	into_zbp->z = atof(row[3]) - 10; // above book
-	into_zbp->heading = atof(row[4]);
+	into_zbp.target_zone_id = atoi(row[0]);
+	into_zbp.x = atof(row[1]);
+	into_zbp.y = atof(row[2]);
+	into_zbp.z = atof(row[3]);
+	into_zbp.heading = atof(row[4]);
 
 	return true;
 }

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4094,7 +4094,7 @@ bool ZoneDatabase::GetZoneBanishPoint(ZoneBanishPoint* into_zbp, const char* des
 	into_zbp->target_zone_id = database.GetZoneID(row[0]);
 	into_zbp->x = atof(row[1]);
 	into_zbp->y = atof(row[2]);
-	into_zbp->z = atof(row[3]) + 10; // above book
+	into_zbp->z = atof(row[3]) - 10; // above book
 	into_zbp->heading = atof(row[4]);
 
 	return true;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4076,3 +4076,25 @@ int16 ZoneDatabase::GetTimerFromSkill(EQ::skills::SkillType skillid)
 
 	return timer;
 }
+
+bool ZoneDatabase::GetZoneBanishPoint(ZoneBanishPoint* into_zbp, const char* dest_zone) {
+	std::string query = StringFormat("SELECT zone, pos_x, pos_y, pos_z, heading, dest_zone "
+		"FROM doors WHERE dest_zone LIKE '%s%%' "
+		"AND ((%.2f >= min_expansion AND %.2f < max_expansion) OR (min_expansion = 0 AND max_expansion = 0)) "
+		"LIMIT 1",
+		dest_zone, RuleR(World, CurrentExpansion), RuleR(World, CurrentExpansion));
+
+	auto results = QueryDatabase(query);
+	if (!results.Success() || results.RowCount() != 1) {
+		return false;
+	}
+
+	auto row = results.begin();
+	into_zbp->target_zone_id = database.GetZoneID(row[0]);
+	into_zbp->x = atof(row[1]);
+	into_zbp->y = atof(row[2]);
+	into_zbp->z = atof(row[3]) + 10; // above book
+	into_zbp->heading = atof(row[4]);
+
+	return true;
+}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4081,6 +4081,7 @@ bool ZoneDatabase::GetZoneBanishPoint(ZoneBanishPoint* into_zbp, const char* des
 	std::string query = StringFormat("SELECT zone, pos_x, pos_y, pos_z, heading, dest_zone "
 		"FROM doors WHERE dest_zone LIKE '%s%%' "
 		"AND ((%.2f >= min_expansion AND %.2f < max_expansion) OR (min_expansion = 0 AND max_expansion = 0)) "
+		"AND guildzonedoor = 1 "
 		"LIMIT 1",
 		dest_zone, RuleR(World, CurrentExpansion), RuleR(World, CurrentExpansion));
 

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -322,6 +322,7 @@ public:
 	bool		UpdateZoneSafeCoords(const char* zonename, const glm::vec3& location);
 	uint8	GetUseCFGSafeCoords();
 	int		getZoneShutDownDelay(uint32 zoneID);
+	bool	GetZoneBanishPoint(ZoneBanishPoint* into_zbp, const char* dest_zone);
 
 	/* Spawns and Spawn Points  */
 	bool		LoadSpawnGroups(const char* zone_name, SpawnGroupList* spawn_group_list);

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -322,7 +322,7 @@ public:
 	bool		UpdateZoneSafeCoords(const char* zonename, const glm::vec3& location);
 	uint8	GetUseCFGSafeCoords();
 	int		getZoneShutDownDelay(uint32 zoneID);
-	bool	GetZoneBanishPoint(ZoneBanishPoint* into_zbp, const char* dest_zone);
+	bool	GetZoneBanishPoint(ZoneBanishPoint& into_zbp, const char* dest_zone);
 
 	/* Spawns and Spawn Points  */
 	bool		LoadSpawnGroups(const char* zone_name, SpawnGroupList* spawn_group_list);

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -961,6 +961,16 @@ void Client::GoToBind(uint8 bindnum) {
 		MovePCGuildID(m_pp.binds[bindnum].zoneId, GUILD_NONE, m_pp.binds[bindnum].x, m_pp.binds[bindnum].y, m_pp.binds[bindnum].z, m_pp.binds[bindnum].heading, 1);
 }
 
+void Client::BootFromGuildInstance() {
+	ZoneBanishPoint* zbp = zone->GetZoneBanishPoint();
+	if (zbp == nullptr) {
+		this->GoToBind();
+	}
+	else {
+		MovePCGuildID(zbp->target_zone_id, GUILD_NONE, zbp->x, zbp->y, zbp->z, zbp->heading, 1, ZoneSolicited);
+	}
+}
+
 void Client::GoToDeath() {
 	//Client will request a zone in EQMac era clients, but let's make sure they get there:
 	zone_mode = ZoneToBindPoint;

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -962,12 +962,12 @@ void Client::GoToBind(uint8 bindnum) {
 }
 
 void Client::BootFromGuildInstance() {
-	ZoneBanishPoint* zbp = zone->GetZoneBanishPoint();
-	if (zbp == nullptr) {
+	ZoneBanishPoint zbp = zone->GetZoneBanishPoint();
+	if (zbp.target_zone_id == 0) {
 		this->GoToBind();
 	}
 	else {
-		MovePCGuildID(zbp->target_zone_id, GUILD_NONE, zbp->x, zbp->y, zbp->z, zbp->heading, 1, ZoneSolicited);
+		MovePCGuildID(zbp.target_zone_id, GUILD_NONE, zbp.x, zbp.y, zbp.z, zbp.heading, 1);
 	}
 }
 


### PR DESCRIPTION
This change will load and attach a zone banish point to each zone.

The zone banish points are populated at zone load time by looking at the doors with `guildzonedoor=1` leading to the zone and storing the book location (zone, x, y, z, heading).

This can be changed later if we want a different system.

Added a grace timer defaulting to 1 minute after zone before being booted out.