### PR TITLE
Fixed zoning from an instance to the same non-instanced zone.

### DIFF
--- a/utils/sql/git/required/2024_07_29_Fix_Loading_Zones_For_Instance_Zoning.sql
+++ b/utils/sql/git/required/2024_07_29_Fix_Loading_Zones_For_Instance_Zoning.sql
@@ -1,0 +1,2 @@
+/* Loading zones for the client need to be set to any expansion, which changed from 0 to -1 */
+update zone set expansion = -1 where short_name in ('load','load2');

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -730,6 +730,9 @@ void Client::ZonePC(uint32 zoneID, uint32 zoneGuildID, float x, float y, float z
 
 		zone_mode = zm;
 
+		Log(Logs::Detail, Logs::EQMac, "Client::ZonePC GetName(%s) pZoneName(%s) zm(%i) zonesummon_id(%i) zoneID(%i) zonesummon_guildid(%i) zoneGuildID(%i) zonesummon_ignorerestrictions(%i) ignorerestrictions(%i) zone->GetZoneID(%i) zone->GetGuildID(%i)",
+										GetName(), pZoneName, zm, zonesummon_id, zoneID, zonesummon_guildid, zoneGuildID, zonesummon_ignorerestrictions, ignorerestrictions, zone->GetZoneID(), zone->GetGuildID());
+
 		if(zm == ZoneSolicited || zm == ZoneToSafeCoords) {
 			Log(Logs::Detail, Logs::EQMac, "Zoning packet about to be sent (ZS/ZTS). We are headed to zone: %i, at %f, %f, %f", zoneID, x, y, z);
 			auto outapp = new EQApplicationPacket(OP_RequestClientZoneChange, sizeof(RequestClientZoneChange_Struct));
@@ -799,7 +802,7 @@ void Client::ZonePC(uint32 zoneID, uint32 zoneGuildID, float x, float y, float z
 			zonesummon_id = zoneID;
 			zonesummon_guildid = zoneGuildID;
 
-			Log(Logs::Detail, Logs::EQMac, "Zoning packet about to be sent (GTB). We are headed to zone: %i, at %f, %f, %f", zoneID, x, y, z);
+			Log(Logs::Detail, Logs::EQMac, "Zoning packet about to be sent (GTB). We are headed to zone: %i (%i), at %f, %f, %f", zoneID, zoneGuildID, x, y, z);
 			if(zoneID == GetZoneID() && zoneGuildID == zone->GetGuildID()) {
 				//Not doing inter-zone for same zone gates. Client is supposed to handle these, based on PP info it is fed.
 				//properly handle proximities


### PR DESCRIPTION
* Fixed a bug where teleporting from an instance of zone to the non-instanced version of the zone would send player to the safe coordinates of the instanced zone and lock their spell gems.