### PR TITLE
Increase drop rate of spider silk for spiders in field of bone

### DIFF
--- a/utils/sql/git/content/2024_10_19_Field_of_Bone_Spiders_Drop_Increase.sql
+++ b/utils/sql/git/content/2024_10_19_Field_of_Bone_Spiders_Drop_Increase.sql
@@ -1,0 +1,31 @@
+-- Get the keys for the lootdrop entries from bonecrawler spider silk drop
+SELECT lde.lootdrop_id, lde.item_id 
+INTO @lootdrop_id, @item_id
+FROM npc_types
+JOIN loottable_entries AS lte ON lte.loottable_id = npc_types.loottable_id
+JOIN lootdrop_entries as lde ON lde.lootdrop_id = lte.lootdrop_id
+JOIN items ON items.id = lde.item_id 
+WHERE npc_types.name = "bonecrawler" AND items.Name = "spider silk"
+LIMIT 1;
+
+SELECT @lootdrop_id, @item_id;
+
+UPDATE lootdrop_entries
+SET multiplier = 4
+WHERE lootdrop_id = @lootdrop_id AND item_id = @item_id;
+
+-- Get the keys for the lootdrop entries from bonebinder spider silk drop
+SELECT lde.lootdrop_id, lde.item_id 
+INTO @lootdrop_id, @item_id
+FROM npc_types
+JOIN loottable_entries AS lte ON lte.loottable_id = npc_types.loottable_id
+JOIN lootdrop_entries as lde ON lde.lootdrop_id = lte.lootdrop_id
+JOIN items ON items.id = lde.item_id 
+WHERE npc_types.name = "a_bonebinder" AND items.Name = "spider silk"
+LIMIT 1;
+
+SELECT @lootdrop_id, @item_id;
+
+UPDATE lootdrop_entries
+SET multiplier = 4
+WHERE lootdrop_id = @lootdrop_id AND item_id = @item_id;


### PR DESCRIPTION
Increase from max 2 to max 4.

Change was already made on takp, but waiting on merge.  I figured I'd go ahead and implement it here since it'll be such a boon for the cash poor iksar newbs.

Discussion thread: https://discord.com/channels/1133452007412334643/1291440098260287549

Implemented by changing the multiplier for this lootdrop_entry to 4 from 2.

Tested by running the script, restarting field of bone, running around doing `#npcloot show` to all  of the spiders to confirm they have 0 - 4 silks.

Also double confirmed by changing the multiplier value to 100 in the updates & selecting all rows that are 100 and it only showed the spider silk for these two, so can confirm it only updated those two rows