### PR TITLE
  Update heartsting sack drop rate from 15-30%

### DIFF
--- a/utils/sql/git/content/2024_10_16_Increase_Heartsting_Sack_Drop_Rate.sql
+++ b/utils/sql/git/content/2024_10_16_Increase_Heartsting_Sack_Drop_Rate.sql
@@ -1,0 +1,30 @@
+UPDATE lootdrop_entries
+SET chance = 30
+WHERE item_id = 16838; -- heartsting venom sack
+
+INSERT INTO `loottable_entries` (`loottable_id`, `lootdrop_id`, `multiplier`, `probability`, `droplimit`, `mindrop`, `multiplier_min`) 
+VALUES 
+(
+	5779,  -- large heartsting scorpion's loottable 
+	104743, -- lootdrop for heartsting venom sack found on the regular heartsting scorpion, so they'll have same drop rate
+	1, 
+	100, 
+	0, 
+	0, 
+	0
+);
+
+-- Handy queries for inspecting drop tables of relevant NPCs
+
+-- SELECT * FROM lootdrop_entries as lde
+-- LEFT JOIN items ON items.id = lde.item_id
+-- WHERE lootdrop_id = 104744 OR lootdrop_id = 104743;  -- 104743 is the venom sack
+
+-- SELECT * FROM lootdrop_entries as lde
+-- LEFT JOIN items ON items.id = lde.item_id
+-- WHERE lootdrop_id = 10844;
+
+-- SELECT * FROM loottable_entries AS lte
+-- JOIN lootdrop_entries as lde ON lde.lootdrop_id = lte.lootdrop_id
+-- JOIN items ON items.id = lde.item_id 
+-- WHERE loottable_id = 5779;


### PR DESCRIPTION
See discussion here for reasoning & community support: https://discord.com/channels/1133452007412334643/1295814305660538901

11 upvotes, no downvotes, no comments arguing against.  Makes farming for slow poisons a little easier from 1 per hour to 3-4 per hour and reducing zone disruption.

Tested by going around FoB pit and killing regular heartstings.  I was getting one every 4 mobs on average.  Mostly like 5, 4, 4, 5, 2, etc

On large heartstings my rng was a little worse running around, they seem to be a rarer spawn too.  When spawned with the spawn command though, I made 6 of them and 2 of them had the sack, so that seems to align well with the intended drop rate.