### PR TITLE
Remove extra incorrect duration tick from Splurt line spells

### DIFF
--- a/utils/sql/git/content/2024_07_20_Increase_Decrepit_Hide_SHD_Epic_Hate.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Decrepit_Hide_SHD_Epic_Hate.sql
@@ -1,0 +1,2 @@
+/* Change chance of ashenbone drakes in hate to drop SHD epic component 'Decrepit Hide' from 19% to 38% (item_id:14371, loottable_id:1958, lootdrop_id:3732) */
+update lootdrop_entries set chance = 38 where lootdrop_id = 3732 and item_id = 14371 and chance = 19;

--- a/utils/sql/git/content/2024_07_20_Increase_Epic_Mob_Spawns_Instanced_Fear.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Epic_Mob_Spawns_Instanced_Fear.sql
@@ -1,0 +1,3 @@
+/* Fix respawn timers for Epic mobs in Plane of Fear */
+update npc_types set instance_spawn_timer_override = 3600000 where name = 'Wraith_of_a_Shissir';
+update npc_types set instance_spawn_timer_override = 3600000 where name = 'a_broken_golem';

--- a/utils/sql/git/content/2024_07_20_Increase_Essence_of_Vampire_ENC_Epic_Hate.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Essence_of_Vampire_ENC_Epic_Hate.sql
@@ -1,0 +1,2 @@
+/* Change chance of male revenants in hate to drop ENC epic component 'Essence of a Vampire' from 1% to 9% (item_id:10624, loottable_id:168, lootdrop_id:385) */
+update lootdrop_entries set chance = 9 where lootdrop_id = 385 and item_id = 10624 and chance = 1;

--- a/utils/sql/git/content/2024_07_20_Increase_Soul_Leech_Hate.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Soul_Leech_Hate.sql
@@ -1,0 +1,2 @@
+/* Change chance of Cazic Thule in fear to drop SHD epic component 'Soul Leech' from 50% to 100% (item_id:4200012, loottable_id:2200034, lootdrop_id:11609) */
+update lootdrop_entries set chance = 100 where lootdrop_id = 2200034 and item_id = 11609;

--- a/utils/sql/git/content/2024_07_20_OT_Hammer_Skeleton_Deagro.sql
+++ b/utils/sql/git/content/2024_07_20_OT_Hammer_Skeleton_Deagro.sql
@@ -1,0 +1,2 @@
+/* Fix aggressive skeleton by using spawn with no faction on boat where players port in from using Worker Sledgemallet (Overthere proc) */
+update spawn2 set x = 3382.000000, y = 2587.000000, z = -126.599998, spawngroupID = 222823 where id = 343728;

--- a/zone/buffstacking.cpp
+++ b/zone/buffstacking.cpp
@@ -898,7 +898,7 @@ bool Mob::AssignBuffSlot(Mob *caster, uint16 spell_id, int &buffslot, int &caste
 	// now add buff at emptyslot
 	assert(buffs[emptyslot].spellid == SPELL_UNKNOWN || buffs[emptyslot].spellid == spell_id);	// sanity check
 
-	int extraTick = 1;  // all buffs get an extra tick
+	int extraTick = (IsSplurtFormulaSpell(spell_id)) ? 0 : 1;  // all buffs get an extra tick, except splurts
 	buffs[emptyslot].spellid = spell_id;
 	buffs[emptyslot].casterlevel = caster_level;
 	buffs[emptyslot].realcasterlevel = caster ? caster->GetLevel() : caster_level;


### PR DESCRIPTION
Splurts are a detrimental buff that do not need an extra tick added to their duration.  The current extra tick is causing the first tick of the spell effect to go missing due to a non-damaging value.