### PR TITLE
Update wizard rain spells to have 0 innate resist

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -381,8 +381,8 @@ RULE_INT ( Spells, SpellRecoveryTimer, 3500, "Begins when a cast is complete, an
 RULE_BOOL ( Spells, JamFestAAOnlyAffectsBard, true, "Bard Jam Fest AA only worked on bards themselves but was changed after AK's era.  Changing this to false will put the client stats out of sync with the server.")
 RULE_BOOL ( Spells, ReducePacifyDuration, false, "AK and the eqmac client have 60 tick Pacify (spell 45) duration.  This rule reduces the duration to 7 ticks without desyncing the cast bar and focus effects for custom servers that want this.")
 RULE_BOOL(Spells, ShowDotDmgMessages, false, "Enables LoY-era DoT damage messages. Disabled by default since this didn't exist on Al'Kabor.")
-RULE_BOOL(Spells, RainResist, false, "Enables 20% resist chance for rain spells")
 RULE_BOOL(Spells, RainPreventKill, false, "Enables blocking rain spells from killing npcs")
+RULE_INT ( Spells, RainWizardResistChance, 0, "Chance for wizard rain spells to get resisted automatically")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Combat )

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4093,8 +4093,14 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 
 	// NPCs use special rules for rain spells in our era.
 	if (IsNPC() && IsRainSpell(spell_id)) {
-		// 20% innate resist
-		if (RuleB(Spells, RainResist) && zone->random.Roll(20)) {
+
+		int resist_chance_percentage = 20;
+		if(caster->GetClass() == WIZARD) {
+			resist_chance_percentage = RuleI(Spells, RainWizardResistChance);
+		}
+		
+		// 20% innate resist for most classes
+		if (zone->random.Roll(resist_chance_percentage)) {
 			return 0;
 		}
 


### PR DESCRIPTION
Related suggestion: https://discord.com/channels/1133452007412334643/1234431884004687942

Related previous PR: https://github.com/SecretsOTheP/EQMacEmu/pull/185

Changed it so only wizards will skip the 20% required resist for poison rain.

Tested by making a wizard lvl 24, gm mode off, casting rain spell on greens, no resists after 20+ attempts

Tested lvl 60 shaman using lvl 24 rain spell, gm off, cast rain on same greens in FoB pit, resists about 20% of the time