### PR TITLE
Fix self/group spells being interrupted when target is sf player

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -635,7 +635,7 @@ bool Mob::DoPreCastingChecks(uint16 spell_id, CastingSlot slot, uint16 spell_tar
 
 		// Interrupt spell casts that are targetting self found or solo if they're not allowed
 		// Already know caster is a client from the first check in this function
-		if(spell_target && spell_target->IsClient())					
+		if(spell_target && spell_target->IsClient() && spells[spell_id].targettype != ST_Self && !IsGroupSpell(spell_id))
 		{
 			// Only fail if it's beneficial - don't want to fail on detrimental for pvp purposes
 			if(IsBeneficialSpell(spell_id))


### PR DESCRIPTION
Fix for https://discord.com/channels/1133452007412334643/1169044978777989182/1169044978777989182