### PR TITLE
Fix sf loot issues

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2270,6 +2270,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 				if (r) {
 					r->VerifyRaid();
 					float raidHighestLevel = r->GetHighestLevel2();
+					corpse->SetInitialAllowedLooters(this->sf_fte_list);
 					int i = 0;
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 					{

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2244,7 +2244,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 			bool is_majority_ds_damage = (float)ds_damage > (float)GetMaxHP() * 0.45f;
 			bool is_majority_killer_dmg = (float)ssf_player_damage > (float)GetMaxHP() * 0.45f;
 
-			if (is_solo_fte_charid)
+			if (is_solo_fte_charid && !is_raid_solo_fte_credit && !is_group_solo_fte_credit)
 			{
 				corpse->AllowPlayerLoot(killer);
 			}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6712,6 +6712,17 @@ bool Client::IsLootLockedOutOfNPC(uint32 npctype_id)
 	return false;
 };
 
+std::string Client::GetSSFLooterName() {
+	std::string appendedCharName = GetCleanName();
+	if (IsSelfFound())
+		appendedCharName += "-SF";
+
+	if (IsSoloOnly())
+		appendedCharName += "-Solo";
+
+	return appendedCharName;
+}
+
 std::vector<int> Client::GetMemmedSpells() {
 	std::vector<int> memmed_spells;
 	for (int index = 0; index < EQ::spells::SPELL_GEM_COUNT; index++) {

--- a/zone/client.h
+++ b/zone/client.h
@@ -350,6 +350,7 @@ public:
 	inline uint8 IsSoloOnly() const { return m_epp.solo_only; }
 	inline uint8 IsSelfFound() const { return m_epp.self_found; }
 	inline uint8 HasBetaBuffGearFlag() const { return m_epp.betabuff_gear_flag; }
+	std::string GetSSFLooterName();
 
 	inline void SetHardcore(uint8 in_hardcore) { m_epp.hardcore = in_hardcore; }
 	inline void SetSoloOnly(uint8 in_solo_only) { m_epp.solo_only = in_solo_only; }

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1078,22 +1078,7 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 	Client* c = entity_list.GetClientByName(playername.c_str());
 	if (c && c->IsSelfFound() || c && c->IsSoloOnly())
 	{
-		auto ssf_looter_name = [](Client* c)
-		{
-			if (c == nullptr)
-				return std::string();
-
-			std::string appendedCharName = c->GetCleanName();
-			if (c->IsSelfFound())
-				appendedCharName += "-SF";
-
-			if (c->IsSoloOnly())
-				appendedCharName += "-Solo";
-
-			return appendedCharName;
-		};
-
-		std::string appendedCharName = ssf_looter_name(c);
+		std::string appendedCharName = c->GetSSFLooterName();
 		auto temporarily_allowed_itr = temporarily_allowed_looters.find(appendedCharName);
 
 		if (temporarily_allowed_itr == temporarily_allowed_looters.end() && c->IsLootLockedOutOfNPC(npctype_id) && npctype_id != 0)
@@ -1112,8 +1097,7 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 		}
 		else
 		{
-			// TODO: Need to check whether player was in fte list
-			if (allowed_looters.find(appendedCharName) == allowed_looters.end())
+			if (allowed_looters.find(appendedCharName) == allowed_looters.end() && initial_allowed_looters.find(appendedCharName) != initial_allowed_looters.end())
 			{
 				Raid* raid = c->GetRaid();
 				if (raid->GetLootType() == 3) // Looter / Raid Leader loot
@@ -1122,9 +1106,9 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 					{
 						for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 						{
-							if (raid->members[x].membername[0])
+							if (raid->members[x].member)
 							{
-								if (allowed_looters.find(ssf_looter_name(raid->members[x].member)) != allowed_looters.end())
+								if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
 								{
 									c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid with another eligible member of the raid.");
 									AllowPlayerLoot(appendedCharName);
@@ -1140,9 +1124,9 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 					{
 						for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 						{
-							if (raid->members[x].membername[0])
+							if (raid->members[x].member)
 							{
-								if (allowed_looters.find(ssf_looter_name(raid->members[x].member)) != allowed_looters.end())
+								if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
 								{
 									c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid and you're a group or raid leader.");
 									AllowPlayerLoot(appendedCharName);
@@ -1156,9 +1140,9 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 				{
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 					{
-						if (raid->members[x].membername[0])
+						if (raid->members[x].member)
 						{
-							if (allowed_looters.find(ssf_looter_name(raid->members[x].member)) != allowed_looters.end())
+							if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
 							{
 								c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid and you're the new raid leader.");
 								AllowPlayerLoot(appendedCharName);
@@ -1171,9 +1155,9 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 				{
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 					{
-						if (raid->members[x].membername[0])
+						if (raid->members[x].member)
 						{
-							if (allowed_looters.find(ssf_looter_name(raid->members[x].member)) != allowed_looters.end())
+							if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
 							{
 								c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid and the loot is set to free-for-all.");
 								AllowPlayerLoot(appendedCharName);

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -952,7 +952,6 @@ bool Corpse::Process() {
 
 	if (corpse_delay_timer.Check()) {
 		allowed_looters.clear();
-		initial_allowed_looters.clear();
 		corpse_delay_timer.Disable();
 		return true;
 	}

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -128,6 +128,7 @@ class Corpse : public Mob {
 	bool    ContainsLegacyItem();
 	void	ProcessLootLockouts(Client* give_exp_client, NPC* in_npc);
 	void	AddPlayerLockout(Client* c);
+	void	SetInitialAllowedLooters(const std::vector<std::string>& in) { initial_allowed_looters = std::unordered_set<std::string>(in.begin(), in.end()); }
 
 
 	inline void	Lock()				{ is_locked = true; }

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -1038,6 +1038,16 @@ void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAd
 				if (kr)
 				{
 					owner->CastToNPC()->solo_raid_fte = kr->GetID();
+					owner->CastToNPC()->sf_fte_list.clear();
+					const uint32 highest_level_in_raid = kr->GetHighestLevel2();
+					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
+					{
+						auto member = kr->members[x].member;
+						if (member && member->IsInLevelRange(highest_level_in_raid))
+						{
+							owner->CastToNPC()->sf_fte_list.emplace_back(member->GetSSFLooterName());
+						}
+					}
 				}
 				else if (kg)
 				{

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -470,6 +470,9 @@ public:
 	uint32 solo_group_fte;
 	uint32 solo_fte_charid;
 
+	// names of first raid members that may be later permitted to loot who aggroed this NPC
+	std::vector<std::string> sf_fte_list;
+
 	bool ValidateFTE();
 
 	std::string GetSpawnedString();


### PR DESCRIPTION
Fixes:
- Player unable to loot if he dies during raid encounter
- Player unable to loot during last 4 minutes during which anyone can loot