### PR TITLE
Prevent PBAE from targeting raid pets.

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1130,8 +1130,25 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 
 		if (detrimental) {
 			// aoe spells do hit other players except if in same raid or group.  their pets get hit even when grouped.  SpellOnTarget checks pvp protection
-			if (caster != curmob && (caster->InSameGroup(curmob) || caster->InSameRaid(curmob) || (curmob->GetOwner() && caster->InSameRaid(curmob->GetOwner()))))
-				continue;
+			if (caster != curmob) {
+				Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d detrimental and not caster, evaluating mob %s", spell_id, curmob->GetName());
+				if (caster->InSameGroup(curmob))
+				{
+					Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d won't hit group member %s", spell_id, curmob->GetName());
+					continue;
+				}
+				else if (caster->InSameRaid(curmob)) 
+				{
+					Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d won't hit raid member %s", spell_id, curmob->GetName());
+					continue;
+				}
+				else if (curmob->GetOwner() && caster->InSameRaid(curmob->GetOwner())) 
+				{
+					Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d won't hit raid member pet %s", spell_id, curmob->GetName());
+					continue;
+				}
+				
+			}
 
 			if (!zone->SkipLoS() && !spells[spell_id].npc_no_los && curmob != caster && !center->CheckLosFN(curmob, true))
 				continue;
@@ -1223,11 +1240,11 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 		{
 			if (curmob->IsClient() && curmob->CastToClient()->GetHideMe())
 			{
-				Log(Logs::Moderate, Logs::Spells, "Non-limited AE Spell: Skipping GM %s with spell %i", curmob->GetCleanName(), spell_id);
+				Log(Logs::Moderate, Logs::Spells, "PB AE Spell: Skipping GM %s with spell %i", curmob->GetCleanName(), spell_id);
 			}
 			else
 			{
-				Log(Logs::Moderate, Logs::Spells, "Non-limited AE Spell: %d has hit target %s", spell_id, curmob->GetCleanName());
+				Log(Logs::Moderate, Logs::Spells, "PB AE Spell: %d has hit target %s", spell_id, curmob->GetCleanName());
 				caster->SpellOnTarget(spell_id, curmob, false, true, resist_adjust, false, ae_caster_id);
 				if (limit_all_aoes)
 				{
@@ -1235,7 +1252,7 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 					if(curmob->IsNPC())
 					{
 						++targets_hit;
-						Log(Logs::Detail, Logs::Spells, "Non-limited AE Spell: %d [#%d/%d]", spell_id, targets_hit, MAX_TARGETS_ALLOWED);
+						Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d [#%d/%d]", spell_id, targets_hit, MAX_TARGETS_ALLOWED);
 					}
 
 					if (targets_hit >= MAX_TARGETS_ALLOWED)

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1233,7 +1233,11 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 				{
 
 					if(curmob->IsNPC())
+					{
 						++targets_hit;
+						Log(Logs::Detail, Logs::Spells, "Non-limited AE Spell: %d [#%d/%d]", spell_id, targets_hit, MAX_TARGETS_ALLOWED);
+					}
+
 					if (targets_hit >= MAX_TARGETS_ALLOWED)
 						break;
 				}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1130,7 +1130,7 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 
 		if (detrimental) {
 			// aoe spells do hit other players except if in same raid or group.  their pets get hit even when grouped.  SpellOnTarget checks pvp protection
-			if (caster != curmob && (caster->InSameGroup(curmob) || caster->InSameRaid(curmob)))
+			if (caster != curmob && (caster->InSameGroup(curmob) || caster->InSameRaid(curmob) || (curmob->GetOwner() && caster->InSameRaid(curmob->GetOwner()))))
 				continue;
 
 			if (!zone->SkipLoS() && !spells[spell_id].npc_no_los && curmob != caster && !center->CheckLosFN(curmob, true))

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1131,7 +1131,7 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 		if (detrimental) {
 			// aoe spells do hit other players except if in same raid or group, raid pets are also excluded.  non-raid, group pets get hit.  SpellOnTarget checks pvp protection
 			if (caster != curmob) {
-				Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d detrimental and not caster, evaluating target %s", spell_id, curmob->GetName());
+				// Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d detrimental and not caster, evaluating target %s", spell_id, curmob->GetName());
 				if (caster->InSameGroup(curmob))
 				{
 					Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d won't hit group member %s", spell_id, curmob->GetName());

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1129,9 +1129,9 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 		}
 
 		if (detrimental) {
-			// aoe spells do hit other players except if in same raid or group.  their pets get hit even when grouped.  SpellOnTarget checks pvp protection
+			// aoe spells do hit other players except if in same raid or group, raid pets are also excluded.  non-raid, group pets get hit.  SpellOnTarget checks pvp protection
 			if (caster != curmob) {
-				Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d detrimental and not caster, evaluating mob %s", spell_id, curmob->GetName());
+				Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d detrimental and not caster, evaluating target %s", spell_id, curmob->GetName());
 				if (caster->InSameGroup(curmob))
 				{
 					Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d won't hit group member %s", spell_id, curmob->GetName());
@@ -1146,8 +1146,7 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 				{
 					Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d won't hit raid member pet %s", spell_id, curmob->GetName());
 					continue;
-				}
-				
+				}		
 			}
 
 			if (!zone->SkipLoS() && !spells[spell_id].npc_no_los && curmob != caster && !center->CheckLosFN(curmob, true))
@@ -1244,16 +1243,12 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 			}
 			else
 			{
-				Log(Logs::Moderate, Logs::Spells, "PB AE Spell: %d has hit target %s", spell_id, curmob->GetCleanName());
+				Log(Logs::Moderate, Logs::Spells, "PB AE Spell: %d has hit target %s [#%d/%d]", spell_id, curmob->GetCleanName(), targets_hit + 1, MAX_TARGETS_ALLOWED);
 				caster->SpellOnTarget(spell_id, curmob, false, true, resist_adjust, false, ae_caster_id);
 				if (limit_all_aoes)
 				{
-
 					if(curmob->IsNPC())
-					{
 						++targets_hit;
-						Log(Logs::Detail, Logs::Spells, "PB AE Spell: %d [#%d/%d]", spell_id, targets_hit, MAX_TARGETS_ALLOWED);
-					}
 
 					if (targets_hit >= MAX_TARGETS_ALLOWED)
 						break;


### PR DESCRIPTION
When a raid is using a PBAE strategy, remove raid member pets from the list of valid targets in order to preserve the maximum targets allowed cap.