### PR TITLE
Database content updates

### DIFF
--- a/utils/sql/git/content/2024_07_20_Add_Decrepit_Hide_Dracoliche_Fear.sql
+++ b/utils/sql/git/content/2024_07_20_Add_Decrepit_Hide_Dracoliche_Fear.sql
@@ -1,0 +1,10 @@
+/* Create new loot drop row */
+INSERT INTO lootdrop VALUES (NULL,'4200024_dracoliche_DecrepitHide');
+
+SET @lootdrop_id = LAST_INSERT_ID();
+
+/* Add item 'Decrepit Hide' to lootdrop entries at 100% chance */
+INSERT INTO lootdrop_entries VALUES (@lootdrop_id,14371,1,0,100,0,255,1,0,0,0,0,0);
+
+/* Attach lootdrop to loottable at 100% probability */
+INSERT INTO loottable_entries VALUES (4200024,@lootdrop_id,1,100,1,1,0);

--- a/utils/sql/git/content/2024_07_20_Increase_Decrepit_Hide_SHD_Epic_Hate.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Decrepit_Hide_SHD_Epic_Hate.sql
@@ -1,0 +1,2 @@
+/* Change chance of ashenbone drakes in hate to drop SHD epic component 'Decrepit Hide' from 19% to 38% (item_id:14371, loottable_id:1958, lootdrop_id:3732) */
+update lootdrop_entries set chance = 38 where lootdrop_id = 3732 and item_id = 14371 and chance = 19;

--- a/utils/sql/git/content/2024_07_20_Increase_Epic_Mob_Spawns_Instanced_Fear.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Epic_Mob_Spawns_Instanced_Fear.sql
@@ -1,0 +1,3 @@
+/* Fix respawn timers for Epic mobs in Plane of Fear */
+update npc_types set instance_spawn_timer_override = 3600000 where name = 'Wraith_of_a_Shissir';
+update npc_types set instance_spawn_timer_override = 3600000 where name = 'a_broken_golem';

--- a/utils/sql/git/content/2024_07_20_Increase_Essence_of_Vampire_ENC_Epic_Hate.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Essence_of_Vampire_ENC_Epic_Hate.sql
@@ -1,0 +1,2 @@
+/* Change chance of male revenants in hate to drop ENC epic component 'Essence of a Vampire' from 1% to 9% (item_id:10624, loottable_id:168, lootdrop_id:385) */
+update lootdrop_entries set chance = 9 where lootdrop_id = 385 and item_id = 10624 and chance = 1;

--- a/utils/sql/git/content/2024_07_20_Increase_Soul_Leech_Hate.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Soul_Leech_Hate.sql
@@ -1,2 +1,2 @@
-/* Change chance of Cazic Thule in fear to drop SHD epic component 'Soul Leech' from 50% to 100% (item_id:4200012, loottable_id:2200034, lootdrop_id:11609) */
-update lootdrop_entries set chance = 100 where lootdrop_id = 2200034 and item_id = 11609;
+/* Change probability of Cazic Thule in fear to drop SHD epic component 'Soul Leech' from 50% to 100% (loottable_id:4200012, lootdrop_id:2200034) */
+update loottable_entries set probability = 100 where loottable_id = 4200012 and lootdrop_id = 2200034;

--- a/utils/sql/git/content/2024_07_20_Increase_Soul_Leech_Hate.sql
+++ b/utils/sql/git/content/2024_07_20_Increase_Soul_Leech_Hate.sql
@@ -1,0 +1,2 @@
+/* Change chance of Cazic Thule in fear to drop SHD epic component 'Soul Leech' from 50% to 100% (item_id:4200012, loottable_id:2200034, lootdrop_id:11609) */
+update lootdrop_entries set chance = 100 where lootdrop_id = 2200034 and item_id = 11609;

--- a/utils/sql/git/content/2024_07_20_OT_Hammer_Skeleton_Deagro.sql
+++ b/utils/sql/git/content/2024_07_20_OT_Hammer_Skeleton_Deagro.sql
@@ -1,0 +1,2 @@
+/* Fix aggressive skeleton by using spawn with no faction on boat where players port in from using Worker Sledgemallet (Overthere proc) */
+update spawn2 set x = 3382.000000, y = 2587.000000, z = -126.599998, spawngroupID = 222823 where id = 343728;


### PR DESCRIPTION
- Change chance of ashenbone drakes in hate to drop SHD epic component 'Decrepit Hide' from 19% to 38% 
- Fix respawn timers for Epic mobs in Plane of Fear 
- Change chance of male revenants in hate to drop ENC epic component 'Essence of a Vampire' from 1% to 9% 
- Change probability of Cazic Thule in fear to drop SHD epic component 'Soul Leech' from 50% to 100% 
- Fix aggressive skeleton by using spawn with no faction on boat where players port in from using Worker Sledgemallet (Overthere proc) 