### PR TITLE
Adds Spell: Ring of the Combines to Roule in North Karana

### DIFF
--- a/utils/sql/git/content/2024_10_17_Add_Druid_Combines_Self_Port.sql
+++ b/utils/sql/git/content/2024_10_17_Add_Druid_Combines_Self_Port.sql
@@ -1,0 +1,4 @@
+INSERT INTO merchantlist 
+(merchantid, slot, item, faction_required, level_required, alt_currency_cost, classes_required, probability, quantity, min_expansion, max_expansion, content_flags, content_flags_disabled) 
+VALUES 
+(13068, 17, 19472, -1100, 0, 0, 32767, 100, 0, 1, 99, NULL, NULL);


### PR DESCRIPTION
The self port for wizards was already there, but the druid one was not in game yet because it's on a merchant that's gated for Velious.

This is added due to unanimous support in the suggestions forum: https://discord.com/channels/1133452007412334643/1279159285061779516

Tested by doing #reloadmerchants while in NK, buying the spell from Roule and then using the spell to port myself to Dreadlands.