### PR TITLE
Fix bug where ssf using ds would get exp but not loot rights

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2241,7 +2241,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 			Raid* raid = entity_list.GetRaidByClient(killer->CastToClient());
 			bool is_raid_solo_fte_credit = raid ? raid->GetID() == CastToNPC()->solo_raid_fte : false;
 			bool is_group_solo_fte_credit = group ? group->GetID() == CastToNPC()->solo_group_fte : false;
-			bool is_majority_ds_damage = (float)ds_damage > (float)GetMaxHP() * 0.45f;
+			bool is_majority_ds_damage = (float)ds_damage - (float)ssf_ds_damage > (float)GetMaxHP() * 0.45f;
 			bool is_majority_killer_dmg = (float)ssf_player_damage > (float)GetMaxHP() * 0.45f;
 
 			if (is_solo_fte_charid && !is_raid_solo_fte_credit && !is_group_solo_fte_credit)


### PR DESCRIPTION
`NPC::Death` and `NPC::CreateCorpse` have slightly different logic for determining whether an sf player gets kill credit, both based on how much damage was done by damage shields. This resulted in situations where a magician chain healing his fire pet would get exp but not loot rights.

This change makes the damage shield check for loot match the damage shield check for exp.

Here is the other damage shield check for exp.
https://github.com/SecretsOTheP/EQMacEmu/blob/54a174ed7191dea7b4c4a420f4f4012fff6e4da5/zone/attack.cpp#L1994