### PR TITLE
Fix songs to expire consistently on server tick rather than client tick

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2786,7 +2786,14 @@ void Mob::BuffProcess()
 			{
 				if(buffs[buffs_i].UpdateClient == true)
 				{
-					CastToClient()->SendBuffDurationPacket(buffs[buffs_i].spellid, buffs[buffs_i].ticsremaining, buffs[buffs_i].casterlevel, buffs_i, buffs[buffs_i].instrumentmod);
+					int client_packet_duration = buffs[buffs_i].ticsremaining;
+					if (IsShortDurationBuff(buffs[buffs_i].spellid)) {
+						// This packet adjustment fixes the client so songs expire consistently on the server tick, rather than on the desync'd client tick.
+						// This was cutting nearly every song duration short by a fixed 0-6s amount until you zone, depending how desync'd the client tick was.
+						// Can eventually remove this if we can get Zeal to implement way to sync client ticks to the server.
+						client_packet_duration++;
+					}
+					CastToClient()->SendBuffDurationPacket(buffs[buffs_i].spellid, client_packet_duration, buffs[buffs_i].casterlevel, buffs_i, buffs[buffs_i].instrumentmod);
 					buffs[buffs_i].UpdateClient = false;
 				}
 			}


### PR DESCRIPTION
This packet adjustment fixes the client so songs expire consistently on the server tick, rather than on the desynced client tick.
- Server makes the client think/notice the song is 18 sec duration (+1 tick), so the client will wait for the server to expire the buff.
- No changes to the actual buff expiration logic on the server, this is only a visual/info change sent to the client to make it behave.

Eventually maybe we can get Zeal to implement a way to sync client ticks to the server, which would fix how the buff timers are decrementing independently of the server ticks.

## Tested
- Buffs properly expire on the server tick (white bar).
![TickDemo](https://github.com/user-attachments/assets/c90a4de7-e625-4171-ac57-2c16adf36736)

## Before
Based on when you logged in, your client tick desync would affect nearly every song duration until you logout/zone. If you had a bad client tick, every song would have a shorter duration until you kept resetting your client tick until you got a decent one that lined up well with the server.

### PlayerA (unlucky)
Has a really bad client-tick. All songs expire very early in the final tick. Songs last about 12sec consistently.
```
|-------------|-------------|-------------|-------------|
            ^ Applied                       ^ Expires
```

### PlayerB (lucky)
Has a pretty good client-tick. All songs last nearly the full final tick. Songs last about 17-ish sec.
```
|-------------|-------------|-------------|-------------|
            ^ Applied                                  ^ Expires
```

## After
Now, regardless of client tick desync, always expires fairly at the server tick, so there is no more RNG based on how screwed up your client tick is.
```
|-------------|-------------|-------------|-------------|
            ^ Applied                                   ^ Expires
```