### PR TITLE
Added classic through luclin eras mitigation AC caps

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -254,7 +254,6 @@ RULE_INT(Quarm, AutomatedRaidRotationRaidGuildMemberCountRequirement, 12) // Req
 RULE_INT(Quarm, AutomatedRaidRotationRaidNonMemberCountRequirement, 18) // Required amount of same-guild members to participate in a raid encounter. These must be in the same guild, and one officer from the current guild must be in the raid.
 RULE_INT(Quarm, MinStatusToZoneIntoAnyGuildZone, 100) // Required amount of same-guild members to participate in a raid encounter. These must be in the same guild, and one officer from the current guild must be in the raid.
 RULE_BOOL(Quarm, EnableGuildZoneRequirementOnEntry, false) // Classic behavior is true. Live Quarm has this false by default. CSR complaints about training warranted this behavior.
-RULE_BOOL(Quarm, EnforceClassicEraHardCaps, true) // Classic behavior is true, Late velious and later is false. Master switch for AC softcaps.
 RULE_INT(Quarm, AOEThrottlingMaxAOETargets, 50) // This will curb nonsense with performance issues relating to amount of targets if the amount of clients exceeds 300 in a single zone.
 RULE_INT(Quarm, AOEThrottlingMaxClients, 300) // This will curb nonsense with performance issues relating to amount of targets if the amount of clients exceeds 300 in a single zone.
 RULE_INT(Quarm, EnableLuclinEraShieldACOvercap, false)


### PR DESCRIPTION
Removed the enforce hardcaps rule and replaced it with CurrentExpansion checks.

This commit made mitigation AC caps the following:

Player level < 51, hardcap of 350 for all classes
In Kunark warriors get a hardcap of 405.  Other classes unchanged. (350)
Early Velious (3.3), hardcaps get raised to 430, 403, 375 for melee classes.
Late Velious (3.6), hardcaps turn into softcaps for melee classes only, with overcap returns being divided by 12.
PoP era unchanged other than levels < 51 being stuck at 350.  Not sure if that should be the case or not but Mackal's Luclin decompile says yes.