### PR TITLE
Fix controllable boat steering / stuttering issues

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3116,9 +3116,15 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app)
 				BoatID = 0;
 				return;
 			}
+
+			auto outapp = new EQApplicationPacket(OP_MobUpdate, sizeof(SpawnPositionUpdates_Struct));
+			SpawnPositionUpdates_Struct* ppus = (SpawnPositionUpdates_Struct*)outapp->pBuffer;
+			boat->SetSpawnUpdate(ppu, &ppus->spawn_update);
+			ppus->num_updates = 1;
+			entity_list.QueueCloseClients(boat, outapp, true, 1000, this, false);
+			safe_delete(outapp);
+					
 			boat->GMMove(ppu->x_pos, ppu->y_pos, ppu->z_pos / 10.f, boat->GetHeading(), false);
-			boat->SendRealPosition();
-			boat->CastToNPC()->SaveGuardSpot();
 			return;
 		}
 		else return;	// if not a boat, do nothing


### PR DESCRIPTION
This update fixes controllable boats by removing visual stutter and making it possible to steer them in different directions, as was possible in classic EQ and P99.

Removed calls to SendRealPosition() and SaveGuardSpot() which were causing hitching/stuttering issues and prevented proper steering.

Instead, send position updates to nearby clients via QueueCloseClients(), in a similar manner to Eye of Zomm code. This seems to achieve the intended aim of the removed function calls (prevents visual desync with other players). Nearby client range currently set to 1000, which is double the range used for of Eye of Zomm code, and close to the max distance that could be seen when testing in OOT. 

Range can be adjusted as needed, or we could instead try QueueClientsPosUpdate() to update all clients regardless of range, but that is untested and I'm unsure of performance implications.

Tested with multiple players controlling boats and all appears to work correctly.