### PR TITLE
Add Shroud of Undeath (1376) to set of spells which have effect: IIlusion Skeleton and apply Iksar skeleton illusion for Iksar race players (call of bones, demi-lich, etc.)

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5243,6 +5243,7 @@ void Mob::ApplyIllusion(const SPDat_Spell_Struct &spell, int i, Mob* caster)
             case 581:
 			case 643:
             case 644:
+			case 1376:
             case 1611:
             {
 				if (GetBaseRace() == IKSAR && spell_base == SKELETON)


### PR DESCRIPTION
Add Shroud of Undeath (1376) to set of spells which have effect: IIlusion Skeleton and apply Iksar skeleton illusion for Iksar race players (call of bones, demi-lich, etc.)

https://www.pqdi.cc/spell/1376
https://www.pqdi.cc/spell/643