### PR TITLE
Slightly improve wizards rain spells

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -381,6 +381,8 @@ RULE_INT ( Spells, SpellRecoveryTimer, 3500, "Begins when a cast is complete, an
 RULE_BOOL ( Spells, JamFestAAOnlyAffectsBard, true, "Bard Jam Fest AA only worked on bards themselves but was changed after AK's era.  Changing this to false will put the client stats out of sync with the server.")
 RULE_BOOL ( Spells, ReducePacifyDuration, false, "AK and the eqmac client have 60 tick Pacify (spell 45) duration.  This rule reduces the duration to 7 ticks without desyncing the cast bar and focus effects for custom servers that want this.")
 RULE_BOOL(Spells, ShowDotDmgMessages, false, "Enables LoY-era DoT damage messages. Disabled by default since this didn't exist on Al'Kabor.")
+RULE_BOOL(Spells, RainResist, false, "Enables 20% resist chance for rain spells")
+RULE_BOOL(Spells, RainPreventKill, false, "Enables blocking rain spells from killing npcs")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Combat )

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4094,12 +4094,12 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 	// NPCs use special rules for rain spells in our era.
 	if (IsNPC() && IsRainSpell(spell_id)) {
 		// 20% innate resist
-		if (zone->random.Roll(20)) {
+		if (RuleB(Spells, RainResist) && zone->random.Roll(20)) {
 			return 0;
 		}
 
 		uint8 hp_percent = (uint8)((float)GetHP() / (float)GetMaxHP() * 100.0f);
-		if(target_level > 20 && hp_percent < 10) {
+		if(RuleB(Spells, RainPreventKill) && target_level > 20 && hp_percent < 10) {
 			return 0;
 		}
 	}


### PR DESCRIPTION
They are no longer resisted 20% by default & no longer prevented from killing mobs.

Also added rules in case these end up being too unbalanced so they can be turned back on easily

Tested by setting level to 24, using Lightning Storm, killing Sarnak Recruits. Some resists, but significantly less than before the change.

Also tested by killing orc centurions and legos in Crushbone while at level 24. No resists at all, which is to be expected for lower level mobs.

Also confirmed that this spell breaks root quite often so probably not that useful as a solo spell.

Feature request & discussion can be found here: https://discord.com/channels/1133452007412334643/1234431884004687942

22 upvotes, 4 downvotes but it makes sense to me.  Wizard rain spells have always sucked and this might improve wizards sustained dps slightly in groups.  It also gives them the possibility to burst damage faster, but due to long casting and time spell refresh time it seems like the impact of this will be negligible.

The default value of both rules is false, so the default coded behavior should be turned off with this change. It can be turned back on by adding those rules to the DB and setting them to True