### PR TITLE
Remove faction from Verina Tomb

### DIFF
--- a/utils/sql/git/content/2024_11_05_Remove_Verina_Tomb_Faction.sql
+++ b/utils/sql/git/content/2024_11_05_Remove_Verina_Tomb_Faction.sql
@@ -1,0 +1,11 @@
+-- Remove the faction from Verina Tomb so that she is not KOS to players.
+-- Resolves issue with Human clerics of innoruuk being KOS and dying while trying to get spells and train
+UPDATE npc_types
+SET npc_faction_id = 0
+WHERE name = "Verina_Tomb";
+
+-- Helpful query to find the npc_faction_id of a specific NPC:
+
+-- SELECT id, name, npc_faction_id
+-- FROM npc_types
+-- WHERE id = 42112;


### PR DESCRIPTION
Resolves Suggestion https://discord.com/channels/1133452007412334643/1280584443752353801

The major problem with this is that human clerics of Innoruuk are sent to Neriak as their primary guild and have to walk right past her to do quests and buy spells.

Those clerics were getting killed bc she's always up now due to easy epics