### PR TITLE
Update sarnak courier named item drops from 2->4%

### DIFF
--- a/utils/sql/git/content/2024_11_02_Increase_Sarnak_Courier_Droprate.sql
+++ b/utils/sql/git/content/2024_11_02_Increase_Sarnak_Courier_Droprate.sql
@@ -1,0 +1,17 @@
+-- Courier currently drops a few named items including the ring everyone wants
+-- Increase all of those from 1-3% -> 4%.  Ring goes from 2% -> 4%
+-- Keep sarnak blood the same (10%)
+
+UPDATE lootdrop_entries AS lde
+JOIN items ON lde.item_id = items.id
+SET chance = 4
+WHERE lde.lootdrop_id = 105798 AND items.Name <> "Sarnak Blood";
+
+-- Helpful query
+
+-- SELECT npc_types.name, items.Name, lte.*, lde.*
+-- FROM npc_types
+-- JOIN loottable_entries AS lte ON lte.loottable_id = npc_types.loottable_id
+-- JOIN lootdrop_entries as lde ON lde.lootdrop_id = lte.lootdrop_id
+-- JOIN items ON items.id = lde.item_id 
+-- WHERE npc_types.name = "a_sarnak_courier";


### PR DESCRIPTION
This includes the goblin ring that everyone wants for clicky charm breaks.

The courier spawn is super rare still, so this will only make the camp slightly better, but hopefully this will still be an improvement for people spending 10s of hours on this.

Even with spawn rate of 100% chance, it was still a challenge for me to find the couriers when I would repop the entire zone and run around with GM speed.

Tested by summoning a ton of couriers & using #npcloot show to see what items they had.  Seemed like the distribution was as expected.  Many with no items, a handful with just 1 named item drop

Suggestion thread: https://discord.com/channels/1133452007412334643/1262033570185089098