### PR TITLE
Update group invite to notify sender too

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5518,6 +5518,8 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 					uint8 lang_skill = 100;
 					std::string message = StringFormat("Invited %s to the group.", Invitee->CastToClient()->GetCleanName());
 					group->GroupMessage(this, language, lang_skill, message.c_str());
+					message = StringFormat("You tell your party, '%s'", message.c_str());
+					Message(Chat::White, message.c_str());
 				}
 			}
 			else if (Invitee->IsRaidGrouped())


### PR DESCRIPTION
Currently it sends a message to each member of the group that you invited someone, but you as the sender don't know that.  This updates it so the sender now knows there's an automated message being sent

Bug report: https://discord.com/channels/1133452007412334643/1161485739293429830/1302192136141279242