### PR TITLE
Sf spell rules

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -656,7 +656,7 @@ bool Mob::DoPreCastingChecks(uint16 spell_id, CastingSlot slot, uint16 spell_tar
 				} 
 				if (spell_target->CastToClient()->IsSelfFound() && spell_target != this)
 				{
-					bool can_get_experience = spell_target->CastToClient()->IsInLevelRange(caster->GetLevel2());
+					bool can_get_experience = spell_target->CastToClient()->IsInLevelRange(caster->GetLevel2()) && caster->IsInLevelRange(spell_target->CastToClient()->GetLevel2());
 					bool compatible = caster->IsSelfFound() == spell_target->CastToClient()->IsSelfFound();
 					if (!compatible)
 					{


### PR DESCRIPTION
- For sf players, check exp level range during pre-casting check i.e. fail spell early
- Make bind affinity and group teleports castable between out of xp level range sf players