### PR TITLE
Persistent Self-Found Item ownership & feature pack. Allow/enforce SF rules on Charm Pet Items / Item Muling / Vendoring / etc

### DIFF
--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -1253,3 +1253,31 @@ int16 EQ::InventoryProfile::_HasItemByUse(ItemInstQueue& iqueue, uint8 use, uint
 
 	return INVALID_INDEX;
 }
+
+void EQ::InventoryProfile::RepairMissingSelfFoundCharacter(uint32 self_found_character_id, const std::string& character_name)
+{
+	for (auto& kv : m_worn) {
+		if (kv.second) {
+			kv.second->SetSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+	for (auto& kv : m_inv) {
+		if (kv.second) {
+			kv.second->SetSelfFoundCharacter(self_found_character_id, character_name);
+			kv.second->SetContentsSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+	for (auto& kv : m_bank) {
+		if (kv.second) {
+			kv.second->SetSelfFoundCharacter(self_found_character_id, character_name);
+			kv.second->SetContentsSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+	for (auto iter = m_cursor.cbegin(); iter != m_cursor.cend(); ++iter) {
+		EQ::ItemInstance* inst = *iter;
+		if (inst != nullptr) {
+			inst->SetSelfFoundCharacter(self_found_character_id, character_name);
+			inst->SetContentsSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+}

--- a/common/inventory_profile.h
+++ b/common/inventory_profile.h
@@ -170,6 +170,9 @@ namespace EQ
 		void SetCustomItemData(uint32 character_id, int16 slot_id, std::string identifier, float value);
 		void SetCustomItemData(uint32 character_id, int16 slot_id, std::string identifier, bool value);
 		std::string GetCustomItemData(int16 slot_id, std::string identifier);
+
+		void RepairMissingSelfFoundCharacter(uint32 self_found_character_id, const std::string& character_name);
+
 	protected:
 		///////////////////////////////
 		// Protected Methods

--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -52,7 +52,7 @@ static inline int32 GetNextItemInstSerialNumber() {
 //
 // class EQ::ItemInstance
 //
-EQ::ItemInstance::ItemInstance(const EQ::ItemData* item, int8 charges) {
+EQ::ItemInstance::ItemInstance(const EQ::ItemData* item, int8 charges, const EQ::ItemCustomData& item_custom_data) {
 	if(item) {
 		m_item = new EQ::ItemData(*item);
 	}
@@ -64,9 +64,10 @@ EQ::ItemInstance::ItemInstance(const EQ::ItemData* item, int8 charges) {
 	}
 
 	m_SerialNumber = GetNextItemInstSerialNumber();
+	m_custom_data = item_custom_data; // map copy
 }
 
-EQ::ItemInstance::ItemInstance(SharedDatabase *db, int16 item_id, int8 charges) {
+EQ::ItemInstance::ItemInstance(SharedDatabase *db, int16 item_id, int8 charges, const EQ::ItemCustomData& item_custom_data) {
 
 	m_item = db->GetItem(item_id);
 	if(m_item) {
@@ -83,6 +84,7 @@ EQ::ItemInstance::ItemInstance(SharedDatabase *db, int16 item_id, int8 charges) 
 	}
 
 	m_SerialNumber = GetNextItemInstSerialNumber();
+	m_custom_data = item_custom_data; // map copy
 }
 
 EQ::ItemInstance::ItemInstance(ItemInstTypes use_type) {
@@ -120,11 +122,6 @@ EQ::ItemInstance::ItemInstance(const ItemInstance& copy)
 			m_contents[it->first] = inst_new;
 		}
 	}
-	std::map<std::string, std::string>::const_iterator iter;
-	for (iter = copy.m_custom_data.begin(); iter != copy.m_custom_data.end(); ++iter) {
-		m_custom_data[iter->first] = iter->second;
-	}
-
 	m_SerialNumber	= copy.m_SerialNumber;
 	m_custom_data	= copy.m_custom_data;
 	m_timers		= copy.m_timers;
@@ -411,27 +408,12 @@ const EQ::ItemData* EQ::ItemInstance::GetItem() const
 	return m_item;
 }
 
-std::string EQ::ItemInstance::GetCustomDataString() const {
-	std::string ret_val;
-	auto iter = m_custom_data.begin();
-	while (iter != m_custom_data.end()) {
-		if (ret_val.length() > 0) {
-			ret_val += "^";
-		}
-		ret_val += iter->first;
-		ret_val += "^";
-		ret_val += iter->second;
-		++iter;
-
-		if (ret_val.length() > 0) {
-			ret_val += "^";
-		}
-	}
-	return ret_val;
+std::string EQ::ItemInstance::GetCustomDataString(bool include_transient_keys) const {
+	return SharedDatabase::EncodeCustomDataToString(m_custom_data, include_transient_keys);
 }
 
 std::string EQ::ItemInstance::GetCustomData(std::string identifier) {
-	std::map<std::string, std::string>::const_iterator iter = m_custom_data.find(identifier);
+	auto iter = m_custom_data.find(identifier);
 	if (iter != m_custom_data.end()) {
 		return iter->second;
 	}
@@ -470,6 +452,130 @@ void EQ::ItemInstance::DeleteCustomData(std::string identifier) {
 	if (iter != m_custom_data.end()) {
 		m_custom_data.erase(iter);
 	}
+}
+
+void EQ::ItemInstance::GetName(char* buf, size_t buf_len) const
+{
+	if (!m_item || buf_len < sizeof(m_item->Name)) {
+		buf[0] = 0;
+		return;
+	}
+
+	if (RuleB(SelfFound, PersonalizedItemNames))
+	{
+		const std::string* sf_name = GetSelfFoundCharacterName();
+		if (sf_name && !sf_name->empty()) {
+			const std::string format = RuleS(SelfFound, PersonalizedItemNameFormat);
+			int len = snprintf(buf, buf_len, format.c_str(), sf_name->c_str(), m_item->Name);
+			if (len < buf_len) {
+				return; // success
+			}
+			// personalized name was too long, fall-through to sending regular item name
+		}
+	}
+
+	memcpy(buf, m_item->Name, sizeof(m_item->Name));
+}
+
+bool EQ::ItemInstance::HasSelfFoundCharacterID() const
+{
+	return m_custom_data.find(CUSTOM_DATA_SELF_FOUND_CHARACTER_ID) != m_custom_data.end();
+}
+
+uint32 EQ::ItemInstance::GetSelfFoundCharacterID(const EQ::ItemCustomData& custom_data)
+{
+	auto iter = custom_data.find(CUSTOM_DATA_SELF_FOUND_CHARACTER_ID);
+	if (iter != custom_data.end()) {
+		return static_cast<uint32>(stoul(iter->second));
+	}
+	return 0;
+}
+
+const std::string* EQ::ItemInstance::GetSelfFoundCharacterName() const
+{
+	auto iter = m_custom_data.find(CUSTOM_DATA_CACHED_SELF_FOUND_CHARACTER_NAME);
+	if (iter != m_custom_data.end()) {
+		return &iter->second;
+	}
+	return nullptr;
+}
+
+size_t EQ::ItemInstance::GetSelfFoundCharacterName(char* out) const
+{
+	auto iter = m_custom_data.find(CUSTOM_DATA_CACHED_SELF_FOUND_CHARACTER_NAME);
+	if (iter != m_custom_data.end()) {
+		strcpy(out, iter->second.c_str());
+		return iter->second.size();
+	}
+	return 0;
+}
+
+void EQ::ItemInstance::SetSelfFoundCharacter(const EQ::ItemData* item_data, EQ::ItemCustomData& custom_data, uint32 self_found_character_id, const char* name)
+{
+	if (item_data && self_found_character_id && !item_data->Stackable)
+	{
+		// Don't overwrite if already set
+		if (custom_data.find(CUSTOM_DATA_SELF_FOUND_CHARACTER_ID) == custom_data.end()) {
+			std::stringstream ss;
+			ss << self_found_character_id;
+			custom_data[CUSTOM_DATA_SELF_FOUND_CHARACTER_ID] = ss.str();
+			if (name && RuleB(SelfFound, PersonalizedItemNames)) {
+				std::string name_str = name;
+				custom_data[CUSTOM_DATA_CACHED_SELF_FOUND_CHARACTER_NAME] = name_str;
+			}
+		}
+	}
+}
+
+void EQ::ItemInstance::SetSelfFoundCharacter(const EQ::ItemData* item_data, EQ::ItemCustomData& custom_data, uint32 self_found_character_id, const std::string& name)
+{
+	if (item_data && self_found_character_id && !item_data->Stackable)
+	{
+		// Don't overwrite if already set
+		if (custom_data.find(CUSTOM_DATA_SELF_FOUND_CHARACTER_ID) == custom_data.end()) {
+			std::stringstream ss;
+			ss << self_found_character_id;
+			custom_data[CUSTOM_DATA_SELF_FOUND_CHARACTER_ID] = ss.str();
+			if (RuleB(SelfFound, PersonalizedItemNames)) {
+				custom_data[CUSTOM_DATA_CACHED_SELF_FOUND_CHARACTER_NAME] = name;
+			}
+		}
+	}
+}
+
+void EQ::ItemInstance::SetContentsSelfFoundCharacter(uint32 self_found_character_id, const std::string& name)
+{
+	if (self_found_character_id && m_item && IsClassBag())
+	{
+		for (auto it = m_contents.begin(); it != m_contents.end(); ++it) {
+			ItemInstance* inst = it->second;
+			if (inst)
+				inst->SetSelfFoundCharacter(self_found_character_id, name);
+		}
+	}
+}
+
+bool EQ::ItemInstance::IsMatchingSelfFoundCharacterID(uint32 self_found_character_id, bool check_all_bag_contents) const
+{
+	if (!self_found_character_id)
+		return false;
+
+	// We don't track self-found stackables
+	if (IsStackable())
+		return false;
+
+	// Check that all bag contents are also self found
+	if (check_all_bag_contents && IsClassBag())
+	{
+		for (auto it = m_contents.begin(); it != m_contents.end(); ++it) {
+			ItemInstance* inst = it->second;
+			if (inst && !inst->IsMatchingSelfFoundCharacterID(self_found_character_id, false)) {
+				return false;
+			}
+		}
+	}
+
+	return GetSelfFoundCharacterID() == self_found_character_id;
 }
 
 // Clone a type of EQ::ItemInstance object

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -33,6 +33,7 @@ class ItemParse;			// Parses item packets
 
 #include <list>
 #include <map>
+#include <unordered_map>
 
 
 // Specifies usage type for item inside EQ::ItemInstance
@@ -51,6 +52,9 @@ typedef enum {
 
 class SharedDatabase;
 
+const std::string CUSTOM_DATA_SELF_FOUND_CHARACTER_ID = "SFCID";
+const std::string CUSTOM_DATA_CACHED_SELF_FOUND_CHARACTER_NAME = "#SFN"; // not saved to DB
+
 // ########################################
 // Class: EQ::ItemInstance
 //	Base class for an instance of an item
@@ -60,6 +64,9 @@ namespace EQ
 {
 	class InventoryProfile;
 
+	typedef std::unordered_map<std::string, std::string> ItemCustomData;
+	const ItemCustomData EmptyItemCustomData;
+
 	class ItemInstance
 	{
 	public:
@@ -68,9 +75,9 @@ namespace EQ
 		/////////////////////////
 
 		// Constructors/Destructor
-		ItemInstance(const EQ::ItemData* item = nullptr, int8 charges = 0);
+		ItemInstance(const EQ::ItemData* item = nullptr, int8 charges = 0, const ItemCustomData& custom_data = EmptyItemCustomData);
 
-		ItemInstance(SharedDatabase* db, int16 item_id, int8 charges = 0);
+		ItemInstance(SharedDatabase* db, int16 item_id, int8 charges = 0, const ItemCustomData& custom_data = EmptyItemCustomData);
 
 		ItemInstance(ItemInstTypes use_type);
 
@@ -142,13 +149,49 @@ namespace EQ
 		bool IsOnCursorQueue() const { return m_cursorqueue; }
 		void SetCursorQueue(bool val) { m_cursorqueue = val; }
 
-		std::string GetCustomDataString() const;
+		ItemCustomData& GetCustomData() { return m_custom_data; }
+		const ItemCustomData& GetCustomData() const { return m_custom_data; }
+		std::string GetCustomDataString(bool include_transient_keys) const;
 		std::string GetCustomData(std::string identifier);
 		void SetCustomData(std::string identifier, std::string value);
 		void SetCustomData(std::string identifier, int value);
 		void SetCustomData(std::string identifier, float value);
 		void SetCustomData(std::string identifier, bool value);
 		void DeleteCustomData(std::string identifier);
+
+		void GetName(char* buf, size_t buf_len) const; // Automatically applies rule SelfFound:PersonalizedItemNames
+
+		// Did a SF character originally acquire this item.
+		bool HasSelfFoundCharacterID() const;
+
+		// Get the SF Character ID that originally found this time.
+		static uint32 GetSelfFoundCharacterID(const ItemCustomData& custom_data);
+
+		// Get the SF Character ID that originally found this time.
+		uint32 GetSelfFoundCharacterID() const { return GetSelfFoundCharacterID(m_custom_data); }
+
+		// returns a pointer to their name string, or null if unknown
+		const std::string* GetSelfFoundCharacterName() const;
+
+		// Copies their self found name to the target buffer, if known
+		size_t GetSelfFoundCharacterName(char* out) const;
+
+		// Marks the SF character ID that found this item. Only updates if not already set. Setting 0 will not clear this field.
+		static void SetSelfFoundCharacter(const EQ::ItemData* item_data, EQ::ItemCustomData& custom_data, uint32 self_found_character_id, const char* name);
+		// Marks the SF character ID that found this item. Only updates if not already set. Setting 0 will not clear this field.
+		static void SetSelfFoundCharacter(const EQ::ItemData* item_data, EQ::ItemCustomData& custom_data, uint32 self_found_character_id, const std::string& name);
+
+		// Marks the SF character ID that found this item. Only updates if not already set. Setting 0 will not clear this field.
+		void SetSelfFoundCharacter(uint32 self_found_character_id, const char* name) { SetSelfFoundCharacter(m_item, m_custom_data, self_found_character_id, name); }
+		// Marks the SF character ID that found this item. Only updates if not already set. Setting 0 will not clear this field.
+		void SetSelfFoundCharacter(uint32 self_found_character_id, const std::string& name) { SetSelfFoundCharacter(m_item, m_custom_data, self_found_character_id, name); }
+
+		// Marks the SF character ID to all contents in this bag. Only updates if not already set.
+		// Setting 0 will not clear this field.
+		void SetContentsSelfFoundCharacter(uint32 self_found_character_id, const std::string& name);
+
+		// Is this item (and its contents, if a bag) all tags with this SF character id.
+		bool IsMatchingSelfFoundCharacterID(uint32 self_found_character_id, bool check_all_bag_contents) const;
 
 		// Allows treatment of this object as though it were a pointer to m_item
 		operator bool() const { return (m_item != nullptr); }
@@ -202,7 +245,7 @@ namespace EQ
 		//
 		// Items inside of this item (augs or contents);
 		std::map<uint8, ItemInstance*>			m_contents; // Zero-based index: min=0, max=9
-		std::map<std::string, std::string>	m_custom_data;
+		ItemCustomData				m_custom_data;
 		std::map<std::string, Timer>		m_timers;
 	};
 }

--- a/common/loot.h
+++ b/common/loot.h
@@ -3,7 +3,10 @@
 
 #include <list>
 #include <string>
+#include <memory>
+#include <unordered_map>
 #include "types.h"
+#include "item_instance.h"
 
 struct LootItem {
 	uint32	item_id;	  // uint32	item_id;
@@ -17,8 +20,30 @@ struct LootItem {
 	bool	forced;
 	uint8	min_looter_level;
 	uint32	item_loot_lockout_timer;
+	EQ::ItemCustomData custom_data;
+
+	LootItem()
+	{
+		item_id = 0;
+		equip_slot = 0;
+		charges = 0;
+		lootslot = 0;
+		min_level = 0;
+		max_level = 0;
+		quest = 0;
+		pet = 0;
+		forced = false;
+		min_looter_level = 0;
+		item_loot_lockout_timer = 0;
+	}
+
+	uint32 GetSelfFoundCharacterID() const { return EQ::ItemInstance::GetSelfFoundCharacterID(custom_data); }
+
 };
 
-typedef std::list<LootItem* > LootItems;
+typedef std::list<std::shared_ptr<LootItem>> LootItems;
+typedef std::unordered_map<int, std::shared_ptr<LootItem>> BagLootItems; // k = 0..9
+
+const BagLootItems EmptyBagLootItems;
 
 #endif

--- a/common/patches/mac.cpp
+++ b/common/patches/mac.cpp
@@ -923,7 +923,7 @@ namespace Mac {
 		}
   
 			mac_pop_item->ItemClass = item->ItemClass;
-			strcpy(mac_pop_item->Name,item->Name);
+			inst->GetName(mac_pop_item->Name, sizeof(mac_pop_item->Name)); // delegating to ItemInstance to support custom item names
 			strcpy(mac_pop_item->Lore,item->Lore);       
 			strcpy(mac_pop_item->IDFile,item->IDFile);  
 			mac_pop_item->Weight = item->Weight;      

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -314,6 +314,17 @@ RULE_INT(Quarm, RebirthTitleLevel, 50, "The minimum level before we add a title 
 RULE_BOOL(Quarm, DruidEpicAppliesEnsnare, true, "")
 RULE_BOOL(Quarm, PreNerfSneakHide, true, "This should be false during Luclin.")
 RULE_CATEGORY_END()
+
+RULE_CATEGORY( SelfFound )
+RULE_BOOL(SelfFound, IdentifyOwner, true, "Casting identify on a self-found item will send a message showing who it belongs to.")
+RULE_BOOL(SelfFound, PetLootSupport, true, "Allow solo/self-found players to loot their own SF items back from pet/npc corpses. This allows SF players to recover their items they gave to charmed pets.")
+RULE_BOOL(SelfFound, ItemMulingSupport, true, "Allow solo/self-found players to pickup their own SF items off the ground. This allows muling of SF items onto alts, and the alt can drop the item back later.")
+RULE_BOOL(SelfFound, TempMerchantSupport, true, "Allow solo/self-found players to repurchase their own SF Items sold to Merchant temp inventory, up to the amount of SF items sold that belonged to them. This allows SF players to vendor recharge their own items. Also makes temp inventory visible, but will get an error message if trying purchase items they are not permitted to buy.")
+RULE_BOOL(SelfFound, TempMerchantFiltering, false, "Make solo/self-found players only see merchant temp inventory for their own purchasable items, hiding the rest. If disabled, they can see the whole temp inventory, but can still only purchase their valid SF items back.")
+RULE_BOOL(SelfFound, PersonalizedItemNames, true, "Makes self-found items easily distinguishable by seeing the owner's name prefixed on their self-found items. Helps players intuitively understad which items are officially supported for self-found features like muling, charm petting, recharging, etc. It's also really cool. Character names are cached in the item instance (not saved to DB). Generally requires a logout/login/zone to start showing up if players were online while this was enabled.")
+RULE_STRING(SelfFound, PersonalizedItemNameFormat, "%1$s`s %2$s", "The format for personalized item names. Default: Soando`s Short Sword. Arg1=CharacterName, Arg2=ItemName.")
+RULE_CATEGORY_END()
+
 RULE_CATEGORY( Map )
 //enable these to help prevent mob hopping when they are pathing
 RULE_BOOL ( Map, FixPathingZWhenLoading, true, "increases zone boot times a bit to reduce hopping.")

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -68,9 +68,15 @@ public:
 	/*
 	* Item Methods
 	*/
-	EQ::ItemInstance* CreateItem(uint32 item_id, int8 charges=0);
-	EQ::ItemInstance* CreateItem(const EQ::ItemData* item, int8 charges=0);
-	EQ::ItemInstance* CreateBaseItem(const EQ::ItemData* item, int8 charges=0);
+	EQ::ItemInstance* CreateItem(uint32 item_id, int8 charges=0, const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData);
+	EQ::ItemInstance* CreateItem(const EQ::ItemData* item, int8 charges=0, const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData);
+	EQ::ItemInstance* CreateBaseItem(const EQ::ItemData* item, int8 charges=0, const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData);
+
+	static std::string EncodeCustomDataToString(const EQ::ItemCustomData& item_custom_data, bool include_transient_key);
+	// Parses custom_data from an existing custom_data string. Use InitializeCustomDataFromString instead if loading from the DB.
+	static void ParseCustomDataFromString(EQ::ItemCustomData& dst, const char* src);
+	// Initializes custom_data from a database column.
+	void InitializeCustomDataFromString(EQ::ItemCustomData& dst, const char* src);
 
 		// Web Token Verification
 		bool VerifyToken(std::string token, int& status);

--- a/utils/sql/git/required/2024_11_29_item_custom_data_propagation.sql
+++ b/utils/sql/git/required/2024_11_29_item_custom_data_propagation.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `character_corpse_items`
+ADD COLUMN `custom_data` TEXT DEFAULT NULL AFTER `charges`;
+
+ALTER TABLE `character_corpse_items_backup`
+ADD COLUMN `custom_data` TEXT DEFAULT NULL AFTER `charges`;
+
+ALTER TABLE `object`
+ADD COLUMN `custom_data` TEXT DEFAULT NULL AFTER `charges`;
+
+ALTER TABLE `object_contents`
+ADD COLUMN `custom_data` TEXT DEFAULT NULL AFTER `charges`;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2070,6 +2070,7 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 		if (IsNPC() && ismerchant && RuleB(Merchant, ClearTempList)) {
 			database.DeleteMerchantTempList(GetNPCTypeID());
 			zone->tmpmerchanttable[GetNPCTypeID()].clear();
+			zone->tmpmerchanttable_ssf_purchase_limits[GetNPCTypeID()].clear();
 		}
 	}
 	else

--- a/zone/client.h
+++ b/zone/client.h
@@ -792,9 +792,9 @@ public:
 	bool	SwapItem(MoveItem_Struct* move_in);
 	void	SwapItemResync(MoveItem_Struct* move_slots);
 	void	QSSwapItemAuditor(MoveItem_Struct* move_in, bool postaction_call = false);
-	void	PutLootInInventory(int16 slot_id, const EQ::ItemInstance &inst, LootItem** bag_item_data = 0);
-	bool	AutoPutLootInInventory(EQ::ItemInstance& inst, bool try_worn = false, bool try_cursor = true, LootItem** bag_item_data = 0);
-	bool	SummonItem(uint32 item_id, int8 quantity = -1, uint16 to_slot = EQ::invslot::slotCursor, bool force_charges = false);
+	void	PutLootInInventory(int16 slot_id, const EQ::ItemInstance &inst, const BagLootItems& bag_item_data = EmptyBagLootItems);
+	bool	AutoPutLootInInventory(EQ::ItemInstance& inst, bool try_worn = false, bool try_cursor = true, const BagLootItems& bag_item_data = EmptyBagLootItems);
+	bool	SummonItem(uint32 item_id, int8 quantity = -1, uint16 to_slot = EQ::invslot::slotCursor, bool force_charges = false, const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData);
 	void	DropItem(int16 slot_id);
 	void	SendLootItemInPacket(const EQ::ItemInstance* inst, int16 slot_id);
 	void	SendItemPacket(int16 slot_id, const EQ::ItemInstance* inst, ItemPacketType packet_type, int16 fromid = 0, int16 toid = 0, int16 skill = 0);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1219,6 +1219,14 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		RemoveNoRent(false);
 	}
 
+	if (m_epp.solo_only || m_epp.self_found) {
+		if (loaditems) {
+			std::string name = m_pp.name;
+			// Any owned items should be stamped with the cid if it's missing
+			m_inv.RepairMissingSelfFoundCharacter(cid, name);
+		}
+	}
+
 	if (m_pp.platinum_cursor > 0 || m_pp.silver_cursor > 0 || m_pp.gold_cursor > 0 || m_pp.copper_cursor > 0) {
 		bool changed = false;
 		uint64 new_coin = 0;
@@ -2992,15 +3000,18 @@ void Client::Handle_OP_ClickObject(const EQApplicationPacket *app)
 			}
 			else if ((IsSelfFound() || IsSoloOnly()))
 			{
-				// If the client is self found or solo, don't allow them to pick up the item, unless they are the one that dropped it
-				// Also make sure they dropped it while SSF
-				if(object->GetCharacterDropperID() != this->CharacterID())
+				// If the client is self found or solo, don't allow them to pick up the item, unless either:
+				// - They are the one that dropped it and they dropped it while SSF.
+				// - They are the original owner of the item, and it was re-dropped by another character/mule back to them.
+				if (object->GetCharacterDropperID() == this->CharacterID())
 				{
-					msg = "You cannot pick up dropped items because you are performing a self found or solo challenge.";
+					if (!object->IsSSFRuleSet()) {
+						msg = "You cannot pick up dropped items from yourself before you accepted the challenge.";
+					}
 				}
-				else if(!object->IsSSFRuleSet())
+				else if (!RuleB(SelfFound, ItemMulingSupport) || !object->IsMatchingSelfFoundCharacterID(this->CharacterID()))
 				{
-					msg = "You cannot pick up dropped items from yourself before you accepted the challenge.";
+					msg = "You cannot pick up someone else's dropped items because you are performing a self found or solo challenge.";
 				}
 				// The else case does not set a msg because they are allowed to pick it up if they dropped it
 			}
@@ -7977,6 +7988,7 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 
 	int merchantid;
 	bool tmpmer_used = false;
+	bool sf_tmpmer_used = false;
 	bool reimbursement_used = false;
 
 	Mob* tmp = entity_list.GetMob(mp->npcid);
@@ -8072,7 +8084,7 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 			}
 		}
 
-		if (!IsSoloOnly() && !IsSelfFound())
+		if ((!IsSoloOnly() && !IsSelfFound()) || RuleB(SelfFound, TempMerchantSupport))
 		{
 			if (item_id == 0)
 			{
@@ -8086,6 +8098,22 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 						item_id = ml.item;
 						tmpmer_used = true;
 						prevcharges = ml.charges;
+						if (IsSoloOnly() || IsSelfFound())
+						{
+							sf_tmpmer_used = true;
+							uint32 purchase_limit = zone->GetSelfFoundPurchaseLimit(tmp->GetNPCTypeID(), item_id, CharacterID());
+							if (purchase_limit <= 0)
+							{
+								Log(Logs::Detail, Logs::Trading, "[S/SF] TEMP: Blocked %s (%i) attempt to purchase item=%i slot=%i that had charges/qty %i/%i",
+									name, CharacterID(), ml.item, ml.slot, ml.charges, ml.quantity);
+								Message(Chat::Red, "You may only repurchase items that belonged to you from merchants. Try selling a copy of this item first.");
+								QueuePacket(returnapp);
+								safe_delete(returnapp);
+								return;
+							}
+							Log(Logs::Detail, Logs::Trading, "[S/SF] TEMP: Allowing %s (%i) attempt to purchase item=%i slot=%i that had charges/qty %i/%i with SF Buy Limit: %i",
+								name, CharacterID(), ml.item, ml.slot, ml.charges, ml.quantity, purchase_limit);
+						}
 						break;
 					}
 				}
@@ -8148,6 +8176,8 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 	// Temp / reimbursement merchantlist
 	if (reimbursement_used)
 		tmp_qty = prevcharges > 240 ? 240 : prevcharges;
+	else if (sf_tmpmer_used)
+		tmp_qty = prevcharges > 0 ? 1 : 0; // we only support non-stackable SSF items, so qty more than 1 is not needed.
 	else if(tmpmer_used)
 		tmp_qty = prevcharges > 240 ? 240 : prevcharges;
 	// Regular merchantlist with limited supplies
@@ -8200,6 +8230,10 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 	int16 freeslotid = INVALID_INDEX;
 
 	EQ::ItemInstance* inst = database.CreateItem(item, quantity);
+	if (inst && (IsSoloOnly() || IsSelfFound()))
+	{
+		inst->SetSelfFoundCharacter(CharacterID(), name); // purchasing the item, they will own it
+	}
 
 	int SinglePrice = 0;
 	float price_mod = CalcPriceMod(tmp);
@@ -8293,6 +8327,12 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 			new_charges = prevcharges - mp->quantity;
 			zone->SaveReimbursementItem(item_reimbursement_list, character_id, item_id, new_charges);
 		}
+		else if (sf_tmpmer_used)
+		{
+			new_charges = prevcharges - mp->quantity;
+			Log(Logs::Detail, Logs::Trading, "[S/SF] TEMP: %s (%i) successfully purchased %i count of item %i.", this->name, CharacterID(), mpo->quantity, item_id);
+			zone->SaveTempItem(merchantid, tmp->GetNPCTypeID(), item_id, new_charges, false, CharacterID());
+		}
 		else if(tmpmer_used)
 		{
 			new_charges = prevcharges - mp->quantity;
@@ -8316,6 +8356,13 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 		}
 		else 
 		{
+			if (RuleB(SelfFound, TempMerchantSupport) && RuleB(SelfFound, TempMerchantFiltering)) {
+				// The item isn't fully out of stock, but it could be for SF characters
+				// Hide it from those who cannot buy any quantity
+				if (tmpmer_used && !reimbursement_used && !inst->IsStackable()) {
+					entity_list.SendDeletedSelfFoundMerchantInventory(tmp, mp->itemslot, item_id);
+				}
+			}
 			inst->SetCharges(new_charges);
 			inst->SetPrice(SinglePrice);
 			inst->SetMerchantSlot(mp->itemslot);
@@ -8488,7 +8535,8 @@ void Client::Handle_OP_ShopPlayerSell(const EQApplicationPacket *app)
 
 	int charges = mp->quantity;
 	int freeslot = 0;
-	if (charges >= 0 && (freeslot = zone->SaveTempItem(vendor->CastToNPC()->MerchantType, vendor->GetNPCTypeID(), itemid, charges, true)) > 0)
+	uint32 self_found_character_id = inst->GetSelfFoundCharacterID();
+	if (charges >= 0 && (freeslot = zone->SaveTempItem(vendor->CastToNPC()->MerchantType, vendor->GetNPCTypeID(), itemid, charges, true, self_found_character_id)) > 0)
 	{
 		EQ::ItemInstance* inst2 = inst->Clone();
 		float merchant_mod = CalcPriceMod(vendor);

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -996,7 +996,7 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid)
 			merlist.push_back(ml);
 			++i;
 		}
-		if (!IsSoloOnly() && !IsSelfFound())
+		if ((!IsSoloOnly() && !IsSelfFound()) || RuleB(SelfFound, TempMerchantSupport))
 		{
 			std::list<TempMerchantList> origtmp_merlist = zone->tmpmerchanttable[npcid];
 			tmp_merlist.clear();
@@ -1018,14 +1018,29 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid)
 						inst->SetMerchantCount(capped_charges);
 						inst->SetCharges(charges);
 
-						if (inst)
+						bool can_see_item = true;
+						if (IsSoloOnly() || IsSelfFound())
+						{
+							bool can_purchase = zone->GetSelfFoundPurchaseLimit(npcid, item->ID, CharacterID()) > 0;
+							if (RuleB(SelfFound, PersonalizedItemNames) && can_purchase) {
+								inst->SetSelfFoundCharacter(CharacterID(), name); // Shows personalized item name in temp merchant's buyback window
+							}
+							if (RuleB(SelfFound, TempMerchantFiltering)) {
+								can_see_item = can_purchase; // Won't display items unless they can purchase them
+							}
+						}
+						if (can_see_item)
 						{
 							std::string packet = inst->Serialize(ml.slot - 1);
 							ser_items[m] = packet;
 							size += packet.length();
 							m++;
+							Log(Logs::Detail, Logs::Trading, "TEMP (%d): %s was added to merchant in slot %d with %d count and %d charges and price %d", i, item->Name, ml.slot, capped_charges, charges, inst->GetPrice());
 						}
-						Log(Logs::Detail, Logs::Trading, "TEMP (%d): %s was added to merchant in slot %d with %d count and %d charges and price %d", i, item->Name, ml.slot, capped_charges, charges, inst->GetPrice());
+						else
+						{
+							safe_delete(inst);
+						}
 					}
 				}
 				tmp_merlist.push_back(ml);

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -91,12 +91,13 @@ class Corpse : public Mob {
 
 	/* Corpse: Items */
 	uint32 GetWornItem(int16 equipSlot) const;
-	LootItem* GetItem(uint16 lootslot, LootItem** bag_item_data = 0); 
+	LootItem* GetItem(uint16 lootslot);
+	LootItem* GetItem(uint16 lootslot, BagLootItems& bag_item_data);
 	void SetPlayerKillItemID(int32 pk_item_id) { player_kill_item = pk_item_id; }
 	int32 GetPlayerKillItem() { return player_kill_item; } 
 	void RemoveItem(uint16 lootslot);
 	void RemoveItem(LootItem* item_data);
-	void AddItem(uint32 itemnum, int8 charges, int16 slot = 0);
+	void AddItem(uint32 itemnum, int8 charges, int16 slot = 0, const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData);
 	
 	/* Corpse: Coin */
 	void SetCash(uint32 in_copper, uint32 in_silver, uint32 in_gold, uint32 in_platinum);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4871,6 +4871,29 @@ void EntityList::SendTraderUpdateMessage(Client* merchant, const EQ::ItemData* i
 	return;
 }
 
+void EntityList::SendDeletedSelfFoundMerchantInventory(Mob* merchant, int32 slotid, uint32 itemid)
+{
+	if (!merchant || !merchant->IsNPC())
+		return;
+
+	for(auto it = client_list.begin(); it != client_list.end(); ++it)
+	{
+		Client* c = it->second;
+		if (c && (c->IsSoloOnly() || c->IsSelfFound()) && c->GetMerchantSession() == merchant->GetID())
+		{
+			if (zone->GetSelfFoundPurchaseLimit(merchant->GetNPCTypeID(), itemid, c->CharacterID()) == 0) {
+				auto delitempacket = new EQApplicationPacket(OP_ShopDelItem, sizeof(Merchant_DelItem_Struct));
+				Merchant_DelItem_Struct* delitem = (Merchant_DelItem_Struct*)delitempacket->pBuffer;
+				delitem->itemslot = slotid;
+				delitem->npcid = merchant->GetID();
+				delitem->playerid = c->GetID();
+				delitempacket->priority = 6;
+				c->QueuePacket(delitempacket);
+				safe_delete(delitempacket);
+			}
+		}
+	}
+}
 
 void EntityList::SendMerchantInventory(Mob* merchant, int32 slotid, bool isdelete)
 {

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -447,6 +447,7 @@ public:
 	uint8 GetClientCountByBoatNPCID(uint32 boatid);
 	uint8 GetClientCountByBoatID(uint32 entityid);
 	void SendMerchantEnd(Mob* merchant);
+	void SendDeletedSelfFoundMerchantInventory(Mob* merchant, int32 slotid, uint32 itemid);
 	void SendMerchantInventory(Mob* merchant, int32 slotid = -1, bool isdelete = false);
 	void SendTraderEnd(Client* merchant);
 	bool TraderHasCustomer(Client* merchant);

--- a/zone/gm_commands/viewzoneloot.cpp
+++ b/zone/gm_commands/viewzoneloot.cpp
@@ -50,7 +50,7 @@ void command_viewzoneloot(Client* c, const Seperator* sep)
 			if (search_item_id == 0 || current_item->item_id == search_item_id) {
 				EQ::SayLinkEngine linker;
 				linker.SetLinkType(EQ::saylink::SayLinkLootItem);
-				linker.SetLootData(current_item);
+				linker.SetLootData(current_item.get());
 				c->Message(
 					Chat::White,
 					fmt::format(

--- a/zone/lua_iteminst.cpp
+++ b/zone/lua_iteminst.cpp
@@ -124,9 +124,24 @@ void Lua_ItemInst::SetPrice(uint32 price) {
 	return self->SetPrice(price);
 }
 
+uint32 Lua_ItemInst::GetSelfFoundCharacterID() {
+	Lua_Safe_Call_Int();
+	return self->GetSelfFoundCharacterID();
+}
+
+void Lua_ItemInst::SetSelfFoundCharacter(uint32 self_found_character_id, std::string name) {
+	Lua_Safe_Call_Void();
+	self->SetSelfFoundCharacter(self_found_character_id, name);
+}
+
 std::string Lua_ItemInst::GetCustomDataString() {
 	Lua_Safe_Call_String();
-	return self->GetCustomDataString();
+	return self->GetCustomDataString(true); // We always copy the full map between instances.
+}
+
+std::string Lua_ItemInst::GetCustomDataString(bool include_transient_keys) {
+	Lua_Safe_Call_String();
+	return self->GetCustomDataString(include_transient_keys);
 }
 
 void Lua_ItemInst::SetCustomData(std::string identifier, std::string value) {
@@ -203,7 +218,10 @@ luabind::scope lua_register_iteminst() {
 		.def("SetCharges", (void(Lua_ItemInst::*)(int))&Lua_ItemInst::SetCharges)
 		.def("GetPrice", (uint32(Lua_ItemInst::*)(void))&Lua_ItemInst::GetPrice)
 		.def("SetPrice", (void(Lua_ItemInst::*)(uint32))&Lua_ItemInst::SetPrice)
+		.def("GetSelfFoundCharacterID", (uint32(Lua_ItemInst::*)(void)) & Lua_ItemInst::GetSelfFoundCharacterID)
+		.def("SetSelfFoundCharacter", (void(Lua_ItemInst::*)(uint32,std::string))&Lua_ItemInst::SetSelfFoundCharacter)
 		.def("GetCustomDataString", (std::string(Lua_ItemInst::*)(void))&Lua_ItemInst::GetCustomDataString)
+		.def("GetCustomDataString", (std::string(Lua_ItemInst::*)(bool))&Lua_ItemInst::GetCustomDataString)
 		.def("SetCustomData", (void(Lua_ItemInst::*)(std::string,std::string))&Lua_ItemInst::SetCustomData)
 		.def("SetCustomData", (void(Lua_ItemInst::*)(std::string,int))&Lua_ItemInst::SetCustomData)
 		.def("SetCustomData", (void(Lua_ItemInst::*)(std::string,float))&Lua_ItemInst::SetCustomData)

--- a/zone/lua_iteminst.h
+++ b/zone/lua_iteminst.h
@@ -50,7 +50,10 @@ public:
 	void SetCharges(int charges);
 	uint32 GetPrice();
 	void SetPrice(uint32 price);
+	uint32 GetSelfFoundCharacterID();
+	void SetSelfFoundCharacter(uint32 self_found_character_id, std::string name);
 	std::string GetCustomDataString();
+	std::string GetCustomDataString(bool include_transient_keys);
 	void SetCustomData(std::string identifier, std::string value);
 	void SetCustomData(std::string identifier, int value);
 	void SetCustomData(std::string identifier, float value);

--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -521,6 +521,14 @@ void Lua_NPC::AddQuestLoot(int itemid, int charges)
 	self->AddQuestLoot(itemid, charges);
 }
 
+void Lua_NPC::AddQuestLoot(int itemid, int charges, std::string item_custom_data_string)
+{
+	Lua_Safe_Call_Void();
+	EQ::ItemCustomData item_custom_data;
+	SharedDatabase::ParseCustomDataFromString(item_custom_data, item_custom_data_string.c_str());
+	self->AddQuestLoot(itemid, charges, item_custom_data);
+}
+
 void Lua_NPC::AddPetLoot(int itemid)
 {
 	Lua_Safe_Call_Void();
@@ -531,6 +539,14 @@ void Lua_NPC::AddPetLoot(int itemid, int charges)
 {
 	Lua_Safe_Call_Void();
 	self->AddPetLoot(itemid, charges, true);
+}
+
+void Lua_NPC::AddPetLoot(int itemid, int charges, std::string item_custom_data_string)
+{
+	Lua_Safe_Call_Void();
+	EQ::ItemCustomData item_custom_data;
+	SharedDatabase::ParseCustomDataFromString(item_custom_data, item_custom_data_string.c_str());
+	self->AddPetLoot(itemid, charges, true, item_custom_data);
 }
 
 bool Lua_NPC::GetQuestLoot(int itemid)
@@ -738,8 +754,10 @@ luabind::scope lua_register_npc() {
 		.def("MerchantCloseShop", (void(Lua_NPC::*)(void))&Lua_NPC::MerchantCloseShop)
 		.def("AddQuestLoot", (void(Lua_NPC::*)(int))&Lua_NPC::AddQuestLoot)
 		.def("AddQuestLoot", (void(Lua_NPC::*)(int,int))&Lua_NPC::AddQuestLoot)
+		.def("AddQuestLoot", (void(Lua_NPC::*)(int,int,std::string))&Lua_NPC::AddQuestLoot)
 		.def("AddPetLoot", (void(Lua_NPC::*)(int))&Lua_NPC::AddPetLoot)
 		.def("AddPetLoot", (void(Lua_NPC::*)(int,int))&Lua_NPC::AddPetLoot)
+		.def("AddPetLoot", (void(Lua_NPC::*)(int,int,std::string))&Lua_NPC::AddPetLoot)
 		.def("GetQuestLoot", (bool(Lua_NPC::*)(int))&Lua_NPC::GetQuestLoot)
 		.def("GetPetLoot", (bool(Lua_NPC::*)(int))&Lua_NPC::GetPetLoot)
 		.def("HasQuestLoot", (bool(Lua_NPC::*)(void))&Lua_NPC::HasQuestLoot)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -127,8 +127,10 @@ public:
 	void MerchantCloseShop();
 	void AddQuestLoot(int itemid);
 	void AddQuestLoot(int itemid, int charges);
+	void AddQuestLoot(int itemid, int charges, std::string item_custom_data_string);
 	void AddPetLoot(int itemid);
 	void AddPetLoot(int itemid, int charges);
+	void AddPetLoot(int itemid, int charges, std::string item_custom_data_string);
 	bool GetQuestLoot(int itemid);
 	bool GetPetLoot(int itemid);
 	bool HasQuestLoot();

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -434,13 +434,6 @@ NPC::~NPC()
 	}
 
 	{
-	LootItems::iterator cur,end;
-	cur = m_loot_items.begin();
-	end = m_loot_items.end();
-	for(; cur != end; ++cur) {
-		LootItem* item = *cur;
-		safe_delete(item);
-	}
 	m_loot_items.clear();
 	}
 
@@ -1341,7 +1334,7 @@ void NPC::PickPocket(Client* thief)
 		cur = m_loot_items.begin();
 		end = m_loot_items.end();
 		for(; cur != end && x < 49; ++cur) {
-			LootItem* citem = *cur;
+			LootItem* citem = cur->get();
 			const EQ::ItemData* item = database.GetItem(citem->item_id);
 			if (item)
 			{
@@ -1365,6 +1358,10 @@ void NPC::PickPocket(Client* thief)
 			inst = database.CreateItem(steal_items[random], charges[random]);
 			if (inst)
 			{
+				if (thief->IsSoloOnly() || thief->IsSelfFound())
+				{
+					inst->SetSelfFoundCharacter(thief->CharacterID(), thief->GetName());
+				}
 				const EQ::ItemData* item = inst->GetItem();
 				if (item)
 				{

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -201,8 +201,8 @@ public:
 	void	CleanQuestLootItems();
 	uint8	CountQuestItem(uint16 itemid);
 	uint8	CountQuestItems();
-	bool	AddQuestLoot(int16 itemid, int8 charges = 1);
-	bool	AddPetLoot(int16 itemid, int8 charges = 1, bool fromquest = false);
+	bool	AddQuestLoot(int16 itemid, int8 charges = 1, const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData);
+	bool	AddPetLoot(int16 itemid, int8 charges = 1, bool fromquest = false, const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData);
 	void	DeleteQuestLoot(int16 itemid1, int16 itemid2 = 0, int16 itemid3 = 0, int16 itemid4 = 0);
 	void	DeleteInvalidQuestLoot();
 
@@ -224,7 +224,8 @@ public:
 		bool wearchange = false, 
 		bool quest = false, 
 		bool pet = false, 
-		bool force_equip = false
+		bool force_equip = false,
+		const EQ::ItemCustomData& item_custom_data = EQ::EmptyItemCustomData
 	);
 
 	void	DeleteEquipment(int16 slotid);

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -561,7 +561,7 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 			if(database.ItemQuantityType(item_id) != EQ::item::Quantity_Charges && charges < 1)
 				charges = 1;
 
-			if (sender->SummonItem(item_id, charges, 0, true))
+			if (sender->SummonItem(item_id, charges, EQ::invslot::slotCursor, true, m_inst->GetCustomData()))
 			{
 				EQ::ItemInstance* curitem = sender->GetInv().GetItem(EQ::invslot::slotCursor);
 				if (curitem && curitem->IsType(EQ::item::ItemClassBag))
@@ -698,10 +698,12 @@ uint32 ZoneDatabase::AddObject(uint32 type, uint32 icon, const Object_Struct& ob
 	uint32 database_id = 0;
 	uint32 item_id = 0;
 	int16 charges = 0;
+	std::string custom_data_str;
 
 	if (inst && inst->GetItem()) {
 		item_id = inst->GetItem()->ID;
 		charges = inst->GetCharges();
+		custom_data_str = Strings::Escape(inst->GetCustomDataString(false));
 	}
 
 	// SQL Escape object_name
@@ -727,10 +729,10 @@ uint32 ZoneDatabase::AddObject(uint32 type, uint32 icon, const Object_Struct& ob
     // Save new record for object
 	query = StringFormat("INSERT INTO object "
 		"(id, zoneid, xpos, ypos, zpos, heading, "
-		"itemid, charges, objectname, type, icon) "
-		"values (%i, %i, %f, %f, %f, %f, %i, %i, '%s', %i, %i)",
+		"itemid, charges, custom_data, objectname, type, icon) "
+		"values (%i, %i, %f, %f, %f, %f, %i, %i, '%s', '%s', %i, %i)",
 		database_id, object.zone_id, object.x, object.y, object.z, object.heading,
-		item_id, charges, object_name, type, icon);
+		item_id, charges, custom_data_str.c_str(), object_name, type, icon);
 
     safe_delete_array(object_name);
 	results = QueryDatabase(query);
@@ -752,10 +754,12 @@ void ZoneDatabase::UpdateObject(uint32 id, uint32 type, uint32 icon, const Objec
 {
 	uint32 item_id = 0;
 	int16 charges = 0;
+	std::string custom_data_str;
 
 	if (inst && inst->GetItem()) {
 		item_id = inst->GetItem()->ID;
 		charges = inst->GetCharges();
+		custom_data_str = Strings::Escape(inst->GetCustomDataString(false));
 	}
 
 	// SQL Escape object_name
@@ -766,10 +770,12 @@ void ZoneDatabase::UpdateObject(uint32 id, uint32 type, uint32 icon, const Objec
 	// Save new record for object
 	std::string query = StringFormat("UPDATE object SET "
                                     "zoneid = %i, xpos = %f, ypos = %f, zpos = %f, heading = %f, "
-                                    "itemid = %i, charges = %i, objectname = '%s', type = %i, icon = %i "
+                                    "itemid = %i, charges = %i, custom_data = '%s', objectname = '%s', "
+                                    "type = % i, icon = % i "
                                     "WHERE id = %i",
                                     object.zone_id, object.x, object.y, object.z, object.heading,
-                                    item_id, charges, object_name, type, icon, id);
+                                    item_id, charges, custom_data_str.c_str(), object_name,
+                                    type, icon, id);
     safe_delete_array(object_name);
     auto results = QueryDatabase(query);
 	if (!results.Success()) {

--- a/zone/object.h
+++ b/zone/object.h
@@ -166,6 +166,9 @@ public:
 	bool IsPlayerDrop() const { return m_is_player_drop; }
 	uint32 GetCharacterDropperID() const { return m_character_id; }
 	bool IsSSFRuleSet() const { return m_ssf_ruleset; }
+	bool IsMatchingSelfFoundCharacterID(uint32 self_found_character_id) {
+		return !m_inst || m_inst->IsMatchingSelfFoundCharacterID(self_found_character_id, true);
+	}
 
 	const char* GetEntityVariable(const char *id);
 	void SetEntityVariable(const char *id, const char *m_var);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1086,10 +1086,17 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 					// Destroy duplicate items on charmed pets and nodrop items.
 					if (item->NoDrop != 0 && (!IsCharmedPet() || (IsCharmedPet() && CastToNPC()->CountQuestItem(item->ID) == 0)))
 					{
+
+						// If the item was summoned by a self-found player, mark the item as owned by them
+						EQ::ItemCustomData item_custom_data;
+						if (caster && caster->IsClient() && (caster->CastToClient()->IsSelfFound() || caster->CastToClient()->IsSoloOnly())) {
+							EQ::ItemInstance::SetSelfFoundCharacter(item, item_custom_data, caster->CastToClient()->CharacterID(), caster->CastToClient()->name);
+						}
+
 						// For pets, all items are added to inventory, even if the
 						// item is summoned into a bag so that the pet can equip
 						// the item, if possible.
-						CastToNPC()->AddPetLoot(item->ID, quantity);
+						CastToNPC()->AddPetLoot(item->ID, quantity, false, item_custom_data);
 					}
 				} else if (caster) {
 					caster->Message_StringID(Chat::SpellFailure, SPELL_NO_EFFECT);
@@ -2184,6 +2191,44 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 				break;
 			}
 
+			case SE_Identify:
+			{
+				if (RuleB(SelfFound, IdentifyOwner))
+				{
+					if (IsClient())
+					{
+						// For self found items, also print the Self Found status of the item.
+						// Note: This is too long to save to a rule (max 21 chars), so hardcoded here.
+						// Self Found Item: Soandso`s Shord Sword
+						static const std::string SF_IDENTIFY_MESSAGE_FORMAT = "Self Found Item: %1$s`s %2$s.";
+
+						EQ::ItemInstance* cursor_item = CastToClient()->GetInv().GetItem(EQ::invslot::slotCursor);
+						if (cursor_item && cursor_item->HasSelfFoundCharacterID())
+						{
+							const uint32 self_found_character_id = cursor_item->GetSelfFoundCharacterID();
+							const std::string* cached_name = cursor_item->GetSelfFoundCharacterName();
+							if (CastToClient()->CharacterID() == self_found_character_id)
+							{
+								Message(Chat::Spells, SF_IDENTIFY_MESSAGE_FORMAT.c_str(), CastToClient()->name, cursor_item->GetItem()->Name);
+							}
+							else if (cached_name && !cached_name->empty())
+							{
+								Message(Chat::Spells, SF_IDENTIFY_MESSAGE_FORMAT.c_str(), cached_name->c_str(), cursor_item->GetItem()->Name);
+							}
+							else
+							{
+								char char_name[64]{ 0 };
+								database.GetCharName(self_found_character_id, char_name);
+								if (char_name[0])
+								{
+									Message(Chat::Spells, SF_IDENTIFY_MESSAGE_FORMAT.c_str(), char_name, cursor_item->GetItem()->Name);
+								}
+							}
+						}
+					}
+				}
+				break;
+			}
 			// Handled Elsewhere
 			case SE_ReduceReuseTimer:
 			case SE_ExtraAttackChance:
@@ -2241,7 +2286,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 			case SE_ManaPool:
 			case SE_TotalHP:
 			case SE_ChangeAggro:
-			case SE_Identify:
 			case SE_InstantHate:
 			case SE_SpellDamageShield:
 			case SE_ReverseDS:

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -322,6 +322,10 @@ bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
 
 			if (returneditem)
 			{
+				if (IsSoloOnly() || IsSelfFound()) {
+					returneditem->SetSelfFoundCharacter(CharacterID(), name);
+				}
+
 				PushItemOnCursorWithoutQueue(returneditem);
 
 				if (this->GetGroup()) {
@@ -370,6 +374,9 @@ bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
 
 			if (returneditem)
 			{
+				if (IsSoloOnly() || IsSelfFound()) {
+					returneditem->SetSelfFoundCharacter(CharacterID(), name); // returned items
+				}
 				PushItemOnCursorWithoutQueue(returneditem);
 				safe_delete(returneditem);
 			}

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -689,7 +689,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 						DeleteItemInInventory(i);
 						if (npc->CanTalk())
 							npc->Say_StringID(zone->random.Int(TRADE_BAD_FACTION1, TRADE_BAD_FACTION4));
-						SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true);
+						SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true, inst->GetCustomData());
 						Log(Logs::General, Logs::Trading, "Quest NPC %s is returning %s because the faction check has failed.", npc->GetName(), item->Name);
 
 					}
@@ -700,7 +700,8 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 						{
 							auto loot_drop_entry = LootdropEntriesRepository::NewNpcEntity();
 							loot_drop_entry.item_charges = static_cast<int8>(inst->GetCharges());
-							npc->AddLootDrop(item, loot_drop_entry, true, true);
+							bool pet = true; // setting pet(traded) flag to prevent self-found from looting this like a normal drop
+							npc->AddLootDrop(item, loot_drop_entry, true, true, false, pet, false, inst->GetCustomData());
 							Log(Logs::General, Logs::Trading, "Adding loot item %s to Quest NPC %s due to bad faction.", item->Name, npc->GetName());
 						}
 					}
@@ -710,7 +711,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 			{
 				if (Admin() == 0)
 				{
-				// if it was not a NO DROP (or if a GM is trading), let the pet have it
+					// if it was not a NO DROP (or if a GM is trading), let the pet have it
 					if (GetGM() || npc->IsPet())
 					{
 						// pets need to look inside bags and try to equip items found there
@@ -730,26 +731,23 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 											npc->AddLootDrop(bagitem, loot_drop_entry, true, true);
 											Log(Logs::General, Logs::Trading, "GM: Adding loot item %s (bag) to non-Quest NPC %s", bagitem->Name, npc->GetName());
 										}
-// Destroy duplicate and nodrop items on charmed pets.
+										// Destroy duplicate and nodrop items on charmed pets.
 										else if (bagitem->NoDrop != 0 &&
 											(!npc->IsCharmedPet() || (npc->IsCharmedPet() && npc->CountQuestItem(bagitem->ID) == 0)))
 										{
-											npc->AddPetLoot(bagitem->ID, baginst->GetCharges());
+											npc->AddPetLoot(bagitem->ID, baginst->GetCharges(), false, baginst->GetCustomData());
 											Log(Logs::General, Logs::Trading, "Adding loot item %s (bag) to non-Quest pet %s", bagitem->Name, npc->GetName());
 										}
-									}
-									else if (RuleB(NPC, ReturnNonQuestItems))
-									{
-										SummonItem(baginst->GetID(), baginst->GetCharges(), EQ::legacy::SLOT_QUEST, true);
-										if (npc->CanTalk())
-											npc->Say_StringID(NO_NEED_FOR_ITEM, GetName());
-										Log(Logs::General, Logs::Trading, "Non-Quest NPC %s is returning %s (bag) because it does not require it.", npc->GetName(), bagitem->Name);
-									}
-									else
-									{
-										if (bagitem->NoDrop != 0 && npc->CountQuestItem(bagitem->ID) == 0)
+										else if (RuleB(NPC, ReturnNonQuestItems))
 										{
-											npc->AddQuestLoot(bagitem->ID, baginst->GetCharges());
+											SummonItem(baginst->GetID(), baginst->GetCharges(), EQ::legacy::SLOT_QUEST, true, baginst->GetCustomData());
+											if(npc->CanTalk())
+												npc->Say_StringID(NO_NEED_FOR_ITEM, GetName());
+											Log(Logs::General, Logs::Trading, "Non-Quest NPC %s is returning %s (bag) because it does not require it.", npc->GetName(), bagitem->Name);
+										}
+										else if (bagitem->NoDrop != 0 && npc->CountQuestItem(bagitem->ID) == 0)
+										{
+											npc->AddQuestLoot(bagitem->ID, baginst->GetCharges(), baginst->GetCustomData());
 											Log(Logs::General, Logs::Trading, "Adding loot item %s (bag) to non-Quest NPC %s", bagitem->Name, npc->GetName());
 										}
 									}
@@ -765,18 +763,18 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 						Log(Logs::General, Logs::Trading, "GM: Adding loot item %s to non-Quest NPC %s", item->Name, npc->GetName());
 					}
 					// Destroy duplicate and nodrop items on charmed pets.
-					else if(item->NoDrop != 0 && 
+					else if(item->NoDrop != 0 &&
 						(!npc->IsCharmedPet() || (npc->IsCharmedPet() && npc->CountQuestItem(item->ID) == 0)))
 					{
-						npc->AddPetLoot(item->ID, inst->GetCharges());
+						npc->AddPetLoot(item->ID, inst->GetCharges(), false, inst->GetCustomData());
 						Log(Logs::General, Logs::Trading, "Adding loot item %s to non-Quest pet %s", item->Name, npc->GetName());
 					}
 				}
 				// Return items being handed into a non-quest NPC if the rule is true
-				else if (RuleB(NPC, ReturnNonQuestItems)) 
+				else if (RuleB(NPC, ReturnNonQuestItems))
 				{
 					DeleteItemInInventory(i);
-					SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true);
+					SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true, inst->GetCustomData());
 					if(npc->CanTalk())
 						npc->Say_StringID(NO_NEED_FOR_ITEM, GetName());
 					Log(Logs::General, Logs::Trading, "Non-Quest NPC %s is returning %s because it does not require it.", npc->GetName(), item->Name);
@@ -789,7 +787,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 					{
 						if (GetGM() || (item->NoDrop != 0 && npc->CountQuestItem(item->ID) == 0))
 						{
-							npc->AddQuestLoot(item->ID, inst->GetCharges());
+							npc->AddQuestLoot(item->ID, inst->GetCharges(), inst->GetCustomData());
 							Log(Logs::General, Logs::Trading, "Adding loot item %s to non-Quest NPC %s", item->Name, npc->GetName());
 						}
 					}

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -96,6 +96,29 @@ struct item_tick_struct {
     std::string qglobal;
 };
 
+struct SsfItemKey {
+	uint32 item_id;
+	uint32 character_id;
+	SsfItemKey(uint32 _item_id, uint32 _character_id)
+	{
+		item_id = _item_id;
+		character_id = _character_id;
+	}
+	bool operator==(const SsfItemKey& other) const {
+		return (item_id == other.item_id && character_id == other.character_id);
+	}
+};
+
+struct SsfItemKeyHash {
+	uint64_t operator() (const SsfItemKey& key) const {
+		const uint64_t item_id = key.item_id;
+		const uint64_t char_id = key.character_id;
+		return (item_id << 32) | char_id;
+	}
+};
+
+typedef std::unordered_map<SsfItemKey, uint32, SsfItemKeyHash> MerchantSsfPurchaseLimits; // (item_id,ssf_character_id) -> purchase_limit
+
 class Client;
 class Map;
 class Mob;
@@ -199,11 +222,15 @@ public:
 	void	LoadTempMerchantData();
 	uint32	GetTempMerchantQuantity(uint32 NPCID, uint32 Slot);
 	int32	GetTempMerchantQtyNoSlot(uint32 NPCID, int16 itemid);
-	int		SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold=false);
+	int		SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold=false, uint32 self_found_character_id = 0);
 	int		SaveReimbursementItem(std::list<TempMerchantList>& reimbursement_list, uint32 charid, uint32 item, int32 charges, bool sold = false);
 	void	SaveMerchantItem(uint32 merchantid, int16 item, int8 charges, int8 slot);
 	void	ResetMerchantQuantity(uint32 merchantid);
 	void	ClearMerchantLists();
+	uint32  GetSelfFoundPurchaseLimit(uint32 npctype_id, uint32 item, uint32 self_found_character_id);
+	uint32  IncreaseSelfFoundPurchaseLimit(uint32 npctype_id, uint32 item, uint32 self_found_character_id, uint32 increment_by);
+	uint32  DecreaseSelfFoundPurchaseLimit(uint32 npctype_id, uint32 item, uint32 self_found_character_id, uint32 decrement_by);
+	void    CapSelfFoundPurchaseLimitsByAvailableQuantity(uint32 npctype_id, uint32 item, uint32 quantity_in_stock);
 
 	uint8	GetZoneExpansion() { return newzone_data.expansion; }
 	uint16	GetPullLimit();
@@ -215,6 +242,7 @@ public:
 	std::map<uint32,std::list<MerchantList> > merchanttable; //This may be dynamic if items are sold out (Crows' Brew)
 	std::map<uint32,std::list<MerchantList> > db_merchanttable; //This is static and should never be changed. 
 	std::map<uint32,std::list<TempMerchantList> > tmpmerchanttable;
+	std::unordered_map<uint32, MerchantSsfPurchaseLimits> tmpmerchanttable_ssf_purchase_limits;
 	std::map<uint32, ZoneEXPModInfo> level_exp_mod;
 	std::map<uint32, SkillDifficulty> skill_difficulty;
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -416,7 +416,7 @@ void ZoneDatabase::LoadWorldContainer(uint32 parentid, EQ::ItemInstance* contain
 		return;
 	}
 
-	std::string query = StringFormat("SELECT bagidx, itemid, charges "
+	std::string query = StringFormat("SELECT bagidx, itemid, charges, custom_data "
                                     "FROM object_contents WHERE parentid = %i", parentid);
     auto results = QueryDatabase(query);
     if (!results.Success()) {
@@ -431,6 +431,7 @@ void ZoneDatabase::LoadWorldContainer(uint32 parentid, EQ::ItemInstance* contain
 
         EQ::ItemInstance* inst = database.CreateItem(item_id, charges);
         if (inst) {
+            InitializeCustomDataFromString(inst->GetCustomData(), row[3]);
             // Put item inside world container
             container->PutItem(index, *inst);
         }
@@ -450,6 +451,7 @@ void ZoneDatabase::SaveWorldContainer(uint32 zone_id, uint32 parent_id, const EQ
 	DeleteWorldContainer(parent_id,zone_id);
 
 	// Save all 10 items, if they exist
+	std::string custom_data_str;
 	for (uint8 index = EQ::invbag::SLOT_BEGIN; index <= EQ::invbag::SLOT_END; index++) {
 
 		EQ::ItemInstance* inst = container->GetItem(index);
@@ -462,11 +464,12 @@ void ZoneDatabase::SaveWorldContainer(uint32 zone_id, uint32 parent_id, const EQ
 		}
 
         uint32 item_id = inst->GetItem()->ID;
+        custom_data_str = Strings::Escape(inst->GetCustomDataString(false));
 
         std::string query = StringFormat("REPLACE INTO object_contents "
-                                        "(zoneid, parentid, bagidx, itemid, charges, droptime) "
-                                        "VALUES (%i, %i, %i, %i, %i, now())",
-                                        zone_id, parent_id, index, item_id, inst->GetCharges());
+                                        "(zoneid, parentid, bagidx, itemid, charges, custom_data, droptime) "
+                                        "VALUES (%i, %i, %i, %i, %i, '%s', now())",
+                                        zone_id, parent_id, index, item_id, inst->GetCharges(), custom_data_str.c_str());
         auto results = QueryDatabase(query);
         if (!results.Success())
             Log(Logs::General, Logs::Error, "Error in ZoneDatabase::SaveWorldContainer: %s", results.ErrorMessage().c_str());
@@ -3069,7 +3072,7 @@ void ZoneDatabase::MarkCorpseAsRezzed(uint32 db_id) {
 	auto results = QueryDatabase(query);
 }
 
-uint32 ZoneDatabase::SaveCharacterCorpse(uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const glm::vec4& position) {
+uint32 ZoneDatabase::SaveCharacterCorpse(uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const LootItems& items, const glm::vec4& position) {
 	/* Dump Basic Corpse Data */
 	std::string query = StringFormat("INSERT INTO `character_corpses` SET \n"
 		"`charname` =		  '%s',\n"
@@ -3172,24 +3175,32 @@ uint32 ZoneDatabase::SaveCharacterCorpse(uint32 charid, const char* charname, ui
 	else
 	{
 		uint8 first_entry = 0;
-		for (unsigned int i = 0; i < corpse->itemcount; i++) {
+		std::string custom_data_str;
+		for (auto it = items.cbegin(); it != items.cend(); it++) {
+			LootItem* item = it->get();
+			if (!item)
+				continue;
+
+			custom_data_str = Strings::Escape(EncodeCustomDataToString(item->custom_data, false));
 			if (first_entry != 1) {
 				corpse_items_query = StringFormat("REPLACE INTO `character_corpse_items` \n"
-					" (corpse_id, equip_slot, item_id, charges) \n"
-					" VALUES (%u, %u, %u, %u) \n",
+					" (corpse_id, equip_slot, item_id, charges, custom_data) \n"
+					" VALUES (%u, %u, %u, %u, '%s') \n",
 					last_insert_id,
-					corpse->items[i].equip_slot,
-					corpse->items[i].item_id,
-					corpse->items[i].charges
+					item->equip_slot,
+					item->item_id,
+					item->charges,
+					custom_data_str.length() ? custom_data_str.c_str() : ""
 				);
 				first_entry = 1;
 			}
 			else {
-				corpse_items_query = corpse_items_query + StringFormat(", (%u, %u, %u, %u) \n",
+				corpse_items_query += StringFormat(", (%u, %u, %u, %u, '%s') \n",
 					last_insert_id,
-					corpse->items[i].equip_slot,
-					corpse->items[i].item_id,
-					corpse->items[i].charges
+					item->equip_slot,
+					item->item_id,
+					item->charges,
+					custom_data_str.length() ? custom_data_str.c_str() : ""
 				);
 			}
 		}
@@ -3201,7 +3212,7 @@ uint32 ZoneDatabase::SaveCharacterCorpse(uint32 charid, const char* charname, ui
 	return last_insert_id;
 }
 
-bool ZoneDatabase::SaveCharacterCorpseBackup(uint32 corpse_id, uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const glm::vec4& position) {
+bool ZoneDatabase::SaveCharacterCorpseBackup(uint32 corpse_id, uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const LootItems& items, const glm::vec4& position) {
 	/* Dump Basic Corpse Data */
 	std::string query = StringFormat("INSERT INTO `character_corpses_backup` SET \n"
 		"`id` =						%u,\n"
@@ -3300,29 +3311,41 @@ bool ZoneDatabase::SaveCharacterCorpseBackup(uint32 corpse_id, uint32 charid, co
 	}
 
 	/* Dump Items from Inventory */
+	query = "";
 	uint8 first_entry = 0;
-	for (unsigned int i = 0; i < corpse->itemcount; i++) {
+	std::string custom_data_str;
+	for (auto it = items.cbegin(); it != items.cend(); it++) {
+		LootItem* item = it->get();
+		if (!item)
+			continue;
+
+		custom_data_str = Strings::Escape(EncodeCustomDataToString(item->custom_data, false));
 		if (first_entry != 1){
 			query = StringFormat("REPLACE INTO `character_corpse_items_backup` \n"
-				" (corpse_id, equip_slot, item_id, charges) \n"
-				" VALUES (%u, %u, %u, %u) \n",
-				corpse_id, 
-				corpse->items[i].equip_slot,
-				corpse->items[i].item_id,
-				corpse->items[i].charges
+				" (corpse_id, equip_slot, item_id, charges, custom_data) \n"
+				" VALUES (%u, %u, %u, %u, '%s') \n",
+				corpse_id,
+				item->equip_slot,
+				item->item_id,
+				item->charges,
+				custom_data_str.length() ? custom_data_str.c_str() : ""
 			);
 			first_entry = 1;
 		}
 		else{ 
-			query = query + StringFormat(", (%u, %u, %u, %u) \n",
+			query += StringFormat(", (%u, %u, %u, %u, '%s') \n",
 				corpse_id,
-				corpse->items[i].equip_slot,
-				corpse->items[i].item_id,
-				corpse->items[i].charges
+				item->equip_slot,
+				item->item_id,
+				item->charges,
+				custom_data_str.length() ? custom_data_str.c_str() : ""
 			);
 		}
 	}
-	auto sc_results = QueryDatabase(query); 
+	if (query.empty()) {
+		return true;
+	}
+	auto sc_results = QueryDatabase(query);
 	if (!sc_results.Success()){
 		Log(Logs::Detail, Logs::Error, "Error inserting character_corpse_items_backup.");
 		return false;
@@ -3412,7 +3435,7 @@ bool ZoneDatabase::LoadCharacterCorpseRezData(uint32 corpse_id, uint32 *exp, uin
 	return false;
 }
 
-bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntry* corpse){
+bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntry* corpse, LootItems& itemlist) {
 	std::string query = StringFormat(
 		"SELECT           \n"
 		"is_locked,       \n"
@@ -3496,7 +3519,8 @@ bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntr
 		"SELECT                       \n"
 		"equip_slot,                  \n"
 		"item_id,                     \n"
-		"charges                      \n"
+		"charges,                     \n"
+		"custom_data                  \n"
 		"FROM                         \n"
 		"character_corpse_items       \n"
 		"WHERE `corpse_id` = %u\n"
@@ -3505,18 +3529,18 @@ bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntr
 	);
 	results = QueryDatabase(query);
 
-	i = 0;
 	corpse->itemcount = results.RowCount();
 	uint16 r = 0;
 	for (auto& row = results.begin(); row != results.end(); ++row) {
-		memset(&corpse->items[i], 0, sizeof(LootItem));
-		corpse->items[i].equip_slot = atoi(row[r++]);		// equip_slot,
-		corpse->items[i].item_id = atoul(row[r++]); 		// item_id,
-		corpse->items[i].charges = atoi(row[r++]); 		// charges,
-		corpse->items[i].min_looter_level = 0;
-		corpse->items[i].item_loot_lockout_timer = 0;
+		std::shared_ptr<LootItem> corpse_item = std::make_shared<LootItem>();
+		corpse_item->equip_slot = atoi(row[r++]);		// equip_slot,
+		corpse_item->item_id = atoul(row[r++]); 		// item_id,
+		corpse_item->charges = atoi(row[r++]); 			// charges,
+		InitializeCustomDataFromString(corpse_item->custom_data, row[r++]); // custom_Data
+		corpse_item->min_looter_level = 0;
+		corpse_item->item_loot_lockout_timer = 0;
+		itemlist.push_back(corpse_item);
 		r = 0;
-		i++;
 	}
 
 	return true;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -176,7 +176,6 @@ struct CharacterCorpseEntry
 	bool  rezzable;
 	uint32	rez_time;
 	uint32 time_of_death;
-	LootItem items[0];
 };
 
 // Actual pet info for a client.
@@ -303,7 +302,7 @@ public:
 	bool		DeleteItemOffCharacterCorpse(uint32 db_id, uint32 equip_slot, uint32 item_id);
 	uint32		GetCharacterCorpseItemCount(uint32 corpse_id);
 	bool		LoadCharacterCorpseRezData(uint32 corpse_id, uint32 *exp, uint32 *gmexp, bool *rezzable, bool *is_rezzed);
-	bool		LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntry* corpse);
+	bool		LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntry* corpse, LootItems& itemlist);
 	Corpse*		LoadCharacterCorpse(uint32 player_corpse_id);
 	Corpse*		SummonBuriedCharacterCorpses(uint32 char_id, uint32 dest_zoneid, uint32 dest_zoneguildid, const glm::vec4& position);
 	Corpse*		SummonCharacterCorpse(uint32 corpse_id, uint32 char_id, uint32 dest_zoneid, uint32 dest_zoneguildid, const glm::vec4& position);
@@ -320,8 +319,8 @@ public:
 	uint32		SendCharacterCorpseToGraveyard(uint32 dbid, uint32 zoneid, uint32 zone_guild_id, const glm::vec4& position);
 	uint32		CreateGraveyardRecord(uint32 graveyard_zoneid, const glm::vec4& position);
 	uint32		AddGraveyardIDToZone(uint32 zone_id, uint32 graveyard_id);
-	uint32		SaveCharacterCorpse(uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const glm::vec4& position);
-	bool		SaveCharacterCorpseBackup(uint32 corpse_id, uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const glm::vec4& position);
+	uint32		SaveCharacterCorpse(uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const LootItems& items, const glm::vec4& position);
+	bool		SaveCharacterCorpseBackup(uint32 corpse_id, uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const LootItems& items, const glm::vec4& position);
 	uint32		UpdateCharacterCorpse(uint32 dbid, uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const glm::vec4& position, bool rezzed = false);
 	bool		UpdateCharacterCorpseBackup(uint32 dbid, uint32 charid, const char* charname, uint32 zoneid, uint32 zoneguildid, CharacterCorpseEntry* corpse, const glm::vec4& position, bool rezzed = false);
 	uint32		GetFirstCorpseID(uint32 char_id);


### PR DESCRIPTION
**Author: viskar (in-game & discord)** if you need to reach me.

I'd like to start by saying thanks for this awesome server, the enjoyable self-found experience, and happy upcoming Quarm anniversary! The <Lost & Self Found> group is having a blast and looking forward to these changes if approved.

# !Attention!
- This patch adds a new column to corpses and objects, so the included database SQL migration script must be run or they will fail to save.
-------------------

# What

- ItemInstances's custom_data is now propagated/persisted between item instances, corpses, objects, and loot.
- Self-found Items now keep track of the self-found player who originally acquired/owned the item (except for stackable items) in the custom_data field.
- Merchants keep count of the quantity of self-found items have been sold to them on a per-character / per-item basis.
- This enables the SF actions listed below, while operating within the rules/limitations of self found.
- Since this makes `custom_data` persistent, this makes it trivial to add new Quarm features that utilize this as well. For example you could make ad-hoc custom GM versions of items that have minor modifications like a custom name override that persist, or maybe a tint override etc, without having to create a whole new Item/ItemID. Instead it's just a unique instance of that item, but otherwise the same item under the hood.

# Self Found Features / Patch Notes
All the features in this patch are gated by the corresponding new rules, so they can be selectively enabled/disabled as desired.

All of these are made to fully respect the rules of self-found, and none of them allow a player to access an item they didn't find first, or benefit from the money spent by other players.

## SelfFound:PetLootSupport
Self-found players can now always loot their own Self-found Items back from charmed pets.
  - This brings SF Enchanter power levels on par with regular Enchanters by being able to supply their pets with high quality self-found gear, and loot it back to use again later.

Rule takes effect immediately when toggled on/off.

## SelfFound:ItemMulingSupport
Self-found players can now always pick up their own Self-found Items from the ground, making it possible to mule their items for storage on alts. (Stackable items not supported).
  - We were in dire need of this with all the items we have to manage on one toon.

Rule takes effect immediately when toggled on/off.

## SelfFound:TempMerchantSupport / SelfFound:TempMerchantFiltering
Self-found players can now repurchase their own self-found items from merchants' temporary inventory, up to the quantity they sold, while supplies last (Stackable items not supported).
  - `SelfFound:TempMerchantFiltering` controls visibility of temporary inventory.
    - Regardless of visibility, SF rules are enforced on what you're actually allowed to purchase, the rest are off limits and only shown (if filtering is disabled) to know how full the vendor is.
    - False will show all items.
    - True will only show items you can repurchase.
    - Currently I recommend this as `false` personally, so you can understand if a vendor is full or not. You can still easily distinguish self-found items by their custom name if the feature is enabled.
    - The filtered inventory still shows items in their original slots, so you might see 60 blank items and then your item floating at the bottom of the window, which is confusing. In a follow up I may be able to improve how that works and get everything pushed to the top, but keeping track of the slot numbers between client server becomes pretty complicated when having to keep all views of the vendor sync'd and coordinated. And I think those of us in the self-found community are fine dealing with seeing the unfilited inventory even though we can't buy from it, if it makes the rest work more intuitively.

Rule takes effect immediately when toggled on/off. If the TempMerchantSupport is turned off, then the temp inventory becomes invisible regardless of the second rule, behaving the way it currently does on Quarm.

## SelfFound:PersonalizedItemNames / SelfFound:PersonalizedItemNameFormat
Self-found items will now display the character name of self-found player in the item name (when it fits).

Generally visible in most places
- In your inventory/bags.
- In loot windows (e.g. looting your pet items back).
- In trade windows (e.g. if Normie players are trading the item).
- On items you picked up/dropped.
- Is NOT displayed when looting an item (I tried it, was messy, plus could be strange for log parses/DKP)
  -  e.g. "-- You receive loot {item}. --"

This allows for easy identification that this item is recognized as a self-found item and is supported by all these other features, making self-inflicted mistakes much less likely to occur:
  - Players will know it is safe to drop-transfer this time for muling.
  - Players will know they can sell it to a vendor and still buy it back, for recharging purposes.
  - Players will know they can buy from a vendor when they see items with their name on it in the vendor inventory window.
  - Players will know they can give it to a charmed pet and loot it back.
  - Players will see who owns which item the loot window of charm pets.
  - The name will stick around on the item as long as the item retains its self-found status.
  - Handy if anyone, quite literally, comes across a Self-found Item and want to take it back to Lost and (Self) Found.
  - It's also a awesome and could make more people want to play SF.

![image](https://github.com/user-attachments/assets/38e18b08-03ce-431a-a2a9-d74e6ed5f31f)

Rule is not immediate if players are online. Existing items should show their updated name after the holder zones/login.

## SelfFound:IdentifyOwner / SelfFound:IdentifyMessageFormat
Casting Identify on a self-found Item sends a message indicating the item's owner:
  - "Self Found Item: Circle's Amulet of Necropotence."

![image](https://github.com/user-attachments/assets/9cac74f3-508c-45e0-a7df-1b71e2f96b97)

Rule takes effect immediately when toggled on/off.

# Bug Fixes
These were basically 1 liners or were just part of the lines already being adjusted.
- Dropped items with charges that were left on the ground during a server restart/crash will no longer lose all their charges when the server restores the ground item.
- Adding missing `safe_delete(item)` in `NPC::AddLootDrop`.
- Minor curly-brace placement fixing that were incorrectly structured in `Client::FinishTrade` section dealing with trades to NPCs.
- Stopped `ZoneDatabase::SaveCharacterCorpseBackup` from double saving the first query when a corpse has zero items.

# Implementation Notes

- `SelfFoundCharacterID` is stored in the item's `custom_data` field/column with attribute key `"SFCID"`.
  - Remains blank for non-SF items.
- The `custom_data` of an item is now propagated (and persisted) when an item moves around:
  - When given to an NPC (`ItemInstance` to npc `LootItem`). In-memory only.
  - When moved to a player corpse (`ItemInstance` to corpse's `LootItem`) and saved to `character_corpse_items`.
  - When dropped as a ground object (`ItemInstance` to Object) and saved to `object` / `object_contents`.
  - When returned/rejected by an NPC trade (`ItemInstance` returned with `SummonItem()`).
- Things that grant self-found status to an item:
  - SF player loots an item.
  - SF player crafts an item.
  - SF player purchases an item.
  - SF player quests an item.
  - SF player summons an item.
  - SF player logs in: Any currently possessed items will upgrade to self-found status, if missing.
- Things that strip self-found status from an item:
  - Normie, posessing a SF Item, sells and repurchases it from a vendor. Anything purchsed by a normie will result in a non-SF item.

![image](https://github.com/user-attachments/assets/f82d5b65-c706-4f7e-b1f4-e06da7f7b11c)

# Supporting Changes
- Added corresponding `custom_data` column to additional tables for propgating the item's `custom_data` attributes:
  - object
  - object_contents
  - character_corpse_items
  - character_corpse_items_backup

- Adjusted the corpse saving code to use iterators instead of arrays for saving items, to avoid unsafe memcpy operations on the new `custom_data` map. Tried everything I could to just keep the existing code, but the array destroy always crashed even after multiple attempts to make it work. So it seemed too fragile, and the array copies were unnecessary copy steps anyway.

# Feedback Welcome
I've made several iterations on this, starting from a very bespoke implementation of passing around/storing raw character IDs everywhere, to now it being a more generalized solution that can be leveraged for future usecases that would want to leverage the custom_data storage.

Most of the work was making item `custom_data` properly propagate between all the places an item can be moved to. This was more complex than simply adding a bespoke `self_found_character_id` field all over the place, but a much cleaner solution for any future use cases that want to leverage this groundwork.

My C++ experience is limited, though I've expanded my comfort quite a bit working on this PR (which is a cool way to learn!). But if I'm missing something obvious I don't mind the feedback.

# Main Tests performed

Testing Notes: For tests with dropped objects, also tested variants where the server crashes while the item is on the ground, letting the server reboot/restore the ground object, and try looting it that way.

- General
  - SF kills and loots a loot drop from an NPC. SF is tagged as the item's owner.
  - SF receives an item via SummonItem (quest dialog, spell, etc). SF is tagged as the item's owner.
  - SF picks up a non-player ground spawn. SF is tagged as the item's owner.
  - SF buys an item from a vendor. SF is tagged as the item's owner.
  - SF logs in for the first time since the patch. All their current posessions (except stackable items) are immediately tagged with SF ownership status.

- Muling
  - SF drops Normie their SF item. Normie drops the SF item back. SF able to pickup.
  - SF drops Normie their empty SF bag. Normie drops the empty SF bag. SF able to pickup.
  - SF drops their SF bag that contains some stacked items (food, water, skins, etc), which won't propagate the SF status. Normie picks it up. Normie drops the SF bag. SF cannot pickup because stackable items are not propagated as SF items. Normie remove the stackable items from the bag. Normie re-drops the SF bag. SF is able to pickup the bag that now only contains their SF tagged items.
  - SF drops their SF bag that contains some stacked items (food, water, skins, etc), which won't propagate the SF status. SF can immediately re-pick it back up since no one else has touched the bag yet. NOTE: If the server crashes and restores the ground object, the SF player loses this chance.
  - Normie dropping normie bag. SF unable to pickup.
  - Normie dropping normie item. SF unable to pickup.
  - Normie drops and picks up an SF item. The item retains its SF tag.
  - Normie logs in and logs out. Normie's current poessions that had SF ownership tags (if any) remain SF tagged across sessions.
  - Normie dies while in possession of an SF item. Normie loots the SF item from their own corpse. The item retains its SF status and is still eligible for muling.

- Pet Loot
  - SF player gives item(s) to a pet. SF gets kill credit for pet. SF able to loot their SF items back, but not other SF players or Normie items.
  - SF player gives item(s) to a pet. Normie kills a charm pet that was holding SF player's items. Normie loots the SF items. Normie drops the items for the SF player. SF player is able to pick up their items.
  - SF kills a charm pet that was holding Normie's items. SF is unable to loot Normie's items that were traded to the pet.

- TempMerchant
  - SF sells 1 SF item to the vendor. SF can rebuy 1 time.
  - SF sells X SF item to the vendor. SF can rebuy X times.
  - SF sells charged items to the vendor. SF can rebuy the items with normal recharging rules.
  - SF sells stackable items to the vendor. SF cannot rebuy them.
  - While an item is available for repurchase, the personalized name appears in the vendor listing for that SF player (if personalized names are on).
  - (Filtering ON) Items properly appear/vanish from visibility depending on repurchases left for that SF player.
  - (Filtering OFF) SF player gets an error message trying to buy a temp item that they have no repurchases for.
  - Normie sells an SF item to a vendor. If Normie rebuys the item, the item has lost its SF status (all purchased items by normies are reset). SF can no longer acquire that item.
  - Normie sells an SF item to a vendor. The SF player who owned the item can see the item on the vendor and can repurchase it.
  - Given a vendor with no items in stock. SF sells 3x of an Item to the vendor. Normie buys 1x of the item from the vendor. Normie sells the item back. SF can only repurchase 2x of the item, since the number in stock was depleted down to 2 temporarily, capping the number of SF repurchases.

# Disclaimers
- While I think this is fairly well tested, there is always the possibility of an SF Item losing its ownership data and getting locked out from the character. Could likely happen if we miss a spot now or in the future where we should have propagated the custom_data, but didn't. Players should mule / pet charm with this in mind; that some combination of actions/bugs may still result in losing the item.