### PR TITLE
Overrides for level 50 and 60 HBMs

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -285,6 +285,11 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, Mob* killed_mob, int16 av
 		aa_lvl_mod = zone->level_exp_mod[GetLevel()].AAExpMod;
 		if (!aa_lvl_mod)
 			aa_lvl_mod = 1.0f;
+
+		if (GetLevel() == 50 && hbm < 1.0f && RuleR(World, CurrentExpansion) < (float)ExpansionEras::KunarkEQEra)
+			hbm = 1.0f;
+		if (GetLevel() == 60 && hbm < 1.0f && RuleR(World, CurrentExpansion) < (float)ExpansionEras::PlanesEQEra)
+			hbm = 1.0f;
 	}
 
 	if (m_epp.perAA<0 || m_epp.perAA>100)


### PR DESCRIPTION
The hell level smoothing done in Luclin reduced the amount of experience gained in these levels because these levels are short.  This results in deaths in these levels being harsher than typical.  Since these levels are the max levels at their respective eras, it makes sense to override their HBMs until they're no longer the max level, particularly when leveling smoothing was a mid to late Luclin era addition.

Before this commit, players had their exp reduced by 25% in these levels.  After this commit that penalty goes away until the max level achieveable is higher than these levels.