### PR TITLE
Added/Fixed skillup multiplier for tradeskills

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -297,6 +297,7 @@ RULE_BOOL(Quarm, NPCBeneficialSpellDurationModifier, false, "Enables or disables
 RULE_BOOL(Quarm, NPCDetrimentalSpellDurationModifier, false, "Enables or disables duration modification for NPC detrimental spells")
 RULE_BOOL(Quarm, EnableGlobalSkillupDifficultyAdjustments, false, "Enables or disables skillup modifiers globally for players. Lower = Faster.")
 RULE_REAL(Quarm, GlobalSkillupDifficultyAdjustment, 1.0f, "Multiplier forEnableGlobalSkillupDifficultyAdjustments - default is 1.0f. 0.5 would be double (Lower = Faster)")
+RULE_REAL(Quarm, GlobalTradeSkillupDifficultyAdjustment, 1.0f, "Tradeskill multiplier forEnableGlobalSkillupDifficultyAdjustments - default is 1.0f. 0.5 would be double (Lower = Faster)")
 RULE_BOOL(Quarm, EnableQuestExpMultiplier, false, "")
 RULE_REAL(Quarm, QuestExpMultiplier, 1.0, "")
 RULE_BOOL(Quarm, EnableBardInstagibLimit, false, "")

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -391,6 +391,15 @@ void Client::CheckIncreaseTradeskill(bool isSuccessfulCombine, EQ::skills::Skill
 
 	double tradeDifficulty = zone->skill_difficulty[tradeskill].difficulty;
 
+	if (RuleB(Quarm, EnableGlobalSkillupDifficultyAdjustments))
+	{
+		float global_skillup_mod = RuleR(Quarm, GlobalTradeSkillupDifficultyAdjustment);
+		tradeDifficulty *= global_skillup_mod;
+		if (tradeDifficulty < 1.0f) {
+			tradeDifficulty = 1.0f;
+		}
+	}
+
 	int tradeStat = 0;
 	if (tradeskill == EQ::skills::SkillFletching || tradeskill == EQ::skills::SkillMakePoison)
 	{


### PR DESCRIPTION
# What
- This adds a rule that can modify the skillup rate for tradeskills.
- For safety/control, I made this a separate rule, so it will need to be applied too.

# Why
- The new skillup modifier wasn't affecting tradeskills because it is a separate code path.
- It sounded like it was supposed to be buffed as part of this bonus, so here's a quick patch.

![image](https://github.com/user-attachments/assets/f679cd2e-3305-4ffa-b1a2-c83d00effa17)

