### PR TITLE
Add notification to all group members when someone is invited

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5503,12 +5503,21 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 					memcpy(outapp->pBuffer, app->pBuffer, outapp->size);
 					Invitee->CastToClient()->QueuePacket(outapp);
 					safe_delete(outapp);
-					return;
 				}
 				else
 				{
 					//The correct opcode, no reason to bother wasting time reconstructing the packet
 					Invitee->CastToClient()->QueuePacket(app);
+				}
+
+				// TODO: Send message to all group members that the invite happened
+				Group* group = GetGroup();
+				if(group != nullptr) 
+				{
+					uint8 language = 0;
+					uint8 lang_skill = 100;
+					std::string message = StringFormat("Invited %s to the group.", Invitee->CastToClient()->GetCleanName());
+					group->GroupMessage(this, language, lang_skill, message.c_str());
 				}
 			}
 			else if (Invitee->IsRaidGrouped())


### PR DESCRIPTION
Suggestion Link: https://discord.com/channels/1133452007412334643/1293991185844539494

Tested by launching 3 clients. First client starts group with 2nd client.  First client invites 3rd client, observe 2nd client sees a message that 3rd client was invited.