### PR TITLE
Lich damage mitigation bound by quarm rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -285,6 +285,7 @@ RULE_REAL(Quarm, BonusGroupEXP5MemberOverride, 1.14, "Quarm's custom group EXP b
 RULE_REAL(Quarm, BonusGroupEXP6MemberOverride, 1.20, "Quarm's custom group EXP bonus override for x members. For server events that directly target group bonuses.")
 RULE_REAL(Quarm, BonusGroupEXP7MemberOverride, 1.24, "Quarm's custom group EXP bonus override for x members. For server events that directly target group bonuses.")
 RULE_INT(Quarm, MaxTimeSpentProcessingConns, 100, "")
+RULE_BOOL(Quarm, LichDamageMitigation, false, "Quarm lich hack to make PoP era lich spell data cause the correct live era pvp mitigated damage to self.")
 RULE_CATEGORY_END()
 RULE_CATEGORY( Map )
 //enable these to help prevent mob hopping when they are pathing

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -98,6 +98,18 @@ bool IsSacrificeSpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_Sacrifice);
 }
 
+bool IsLichSpell(uint16 spell_id)
+{
+	if (!IsValidSpell(spell_id))
+		return false;
+
+	// Lich line valid through PoP. This should probably be a hash lookup or dynamic if scaled bigger than quarm PoP.
+	if (spell_id == 641 || spell_id == 642 || spell_id == 643 || spell_id == 644 || spell_id == 1611 || spell_id == 1416 || spell_id == 2114 || spell_id == 3311)
+		return true;
+
+	return false;
+}
+
 bool IsLifetapSpell(uint16 spell_id)
 {
 	if (IsValidSpell(spell_id) && (spells[spell_id].targettype == ST_Tap || spells[spell_id].targettype == ST_TargetAETap))

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -639,6 +639,7 @@ extern int32 SPDAT_RECORDS;
 
 bool IsTargetableAESpell(uint16 spell_id);
 bool IsSacrificeSpell(uint16 spell_id);
+bool IsLichSpell(uint16 spell_id);
 bool IsLifetapSpell(uint16 spell_id);
 bool IsMezSpell(uint16 spell_id);
 int16 GetBaseValue(uint16 spell_id, uint16 effect);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1136,7 +1136,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 				
 				// Reintroduce spell dampening for self, but only for lich spells at the correct value.
 				if (other == this)
-					mitigation = 1f;
+					mitigation = 1.0f;
 					if (RuleB(Quarm, LichDamageMitigation) && IsLichSpell(spell_id))
 						mitigation = 0.68000001f;
 				}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1141,7 +1141,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 					if (RuleB(Quarm, LichDamageMitigation) && IsLichSpell(spell_id))
 					{
 						mitigation = 0.68000001f;
-						Log(Logs::Detail, Logs::Spells, "%s is getting %d lich mitigation for %s in slot %d. Was %d damage", GetName(), mitigation, GetSpellName(spell_id), slot, damage);
+						Log(Logs::Detail, Logs::Spells, "%s is getting %d lich mitigation for %s in slot %d. Was %d damage", GetName(), mitigation, GetSpellName(spell_id), buffslot, damage);
 					}
 				}
 				

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1136,7 +1136,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 				
 				// Reintroduce spell dampening for self, but only for lich spells at the correct value.
 				if (other == this)
-					mitigation = 1;
+					mitigation = 1f;
 					if (RuleB(Quarm, LichDamageMitigation) && IsLichSpell(spell_id))
 						mitigation = 0.68000001f;
 				}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1136,6 +1136,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 				
 				// Reintroduce spell dampening for self, but only for lich spells at the correct value.
 				if (other == this)
+				{
 					mitigation = 1.0f;
 					if (RuleB(Quarm, LichDamageMitigation) && IsLichSpell(spell_id))
 						mitigation = 0.68000001f;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1142,6 +1142,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 					{
 						mitigation = 0.68000001f;
 						Log(Logs::Detail, Logs::Spells, "%s is getting %d lich mitigation for %s in slot %d. Was %d damage", GetName(), mitigation, GetSpellName(spell_id), slot, damage);
+					}
 				}
 				
 				damage = (int32)((double)damage * mitigation);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1093,7 +1093,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 			*/
 
 			// this spell mitigation part is from a client decompile
-			if (IsValidSpell(spell_id) && spells[spell_id].goodEffect == 0)
+			if (IsValidSpell(spell_id) && (spells[spell_id].goodEffect == 0 || IsLichSpell(spell_id)))
 			{
 				int caster_class = other->GetClass();
 				float mitigation;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1141,7 +1141,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 					if (RuleB(Quarm, LichDamageMitigation) && IsLichSpell(spell_id))
 					{
 						mitigation = 0.68000001f;
-						Log(Logs::Detail, Logs::Spells, "%s is getting %d lich mitigation for %s in slot %d. Was %d damage", GetName(), mitigation, GetSpellName(spell_id), buffslot, damage);
+						Log(Logs::Detail, Logs::Spells, "%s is getting %.2f lich mitigation for %s in slot %d. Was %d damage", GetName(), mitigation, GetSpellName(spell_id), buffslot, damage);
 					}
 				}
 				

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1139,7 +1139,9 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 				{
 					mitigation = 1.0f;
 					if (RuleB(Quarm, LichDamageMitigation) && IsLichSpell(spell_id))
+					{
 						mitigation = 0.68000001f;
+						Log(Logs::Detail, Logs::Spells, "%s is getting %d lich mitigation for %s in slot %d. Was %d damage", GetName(), mitigation, GetSpellName(spell_id), slot, damage);
 				}
 				
 				damage = (int32)((double)damage * mitigation);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1075,7 +1075,7 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 
 	// Reduce PVP damage. Don't do PvP mitigation if the caster is damaging themself or it's from a DS.
 	bool FromDamageShield = (attack_skill == EQ::skills::SkillAbjuration);
-	if (!FromDamageShield && other && other->IsClient() && (other != this) && damage > 0)
+	if (!FromDamageShield && other && other->IsClient() && damage > 0)
 	{
 		if (spell_id != SPELL_UNKNOWN)
 		{
@@ -1133,6 +1133,14 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 						mitigation = 0.63f;
 					}
 				}
+				
+				// Reintroduce spell dampening for self, but only for lich spells at the correct value.
+				if (other == this)
+					mitigation = 1;
+					if (RuleB(Quarm, LichDamageMitigation) && IsLichSpell(spell_id))
+						mitigation = 0.68000001f;
+				}
+				
 				damage = (int32)((double)damage * mitigation);
 				if (damage < 1)
 				{


### PR DESCRIPTION
Lich damage mitigation bound by quarm rule to fix live damage discrepancy.

Tested on my dev world against current origin/main base.

Set Quarm:LichDamageMitigation to true to enable it.