### PR TITLE
Charisma check on  lull resists seems flipped

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5067,7 +5067,7 @@ void Mob::ResistSpell(Mob* caster, uint16 spell_id, bool isProc)
 			// See http://www.eqemulator.org/forums/showthread.php?t=43370
 			int aggroChance = 90 - caster->GetCHA() / 4;
 
-			if (!zone->random.Roll(aggroChance))
+			if (zone->random.Roll(aggroChance))
 			{
 				AddToHateList(caster, aggro);
 				Log(Logs::Detail, Logs::Spells, "ResistSpell(): Lull critical fail; aggro chance was %i.", aggroChance);


### PR DESCRIPTION
Maybe I'm reading this wrong, but it seems like the charisma check for lull resists causing aggro is backward: `!zone->random.Roll(aggroChance)`
If my aggro chance is 100 because I have -40 charisma, then .roll(100) will always return true, and the ! makes it false, so I'd never get aggro. If my aggrochance is 0 (360 CHA). I'd ALWAYS hit the addToHateList block. But Maybe I'm reading this wrong, haven't written C since college