### PR TITLE
Update monk kurn fingers to drop 50% chance instead of 100%

### DIFF
--- a/utils/sql/git/content/2024_10_30_Balance_Iksar_Monk_Kurns_Fingers.sql
+++ b/utils/sql/git/content/2024_10_30_Balance_Iksar_Monk_Kurns_Fingers.sql
@@ -1,0 +1,23 @@
+-- Update drop chance to 50% for all fingers because right now you can complete the quest in 24-30 minutes, increases it to ~1 hour which is more in line with the new update for the shaman skulls
+
+SELECT lde.lootdrop_id
+INTO @lootdrop_id
+FROM npc_types
+JOIN loottable_entries AS lte ON lte.loottable_id = npc_types.loottable_id
+JOIN lootdrop_entries as lde ON lde.lootdrop_id = lte.lootdrop_id
+JOIN items ON items.id = lde.item_id 
+WHERE npc_types.name = "fingered_skeleton" AND items.Name LIKE "%Finger"
+LIMIT 1;
+
+UPDATE lootdrop_entries
+SET chance = 50
+WHERE lootdrop_id = @lootdrop_id;
+
+-- Helpful query for verifying results
+
+-- SELECT npc_types.name, items.Name, lte.*, lde.*
+-- FROM npc_types
+-- JOIN loottable_entries AS lte ON lte.loottable_id = npc_types.loottable_id
+-- JOIN lootdrop_entries as lde ON lde.lootdrop_id = lte.lootdrop_id
+-- JOIN items ON items.id = lde.item_id 
+-- WHERE npc_types.name = "fingered_skeleton";


### PR DESCRIPTION
It was only taking 30 minutes on average to complete and now will be 1 hour on average to bring it in line with the shaman iksar skulls of similar difficulty

Drop rate was also increased previously & that change is staying in place, so it's still significantly buffed from the original

Previously was 25% which was deemed too much of a bottleneck

Source link: https://discord.com/channels/1133452007412334643/1294349487765979287

Source link pre-buff: https://discord.com/channels/1133452007412334643/1270799693122895882