### PR TITLE
Made disarm useful

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5119,7 +5119,17 @@ float Client::GetQuiverHaste()
 
 uint8 Client::Disarm(float chance)
 {
-	EQ::ItemInstance* weapon = m_inv.GetItem(EQ::invslot::slotPrimary);
+	int16 slot = EQ::invslot::SlotPrimary
+	EQ::ItemInstance* weapon = m_inv.GetItem(slot);
+	uint8 texture = EQ::textures::weaponPrimary
+
+	if(!weapon)
+	{
+		slot = EQ::invslot::slotSecondary
+		weapon = m_inv.GetItem(slot)
+		texture = EQ::textures::weaponSecondary
+	}
+  // TODO <Lynch>: maybe change this to align more with npcs? (drop non magical)
 	if(weapon)
 	{
 		if (zone->random.Roll(chance))
@@ -5128,9 +5138,9 @@ uint8 Client::Disarm(float chance)
 			uint16 freeslotid = m_inv.FindFreeSlot(false, true, weapon->GetItem()->Size);
 			if(freeslotid != INVALID_INDEX)
 			{
-				DeleteItemInInventory(EQ::invslot::slotPrimary,0,true);
+				DeleteItemInInventory(slot,0,true);
 				SummonItem(weapon->GetID(),charges,freeslotid);
-				WearChange(EQ::textures::weaponPrimary,0,0);
+				WearChange(texture,0,0);
 
 				return 2;
 			}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2605,7 +2605,17 @@ uint8 NPC::Disarm(float chance)
 		return 0;
 	}
 
-	ServerLootItem_Struct* weapon = GetItem(EQ::invslot::slotPrimary);
+	int16 slot = EQ::invslot::SlotPrimary
+	ServerLootItem_Struct* weapon = GetItem(slot);
+	uint8 texture = EQ::textures::weaponPrimary
+
+	if(!weapon)
+	{
+		slot = EQ::invslot::slotSecondary
+		weapon = GetItem(slot)
+		texture = EQ::textures::weaponSecondary
+	}
+
 	if (weapon)
 	{
 		if (zone->random.Roll(chance))
@@ -2615,11 +2625,14 @@ uint8 NPC::Disarm(float chance)
 
 			if (inst)
 			{
-				// No drop weapons not disarmable
-				if (inst->GetItem()->Magic)
-					return 0;
-
-				if (inst->GetItem()->NoDrop == 0)
+				// Redid this so that maybe some raid encounters could be spicy?
+				// otherwise no reason most solo/group mobs should have double dps randomly
+				// without a way to disable it (eg haste/slow)
+				if (inst->GetItem()->Magic && (inst->GetItem()->NoDrop == 0))
+				{
+					return 0
+				}
+				else if(inst->GetItem()->Magic || (inst->GetItem()->NoDrop == 0))
 				{
 					MoveItemToGeneralInventory(weapon);
 				}
@@ -2629,7 +2642,7 @@ uint8 NPC::Disarm(float chance)
 					entity_list.CreateGroundObject(weaponid, glm::vec4(GetX(), GetY(), GetZ(), 0), RuleI(Groundspawns, DisarmDecayTime));
 				}
 
-				WearChange(EQ::textures::weaponPrimary, 0, 0);
+				WearChange(texture, 0, 0);
 				CalcBonuses();
 				SetPrimSkill(EQ::skills::SkillHandtoHand);
 


### PR DESCRIPTION
Classic disarm sucks, should be able to disarm offhand (and thus duel wield) ala haste/slow. Upon 2nd successful disarm npc should set to single attack timer via CalcBonuses()

Also, magic tags are very liberal and makes disarm worthless if you cant disarm. Left combonation NODROP & magic unable to be disarmed cause most of those weapons are likely raid targets anyway. 

This is basically a buff to solo/grouping melee.