### PR TITLE
Update Chardok spawngroup that is too close to the wall and causing problems

### DIFF
--- a/utils/sql/git/content/2024_07_27_Chardok_Soultrapper_Pet_In_Wall_Fix.sql
+++ b/utils/sql/git/content/2024_07_27_Chardok_Soultrapper_Pet_In_Wall_Fix.sql
@@ -1,0 +1,2 @@
+/* a Shai`din Soultrapper in the spawngroup 223251 (chardok) and 223251 (chardok_instanced [not currently used]) spawns so close to the wall that it's pet is summoned in the wall */
+update spawn2 set y = 138.000000 where zone like 'chardok%' and x = 240.000000 and y = 140.000000 and z = 44.400002;


### PR DESCRIPTION
Fixed spawnpoint for a Shai`din Soultrapper in Chardok so when it summons a pet, that pet is no longer stuck in the wall causing players to crash when targeting it.