### PR TITLE
Updated surname rules to better simulate Daybreak's naming policy

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1346,6 +1346,7 @@ bool Database::CheckNameFilter(const char* name, bool surname) {
 
 	// Rule 2: Check for allowed characters and optional backtick for surnames.
 	bool special_char_found = false;
+	int second_uppercase_used = false; // Surnames may contain 2 uppercase letters
 	for (size_t i = 0; i < str_name.size(); i++) {
 		if (str_name[i] == '`' || str_name[i] == '\'') {
 			// For non-surnames, if special char already found, or if it's at the start/end of the string.
@@ -1356,6 +1357,11 @@ bool Database::CheckNameFilter(const char* name, bool surname) {
 		}
 		else if (!isalpha(str_name[i])) {
 			return false;
+		}
+		else if (i > 0 && isupper(str_name[i])) {
+			if (!surname || second_uppercase_used)
+				return false;
+			second_uppercase_used = true;
 		}
 	}
 

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1346,7 +1346,7 @@ bool Database::CheckNameFilter(const char* name, bool surname) {
 
 	// Rule 2: Check for allowed characters and optional backtick for surnames.
 	bool special_char_found = false;
-	int second_uppercase_used = false; // Surnames may contain 2 uppercase letters
+	bool second_uppercase_used = false; // Surnames may contain 2 uppercase letters
 	for (size_t i = 0; i < str_name.size(); i++) {
 		if (str_name[i] == '`' || str_name[i] == '\'') {
 			// For non-surnames, if special char already found, or if it's at the start/end of the string.

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8897,16 +8897,7 @@ void Client::Handle_OP_Surname(const EQApplicationPacket *app)
 			*c = toupper(*c);
 			first = false;
 		}
-		else if (*c == '`' || *c == '\'') { // if we find a backtick, don't modify the next character's capitalization
-			// If this is the last character, we can break out of the loop
-			if (*(c+1) == '\0')
-				break;
-
-			c++; // Move to the next character
-		}
-		else {
-			*c = tolower(*c);
-		}
+		// Valid captialization will be checked by CheckNameFilter
 	}
 
 	if (strlen(surname->lastname) >= 20) {
@@ -8914,7 +8905,7 @@ void Client::Handle_OP_Surname(const EQApplicationPacket *app)
 		return;
 	}
 
-	if (!database.CheckNameFilter(surname->lastname, true))
+	if (strlen(surname->lastname) > 0 && !database.CheckNameFilter(surname->lastname, true))
 	{
 		Message_StringID(Chat::Yellow, SURNAME_REJECTED);
 		return;


### PR DESCRIPTION
TLDR: Minor change that decouples the "Max 1 Accent" and "Max 2 capitalization" checks into separate checks, based on the evidence/use-cases cited below. Current logic only allows a 2nd capitalization immediately after an accent, but evidence shows that, in practice, players were allowed a 2nd capitalization without requiring a preceding accent per their supported naming policies.

# What
- Adjust surname validation to closer match Daybreak's historical naming policy (read below).
- Server will reject badly capitalized surnames instead of forcing to lowercase and approving (Prevents user error, try again).

# References

(1) https://forums.daybreakgames.com/eq/index.php?threads/surname-support-help-co-devs.232050/

This post shows that from 1999-2016, SOE/Daybreak actively supported the following surnames in their naming policies and granted them upon request:
- Back-ticks (K`Ven)
- Apostrophes (O'Bannon)
- Use of a second capitalized letter (McDuff, MacDonald, McMarrin, McVaxius, etc..)

Post-2016 Daybreak no longer offered as much CSR support to players, so support for this was cut off around that time, to the dismay of players.

In 2020 they finally implemented their surname rules directly into the /surname command, replacing the manual CSR process for an automated one, re-enabling players to get the surnames they've historically been allowed to use. This still matches their previous policy, just automated it with code. Patch notes:

(2) https://forums.daybreakgames.com/eq/index.php?threads/game-update-notes-march-11-2020.263793/#post-3878224
```
- The surname command now allows the use of a second capital letter and a single accent character.
```

# Discussion

Since our PQ/TAKP `/surname` command aims to natively support EQ-style surnames without needlessly requiring CSR involvement (it allows the ` and ' characters already), it would follow that it is appropriate to mirror this last element of their naming policy here as well with this minor change.

This would allow some players to get names like McBannon, McDouglas, MacDuff, etc, which is currently not possible nor supported by the CSRs on Quarm.

EQ has always been deeply rooted in D&D culture, and the character naming policy they supported is part of that. This is a pretty minor adjustment that fits with their own philosophy and actions throughout the years. Overall, I think this is in the spirit of EQ and would make Quarm just a tad bit more fun with character naming options; it unlocks a few more fun/roleplay type names that people would like to use. And this is all based on the same policies that people got to enjoy on Live as well.

# Risks?

- Personally I don't really see any major risks or impact on CSR. While some people get creative with their names from time-to-time, they can already do this in the current system and this validation change doesn't really change anything materially significant that people could do with their names.