### PR TITLE
Fix self/group spells being interrupted when target is an immune npc

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -277,7 +277,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	}
 
 	//prevent immune from aggro and spells npcs from being casted on.
-	if (IsClient() && spell_target && spell_target->IsNPC())
+	if (IsClient() && spell_target && spell_target->IsNPC() && spells[spell_id].targettype != ST_Self && !IsGroupSpell(spell_id))
 	{
 		NPC* spell_target_npc = spell_target->CastToNPC();
 		if (spell_target_npc)


### PR DESCRIPTION
Fixes issue where spells like selos or clickies like jboots that are ST_Self are interrupted with a message that the spell cannot affect the target npc.