### PR TITLE
Pseudo-Classic Resists

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3971,10 +3971,52 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 		}
 	}
 
+	bool use_classic_resists = RuleR(World, CurrentExpansion) < (float)ExpansionEras::LuclinEQEra + 0.79;
+
 	//Add our level, resist and -spell resist modifier to our roll chance
-	resist_chance += level_mod;
-	resist_chance += resist_modifier;
 	resist_chance += target_resist;
+	resist_chance += level_mod;
+	if (use_classic_resists && IsClient())
+	{
+		if (resist_chance > 200 && spells[spell_id].targettype == ST_Tap)
+			resist_chance = 200;
+
+		if (caster->IsNPC())
+		{
+			if (spell_id == 837)	// Stun Breath
+				resist_modifier = -50;
+			if (spell_id == 843)	// Immolating Breath
+				resist_modifier = -100;
+
+			if (resist_modifier == -150)
+			{
+				// dragon aoes
+				resist_modifier = -100;
+			}
+		}
+
+		int hardcap = 350;
+		if (RuleR(World, CurrentExpansion) < (float)ExpansionEras::VeliousEQEra)
+			hardcap = 250;
+
+		if (resist_chance > hardcap)
+			resist_chance = hardcap;
+
+		if (resist_chance > 200)
+			resist_chance = 200 + (resist_chance - 200) / 2;
+	}
+
+	resist_chance += resist_modifier;
+
+	if (use_classic_resists && caster->IsNPC() && caster->GetLevel() > 24 && zone->GetZoneID() != sirens
+		&& (caster->GetClass() == ENCHANTER || caster->GetClass() == ENCHANTERGM) )
+	{
+		if (GetLevel() < resist_chance)
+			resist_chance = GetLevel();
+
+		if (resist_chance > 80)
+			resist_chance = 80;
+	}
 
 	if (tick_save)
 	{
@@ -4038,16 +4080,19 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 		}
 		else
 		{
+			if (use_classic_resists && resist_chance > 200 && IsClient())
+				resist_chance = 200;
+
 			int partial_modifier = ((150 * (resist_chance - roll)) / resist_chance);
 
 			if(IsNPC())
 			{
-				if(target_level > caster_level && target_level >= 17 && caster_level <= 50)
+				if(target_level > caster_level && target_level >= 17 && (caster_level <= 50 || use_classic_resists))
 				{
 					partial_modifier += 5;
 				}
 
-				if(target_level >= 30 && caster_level <= 50)
+				if(target_level >= 30 && (caster_level <= 50 || use_classic_resists))
 				{
 					partial_modifier += (caster_level - 25);
 				}


### PR DESCRIPTION
This commit alters the resist spell method to try and mimic the classic, pre-September 2002 resists while keeping the 0-200 scale and -resist adjusts on spells.  Switching to the 0-99 scale would be too disruptive and troublesome to implement and would require a lot of database changes, so maintaining much of the PoP era system was desirable.  These changes are all gated to late Luclin and earlier.

Changes in this commit:

* Lifetaps on client targets are unresistable.
* Resist hardcap of 250 in Classic and Kunark eras, 350 after Kunark.
* Softcap at 200, overcap returns are half.
* Dragon breaths with a lure component hardcoded to be -100 instead of -150.
* Immolating Breath and Stun Breath hardcoded to be granted resist modifiers.
* Enchanter NPCs will be able to land spells on high resist targets.
* Partial hit damage is reduced for 51+ client casters. (it's kept as it is at level 50 and under)
* Partial damage taken by clients is increased.

I omitted the resist floors due to how disruptive those would be.  In some scenarios the resists are knowingly more lenient (higher caps) in this than in the Kunark decompile because the hardcap back then was rather harsh and the effectiveness per point of resist is reduced in many cases due to the 200 scale, requiring more resist to reach the same mitigation as classic.  I also believe that Sony likely altered the resist function at Velious launch to make resisting dragons easier and I can't say how exactly, but the obvious move would have been to raise the hardcap so that's what I did.