### PR TITLE
Hardcode warrior epic effects to standard hate before proc hate cap i…

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1546,6 +1546,12 @@ int32 Mob::CheckAggroAmount(uint16 spell_id, Mob* target)
 			case SE_InstantHate:
 			{
 				instantHate += CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base[o], spells[spell_id].max[o], slevel, spell_id);
+
+				// Warrior epic effects; they used to do a AC debuff; need to do this else other procs will do more hate on high HP targets
+				if ((spell_id == 1935 || spell_id == 1933) && RuleR(World, CurrentExpansion) < (float)ExpansionEras::VeliousEQEra + 0.19)
+				{
+					instantHate = standardSpellHate;
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
…s enabled

This just makes sense to do if we're gating the proc hate cap, otherwise warrior epics will end up doing less hate than most proc weapons on high HP targets.

The warrior epic effects used to do AC debuffs, and that's how they generated significant hate.  Sony changed these effects to do a flat +hate amount when EB weapons were put in, and our spells are the post-change versions.