### PR TITLE
Temp - Idea Review - Allow guild consent

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3440,6 +3440,8 @@ void Client::Handle_OP_Consent(const EQApplicationPacket *app)
 			Message_StringID(Chat::White, NO_CORPSES);
 			return;
 		}
+		// TODO: Will need special handling if the gname is guild or Guild
+		// Probably split up the response packets below to be generic for if it worked or not
 		else if (IsConsented(gname))
 		{
 			Message_StringID(Chat::White, CONSENT_DENIED, c->name);

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -46,7 +46,7 @@ class Corpse : public Mob {
 	static void SendLootReqErrorPacket(Client* client, uint8 response = 2);
 	Corpse(NPC* in_npc, LootItems *in_itemlist, uint32 in_npctypeid, uint32 in_decaytime = 600000, bool is_client_pet = false);
 	Corpse(Client* client, int32 in_rezexp, uint8 killedby = 0);
-	Corpse(uint32 in_corpseid, uint32 in_charid, const char* in_charname, LootItems* in_itemlist, uint32 in_copper, uint32 in_silver, uint32 in_gold, uint32 in_plat, const glm::vec4& position, float in_size, uint8 in_gender, uint16 in_race, uint8 in_class, uint8 in_deity, uint8 in_level, uint8 in_texture, uint8 in_helmtexture, uint32 in_rezexp, uint32 in_gmrezexp, uint8 in_killedby, bool in_rezzable, uint32 in_rez_time, bool wasAtGraveyard = false);
+	Corpse(uint32 in_corpseid, uint32 in_charid, const char* in_charname, LootItems* in_itemlist, uint32 in_copper, uint32 in_silver, uint32 in_gold, uint32 in_plat, const glm::vec4& position, float in_size, uint8 in_gender, uint16 in_race, uint8 in_class, uint8 in_deity, uint8 in_level, uint8 in_texture, uint8 in_helmtexture, uint32 in_rezexp, uint32 in_gmrezexp, uint8 in_killedby, bool in_rezzable, uint32 in_rez_time, uint32 in_guild_id, bool wasAtGraveyard = false);
 	~Corpse();
 	static Corpse* LoadCharacterCorpseEntity(uint32 in_dbid, uint32 in_charid, std::string in_charname, const glm::vec4& position, uint32 time_of_death, bool rezzed, bool was_at_graveyard);
 
@@ -204,6 +204,7 @@ private:
 	bool		rezzable; /* Determines if the corpse is still rezzable */
 	EQ::TintProfile item_tint;
 	uint32		rez_time; /* How much of the rez timer remains */
+	uint32		guild_id; /* The guild id the character of this corpse was in */
 	bool		is_owner_online;
 	uint32		time_of_death;
 	std::string npc_clean_name;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3435,6 +3435,7 @@ bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntr
 		"killedby,		  \n"
 		"rezzable,		  \n"
 		"rez_time		  \n"
+		"guild_id		  \n"
 		"FROM             \n"
 		"character_corpses\n"
 		"WHERE `id` = %u  LIMIT 1\n",
@@ -3477,6 +3478,7 @@ bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntr
 		corpse->killedby = atoi(row[i++]);						// killedby
 		corpse->rezzable = atoi(row[i++]);						// rezzable
 		corpse->rez_time = atoul(row[i++]);					// rez_time
+		corpse->guild_id = atoi(row[i++]);						// guild_id  - // TODO Need to add guild id column to the table
 	}
 	query = StringFormat(
 		"SELECT                       \n"


### PR DESCRIPTION
## Description

First Brainstorming pass to allow the command /consent guild - requested here: https://discord.com/channels/1133452007412334643/1275187372551835719

This thread has 60 upvotes and no downvotes & it is something included in the ROF2 client, so seems like a good addition to quarm.

## Implementation Brainstorming

Included my chain of thought in the comments of this commit, but to summarize, here's the current idea I'm thinking will work:

### Requirements
 - Players should be able to type /consent guild
 - Once this is done, anyone in the guild should be able to /drag that player's corpse
 - Preserve current corpse dragging functionality that allows cross zone consenting & dragging of corpses while the dead player is offline

### Solution Idea

Need more generic version of Idea 4 so it can be used for guild, raid, and group
- Existing implementation - every client has a consent_list of player names they can drag
- We could check the DB directly when /drag is used and then cache that info, could also have a cooldown if needed to prevent DB overload
- This would check a new table called character_consent_multiple
	- This will have columns: player_id and then 3 bool columns: consent_guild, consent_group, consent_raid
- Will look up player_id using this->GetCharID() on the corpse
- Will update Client consent_list with the player's name
- All of this will run only if they aren't currently in the consent list