### PR TITLE
Fix typo in monk thunderkick discipline

### DIFF
--- a/utils/sql/git/content/2024_10_31_Fix_Monk_Thunderkick_Typo.sql
+++ b/utils/sql/git/content/2024_10_31_Fix_Monk_Thunderkick_Typo.sql
@@ -1,0 +1,3 @@
+UPDATE spells_new
+SET cast_on_you = "Your feet glow with mystic power."
+WHERE ID = 4511;


### PR DESCRIPTION
This apparently might not be classic, but seems like it would make sense to fix it

Bug report: https://discord.com/channels/1133452007412334643/1301306881209270343