### PR TITLE
Default GCD rule changed to 3500ms; added spell cast times to spell c…

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -330,7 +330,7 @@ RULE_INT ( Spells, AI_IdleNoSpellMaxRecast, 6000) // AI spell recast time(MS) ch
 RULE_INT ( Spells, AI_IdleBeneficialChance, 100) // Chance while idle to do a beneficial spell on self or others.
 RULE_BOOL ( Spells, SHDProcIDOffByOne, true) // pre June 2009 SHD spell procs were off by 1, they stopped doing this in June 2009 (so UF+ spell files need this false)
 RULE_BOOL ( Spells, SwarmPetTargetLock, false) // Use old method of swarm pets target locking till target dies then despawning.
-RULE_INT ( Spells, SpellRecoveryTimer, 2500) // Begins when a cast is complete, and is checked after the next spell finishes casting. If not expired, the new spell is interrupted. Clickies are exempt.
+RULE_INT ( Spells, SpellRecoveryTimer, 3500) // Begins when a cast is complete, and is checked after the next spell finishes casting. If not expired, the new spell is interrupted. Clickies are exempt. 3500 is Sony's value
 RULE_BOOL ( Spells, JamFestAAOnlyAffectsBard, true) // Bard Jam Fest AA only worked on bards themselves but was changed after AK's era.  Changing this to false will put the client stats out of sync with the server.
 RULE_BOOL ( Spells, ReducePacifyDuration, false) // AK and the eqmac client have 60 tick Pacify (spell 45) duration.  This rule reduces the duration to 7 ticks without desyncing the cast bar and focus effects for custom servers that want this.
 RULE_CATEGORY_END()

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2304,6 +2304,15 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 				recast -= GetAA(aaTouchoftheWicked) * 720;
 				CastToClient()->ExpendAATimer(aaImprovedHarmTouch);
 			}
+			else
+			{
+				recast += GetActSpellCasttime(spell_id, spells[spell_id].cast_time) / 1000 - 1;
+				if (
+					GetLevel() > 50 && spells[spell_id].goodEffect == 0 && spells[spell_id].cast_time > 2999 &&
+					(GetClass() == BEASTLORD || GetClass() == PALADIN || GetClass() == RANGER || GetClass() == SHADOWKNIGHT)
+				)
+					recast -= 1;
+			}
 
 			uint16 timer_id = spell_id;
 			if(spell_id == SPELL_HARM_TOUCH2)


### PR DESCRIPTION
…ooldown server checks

Sony's global cooldown was 3.5 seconds and this is very obvious from logs.  I changed the rule default value to 3500ms, so the default is now accuruate and non-custom.  However the database has the rule in it so that will need to be changed for Quarm.

Spell cast times were added to the server cooldowns for individual spells.  This will prevent chain casts of certain spells with a cooldown, like enchanter nukes and wizard pillars.  Before, the cooldown was run concurrently with the spell cast time when the spell was in gem slot 1 and clickables were used, which in some cases could nearly double the cast rate.  I subtracted 1 second from the cast time added to the cooldown just to be cautious.