### PR TITLE
Add a small cost for Morning Dew so it can be sold to merchants

### DIFF
--- a/utils/sql/git/content/2024_10_17_Morning_Dew_Vendor_Cost.sql
+++ b/utils/sql/git/content/2024_10_17_Morning_Dew_Vendor_Cost.sql
@@ -1,0 +1,3 @@
+UPDATE items
+SET price = 80
+WHERE NAME = "Morning Dew";


### PR DESCRIPTION
This implements suggestion: https://discord.com/channels/1133452007412334643/1267554989203525703

4 upvotes, 1 100% emoji and no downvotes.  The main idea is to incentivize players to sell their foraged morning dew so crafters can do vendor diving to find more mats like they can for other cultural armor.

Sell price at amiable is 7 silver, 1 copper.  Purchase price is 9 silver.

Tested with both GM summoned item & actually foraging one to double check that both work.