### PR TITLE
Fix for Self-Found level check when buffing.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -663,11 +663,13 @@ bool Mob::DoPreCastingChecks(uint16 spell_id, CastingSlot slot, uint16 spell_tar
 					bool compatible = caster->IsSelfFound() == spell_target->CastToClient()->IsSelfFound();
 					if (!compatible)
 					{
+						// if the spell target is self found, but the caster is not, don't allow the caster to buff
 						is_failed_cast = true;
 						fail_message = SELF_FOUND_ERROR;
 					}
 					else if(compatible && !can_get_experience)
 					{
+						// if the spell_target can not get EXP while grouped with the caster, don't allow the caster to buff
 						is_failed_cast = true;
 						fail_message = LEVEL_ERROR;
 					}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -659,7 +659,7 @@ bool Mob::DoPreCastingChecks(uint16 spell_id, CastingSlot slot, uint16 spell_tar
 				} 
 				if (spell_target->CastToClient()->IsSelfFound() && spell_target != this)
 				{
-					bool can_get_experience = caster->IsInLevelRange(spell_target->CastToClient()->GetLevel2());
+					bool can_get_experience = spell_target->CastToClient()->IsInLevelRange(caster->GetLevel2());
 					bool compatible = caster->IsSelfFound() == spell_target->CastToClient()->IsSelfFound();
 					if (!compatible)
 					{


### PR DESCRIPTION
Currently, the self found buff checks are broken, allowing a higher level character to cast buffs on a lower level character but not the other way around. This is backwards to how it should be.

Changing IsInLevelRange() to verify that the spell_target can get EXP while with the caster should fix this instead of the other way around.