### PR TITLE
Polish/allow sow to not block selos

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1376,7 +1376,17 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* ne
 			}
 
 			case SE_MovementSpeed:
-				new_bonus->movementspeed += effect_value;
+				// Handle specific case for Selo's Accelerando and Spirit of the Wolf
+				// It should use the max of either of these two
+				if (spell_id == 717 || spell_id == 278) 
+				{
+					new_bonus->movementspeed = std::max(new_bonus->movementspeed, effect_value);
+				} 
+				else 
+				{
+					new_bonus->movementspeed += effect_value;
+				}
+				Log(Logs::Detail, Logs::Spells, "Mob %s has movement speed bonus of %d from spell %d New movement speed: %d", GetName(), effect_value, spell_id, new_bonus->movementspeed);
 				break;
 
 			case SE_SpellDamageShield:

--- a/zone/buffstacking.cpp
+++ b/zone/buffstacking.cpp
@@ -572,12 +572,9 @@ int Mob::FindAffectSlot(Mob *caster, uint16 spell_id, int *result_slotnum, int r
 	{
 		if (new_spelldata->goodEffect
 			&& GetSpellEffectIndex(new_spelldata->id, SE_MovementSpeed) != -1
-			&& GetSpellEffectIndex(old_spelldata->id, SE_MovementSpeed) != -1
-			|| new_spelldata->goodEffect
-			&& GetSpellEffectIndex(new_spelldata->id, SE_MovementSpeed) != -1
 			&& GetSpellEffectIndex(old_spelldata->id, SE_Root) != -1)
 		{
-			goto BLOCKED_BUFF;                        // Bard Selos can't overwrite regular SoW type spell or rooting illusion
+			goto BLOCKED_BUFF;                        // Bard Selos can't overwrite rooting illusion
 		}
 
 		// generally, bard songs stack with anything that's not a bard song


### PR DESCRIPTION
Spent some time trying to figure out how to implement the suggestion that selos should be able to appear on the buff bar alongside Spirit of Wolf and then the movementspeed of the character should be whichever is higher.

With these changes, I get the message "your feet move faster" when I cast selos even when I have SoW on, which is good.  However, the buff doesn't show up on the buff bar and the movement speed isn't actually modified.

Despite this, the code for running the speed modification does actually run & apply selos overwriting sow speed instead of adding to it.

The weird part is that if I shutdown the client while both are on & then re-login, I see SoW in slot 0 and Selos in slot 1!  I also see the movement speed is increased to selos speed until the buff wears off and then I return to sow speed & clicking that off returns to normal speed.

So technically the code is working properly, but for some reason the client doesn't add the buff to the buff bar and respect the movement speed change unless it's rebooted.

I can see there's a packet being sent to the client in `AssignBuffSlot` but this doesn't include the slot ID and the comment mentions that we are trying to sync it up with the client behavior.

So this makes me think that maybe there's a client change that's required as well?

Otherwise, we might need a way to re-sync all of the buffs when selos is applied.

I've attached logs from the different scenarios I've described here.

[logging in with both applied.txt](https://github.com/user-attachments/files/17626379/logging.in.with.both.applied.txt)
[selos only.txt](https://github.com/user-attachments/files/17626380/selos.only.txt)
[sow and selos.txt](https://github.com/user-attachments/files/17626381/sow.and.selos.txt)
