### PR TITLE
Add support for any lighted item to shine from inventory slots

### DIFF
--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -959,7 +959,9 @@ uint8 EQ::InventoryProfile::FindBrightestLightType()
 		if (item == nullptr) { continue; }
 
 		if (item->ItemClass != item::ItemClassCommon) { continue; }
-		if (item->Light < 9 || item->Light > 13) { continue; }
+
+		// Custom Quarm - Allow any item with a light on it to shine light from general inventory slots
+		if (item->Light == 0) { continue; }
 
 		if (lightsource::TypeToLevel(item->Light))
 			general_light_type = item->Light;

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -1723,7 +1723,8 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	} 
 	else
 	{
-		database.SaveInventory(character_id, m_inv.GetItem(dst_slot_id), dst_slot_id);
+		const EQ::ItemInstance* dst_item_instance = m_inv.GetItem(dst_slot_id);
+		database.SaveInventory(character_id, dst_item_instance, dst_slot_id);
 
 		// When we have a bag on the cursor filled with items that is new (zoned with it, summoned it, picked it up from the ground)
 		// the client is only aware of the bag. So, we have to send packets for each item within the bag once it is placed in the inventory.
@@ -1741,6 +1742,15 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 					SendItemPacket(trade_bag_slot, inst, ItemPacketTrade);
 				}
 			}
+		}
+
+		// My attempt to get the lighting update to be pushed to the client
+		// However, it doesn't seem to work, so I think there may be client changes required for this
+		if(dst_item_instance->GetItem()->Light > 0)
+		{
+			UpdateEquipmentLight();
+			UpdateActiveLight();
+			SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 		}
 	}
 


### PR DESCRIPTION
This will include the suggestion made for Staff of Null as well as other lighted items like candles, etc

This was working with a certain set of items like Greater Lightstone already, but I think it's hardcoded into the client to update those and not others.  I couldn't find a reason why the light was updating via server code for Greater Lightstone when it was put into an inventory slot using logs.

Instead of this, whenever an item is put into the general inventory, if it has light, we check to see if the client's light source should be updated and if so, then send the packet to update.

Suggestion thread: https://discord.com/channels/1133452007412334643/1277581221697814538