### PR TITLE
Add support for /who all for selffound hardcore & solo

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -415,6 +415,9 @@ struct ServerClientList_Struct {
 	bool	AFK;
 	bool	Trader;
 	int8	Revoked;
+	bool	selffound;
+	bool	hardcore;
+	bool	solo;
 };
 
 struct ServerClientListKeepAlive_Struct {

--- a/world/cliententry.cpp
+++ b/world/cliententry.cpp
@@ -214,6 +214,9 @@ void ClientListEntry::Update(ZoneServer* iZS, ServerClientList_Struct* scl, int8
 	pAFK = scl->AFK;
 	pTrader = scl->Trader;
 	pRevoked = scl->Revoked;
+	pSelfFound = scl->selffound;
+	pHardcore = scl->hardcore;
+	pSolo = scl->solo;
 
 	// Fields from the LFG Window
 	if((scl->LFGFromLevel != 0) && (scl->LFGToLevel != 0)) {

--- a/world/cliententry.h
+++ b/world/cliententry.h
@@ -95,6 +95,9 @@ public:
 	inline bool		AFK() const { return pAFK;  }
 	inline bool		Trader() const { return pTrader; }
 	inline int8		Revoked() const { return pRevoked; }
+	inline bool		IsSelfFound() const { return pSelfFound; }
+	inline bool		IsHardcore() const { return pHardcore; }
+	inline bool		IsSolo() const { return pSolo; }
 
 	inline bool TellQueueFull() const { return tell_queue.size() >= RuleI(World, TellQueueSize); }
 	inline bool TellQueueEmpty() const { return tell_queue.empty(); }
@@ -152,6 +155,9 @@ private:
 	bool	pAFK;
 	bool	pTrader;
 	int8	pRevoked;
+	bool	pSelfFound;
+	bool	pHardcore;
+	bool	pSolo;
 
 	// Tell Queue -- really a vector :D
 	std::vector<ServerChannelMessage_Struct *> tell_queue;

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -32,6 +32,7 @@
 #include "../zone/string_ids.h"
 
 #include <set>
+#include <cstring>  // For strlen and strncat
 
 extern ConsoleList		console_list;
 extern ZSList			zoneserver_list;
@@ -891,6 +892,40 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 				char plname[64] = { 0 };
 				strcpy(plname, cle->name());
 
+				// Append the SSFHC flags after the name if there's room
+				if(cle->IsSelfFound() || cle->IsHardcore() || cle->IsSolo())
+				{
+					// Start with the base append string
+					std::string appendStr = " -";
+
+					if(cle->IsSolo())
+						appendStr += "s";
+					if (cle->IsSelfFound())
+						appendStr += "sf";
+					if (cle->IsHardcore())
+						appendStr += "hc";
+
+					appendStr += "-";
+
+					// Calculate the remaining space in the buffer
+					size_t remainingSpace = 63 - strlen(plname); // 63 because we need one char for null-terminator
+					// Append appendStr to plname if there's enough space
+					if (remainingSpace >= appendStr.length()) {
+						// Append should look like this:
+						strncat(plname, appendStr.c_str(), remainingSpace);
+
+						// To prepend:
+						// char tempBuffer[64];
+						// // First, copy appendStr to tempBuffer
+						// strcpy(tempBuffer, appendStr.c_str());
+						// // Then concatenate plname to tempBuffer
+						// strncat(tempBuffer, plname, remainingSpace);
+						// // Copy back the combined string to plname
+						// strncpy(plname, tempBuffer, 64);
+						// plname[63] = '\0'; // Ensure null-termination
+					}
+				}
+
 				char placcount[30] = { 0 };
 				if (admin >= cle->Admin() && admin >= AccountStatus::QuestTroupe)
 					strcpy(placcount, cle->AccountName());
@@ -1599,6 +1634,9 @@ bool ClientList::WhoAllFilter(ClientListEntry* client, Who_All_Struct* whom, int
 		((tmpZone != 0 && strncasecmp(tmpZone, whom->whom, whomlen) == 0 && not_anon) || //zone (GM only)
 		strncasecmp(client->name(),whom->whom, whomlen) == 0 || // name
 		(strncasecmp(guild_mgr.GetGuildName(client->GuildID()), whom->whom, whomlen) == 0 && guild_not_anon)|| // This is used by who all guild
+		(strstr(whom->whom, "solo") != NULL && client->IsSolo()) || // This is used to search for any players with the solo flag
+		(strstr(whom->whom, "selffound") != NULL && client->IsSelfFound() && !client->IsSolo()) || // This is used to search for any players with the self found flag that aren't solo
+		(strstr(whom->whom, "hardcore") != NULL && client->IsHardcore()) || // This is used to search for any players with the hardcore flag
 		(admin >= gmwholist && strncasecmp(client->AccountName(), whom->whom, whomlen) == 0)))) // account (GM only)
 	{
 		return true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1422,6 +1422,10 @@ void Client::UpdateWho(uint8 remove) {
 	scl->Trader = this->IsTrader();
 	scl->Revoked = this->GetRevoked();
 
+	scl->selffound = this->IsSelfFound();
+	scl->hardcore = this->IsHardcore();
+	scl->solo = this->IsSoloOnly();
+
 	worldserver.SendPacket(pack);
 	safe_delete(pack);
 }


### PR DESCRIPTION
Each of these would be separate commands

These changes were previously submitted, merged and then reversed due to unknown performance issues at the time. I don't think reversing this commit fixed the performance issues, so now that things are more stable, hopefully this can be added again.  Feel free to revert if performance issues come back up and we can take a look at them.

Tested by making multiple characters with different combinations of hardcore, solo and self found flags.

Once they were logged in, used /who all solo, /who all selffound, /who all hardcore to find these players and the filtering was working properly