### PR TITLE
Add Quarm:AutoRaidConsent rule support

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -310,6 +310,7 @@ RULE_STRING(Quarm, ChatShortName, "takp", "")
 RULE_STRING(Quarm, AllianceChannelName, "Alliance", "")
 RULE_STRING(Quarm, AllianceChannelReplacementName, "General", "")
 RULE_INT(Quarm, AllianceChannelLevelRequirement, 10, "")
+RULE_BOOL(Quarm, AutoRaidConsent, false, "Enable automatic granting of temporary corpse consent if in the same raid")
 RULE_CATEGORY_END()
 RULE_CATEGORY( Map )
 //enable these to help prevent mob hopping when they are pathing

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -2098,6 +2098,10 @@ bool Corpse::Summon(Client* client, bool spell, bool CheckDistance) {
 				break;
 			}
 		}
+		if (!consented && client->GetRaid() && RuleB(Quarm, AutoRaidConsent)) {
+			Client* corpse_owner = entity_list.GetClientByName(this->GetOwnerName());
+			consented = (corpse_owner && corpse_owner->GetRaid() == client->GetRaid());
+		}
 		if (!consented) {
 			client->Message_StringID(Chat::White, CONSENT_NONE);
 			return false;


### PR DESCRIPTION
- Adds support for a new rule that automatically allows corpse dragging consent for fellow raid members
- The consent is temporary and only exists while in the same raid
- Defaulted to off (requires active db rule to enable)

This simple PR assumes that it is reasonable to automatically grant corpse dragging consent to all fellow raid members when joining a raid for the duration of the raid.  That assumption seems less valid for guilds (longer duration) and random groups (higher chances of abuse).

Tested by adding to rule_values: 
(1,'Quarm:AutoRaidConsent','true','Enable automatic granting of temporary corpse consent if in the same raid')