### PR TITLE
hell_mods for levels 60-65 made accurate

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -792,17 +792,17 @@ uint32 Client::GetEXPForLevel(uint16 check_level, bool aa)
 	else if (check_level == 59)
 		mod = 3.0;
 	else if (check_level == 60)
-		mod = 3.1;
+		mod = 3.0;
 	else if (check_level == 61)
-		mod = 3.3;
+		mod = 3.225;
 	else if (check_level == 62)
-		mod = 3.5;
+		mod = 3.45;
 	else if (check_level == 63)
-		mod = 3.7;
+		mod = 3.675;
 	else if (check_level == 64)
 		mod = 3.9;
 	else
-		mod = 4.1;
+		mod = 4.125;
 
 	uint32 finalxp = uint32(base * playermod * mod);
 


### PR DESCRIPTION
Note that this commit will result in some players who are levels 60 to 64 to end up one level higher than they were, as it changes the amount of experience for these levels.  Quarm shouldn't have a problem with this since we're still in classic era.  TAKP on the otherhand will have this problem, so I didn't push this there.  However these are the precise hell_mods and TAKP needs to have them eventually.