### PR TITLE
Hardcoded Maestro AoE to heal him

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -58,6 +58,7 @@
 #define SPELL_AA_BOASTFUL_BELLOW 3282
 #define SPELL_EPOCH_CONVICTION 3767
 #define SPELL_GREENMIST_RECOURSE 3978
+#define SPELL_LIFE_DRAIN 931
 
 #define EFFECT_COUNT 12
 #define MAX_SPELL_TRIGGER 12	// One for each slot(only 6 for AA since AA use 2)

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -144,6 +144,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 					//handles AAs and what not...
 					if(caster) {
 						dmg = caster->GetActSpellDamage(spell_id, dmg, this);
+
+						if (spell_id == SPELL_LIFE_DRAIN)	// Maestro AoE.  Spell data uses type 8, but it's supposed to heal him.  Sony may have hardcoded
+							caster->HealDamage(-dmg);		// this because targettype 20 didn't exist back then and there's seemingly no other way to make it tap
 					}
 
 					dmg = -dmg;


### PR DESCRIPTION
This is a hack to make Maestro's AoE heal.  I couldn't think of a better way to do this.

Changing the targettype to 20 in the database would probably work but people seem to frown upon editing spells.