### PR TITLE
Cache server quake times and unrestrict use of showquake command.

### DIFF
--- a/common/database.h
+++ b/common/database.h
@@ -232,6 +232,7 @@ public:
 	void LoadQuakeData(ServerEarthquakeImminent_Struct & earthquake_struct);
 	bool LoadNextQuakeTime(ServerEarthquakeImminent_Struct &realtime);
 	bool SaveNextQuakeTime(ServerEarthquakeImminent_Struct & earthquake_struct, QuakeType in_quake_type = QuakeType::QuakeNormal);
+	bool UpdateQuakeTime(const ServerEathquakeImminent_Struct& earthquake_struct);
 	bool	SaveTime(int8 minute, int8 hour, int8 day, int8 month, int16 year);
 	bool	AdjustSpawnTimes();
 	uint8   GetZoneRandomLoc(uint32 zoneid);
@@ -242,6 +243,7 @@ private:
 	std::map<std::string, std::string>	zonename_filename_array;
 	Mutex Mvarcache;
 	VarCache_Struct varcache;
+	ServerEarthquakeImminent_Struct quake_time_cache;
 
 	/* Groups, utility methods. */
 	void    ClearAllGroupLeaders();

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -393,7 +393,7 @@ int command_init(void)
 		command_add("showhelm", "on/off [all] Toggles displaying of player helms (including your own.) Specifying 'all' toggles every character currently on your account", AccountStatus::Player, command_showhelm) ||
 		command_add("showlootlockouts", "- Shows your currently active loot lockouts. These do not apply to earthquake creatures.", AccountStatus::Player, command_showlootlockouts) ||
 		command_add("showpetspell", "[spellid/searchstring] - search pet summoning spells.", AccountStatus::Guide, command_showpetspell) ||
-		command_add("showquake", "- Shows current earthquake timer. Requires you to be a guild officer or leader.", AccountStatus::Player, command_showquake) ||
+		command_add("showquake", "- Shows current earthquake timer.", AccountStatus::Player, command_showquake) ||
 		command_add("showregen", "- Shows information about your target's regen.", AccountStatus::GMAdmin, command_showregen) ||
 		command_add("showskills", "- Show the values of your skills if no target, or your target's skills.", AccountStatus::Guide, command_showskills) ||
 		command_add("showspellslist", "Shows spell list of targeted NPC.", AccountStatus::GMStaff, command_showspellslist) ||
@@ -4204,23 +4204,10 @@ void command_showquake(Client *c, const Seperator *sep)
 {
 	if (!c)
 		return;
-	
-	if (c->GuildID() == GUILD_NONE)
-	{
-		c->Message(Chat::Default, "You must be part of a guild to use this command.");
-		return;
-	}
-
-	if (c->GuildRank() == 0)
-	{
-		c->Message(Chat::Default, "You must be an officer rank or higher to use this command.");
-		return;
-	}
 
 	if (zone)
 	{
 		ServerEarthquakeImminent_Struct quake_struct;
-		memset(&quake_struct, 0, sizeof(ServerEarthquakeImminent_Struct));
 		database.LoadQuakeData(quake_struct);
 		int64 nextQuakeTime = quake_struct.next_start_timestamp;
 		int64 curTime = Timer::GetTimeSeconds();


### PR DESCRIPTION
Cache the server quake time on `LoadNextQuakeTime`, and any time the DB entry is updated.

Make showquake command get data from the cached values instead, and open up access to the command to all