### PR TITLE
Added some level checks to summon and enrage

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2067,6 +2067,10 @@ bool Mob::CheckHateSummon(Mob* summoned) {
 		return false;
 	}
 
+	// this is so we don't have to make duplicate types; some mob types are 48-52 and only the 51-52s should summon
+	if (IsNPC() && GetLevel() < 51 && GetLevel() > 47 && zone->GetZoneExpansion() < LuclinEQ)
+		return false;
+
 	// now validate the timer
 	Timer *timer = GetSpecialAbilityTimer(SPECATK_SUMMON);
 	if (!timer)

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2665,6 +2665,10 @@ void Mob::CheckEnrage()
 {
 	if (!bEnraged && GetSpecialAbility(SPECATK_ENRAGE))
 	{
+		// this is so we don't have to make duplicate NPC types
+		if (IsNPC() && GetLevel() < 56 && GetLevel() > 52)
+			return;
+
 		int hp_ratio = GetSpecialAbilityParam(SPECATK_ENRAGE, 0);
 		hp_ratio = hp_ratio > 0 ? hp_ratio : RuleI(NPC, StartEnrageValue);
 		if (GetHPRatio() <= static_cast<float>(hp_ratio))


### PR DESCRIPTION
This was done because NPC types have level ranges and sometimes these ranges cross the threshold of summoning and enrage.  Previously the only way to handle this was to duplicate the NPC type and apply the special ability to one type and not the other, but this clutters up the database.  So I hardcoded level checks to fail summon and enrage if the NPC was under the threshold levels even while having the special abilty set.  Currently we have some planar mobs not summoning at all when they should be due to this problem.

I would have checked the maxlevel field but that is not accessible from the Mob class and adding new methods for this would add more clutter so I just checked if the NPC is level 48-50 and 53-55.