### PR TITLE
Fix some cases where persistent buffs are removed

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1432,3 +1432,11 @@ bool IsDispellableSpell(uint16 spell_id)
 
 	return true;
 }
+
+bool SpellPersistsThroughDeath(uint16 spell_id)
+{
+	if(IsValidSpell(spell_id) && spells[spell_id].persist_through_death == 1)
+		return true;
+
+	return false;	
+}

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -796,5 +796,6 @@ bool IsInstrumentModdableSpellEffect(uint16 spell_id, int effect_index);
 bool IsSplurtFormulaSpell(uint16 spell_id);
 bool IsMGBCompatibleSpell(uint16 spell_id);
 bool IsDispellableSpell(uint16 spell_id);
+bool SpellPersistsThroughDeath(uint16 spell_id);
 
 #endif

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3520,7 +3520,7 @@ void Client::Sacrifice(Client *caster)
 			Client* killer = caster ? caster : nullptr;
 			GenerateDeathPackets(killer, 0, 1768, EQ::skills::SkillAlteration, false, Killed_Sac);
 
-			BuffFadeAll();
+			BuffFadeNonPersistDeath();
 			UnmemSpellAll();
 			Group *g = GetGroup();
 			if(g){

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1589,7 +1589,8 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	for (int i = 0; i < max_slots; i++) 
 	{
 		if ((buffs[i].spellid != SPELL_UNKNOWN && !stripbuffs) ||
-			IsResurrectionEffects(buffs[i].spellid))
+			IsResurrectionEffects(buffs[i].spellid) ||
+			SpellPersistsThroughDeath(buffs[i].spellid))
 		{
 			m_pp.buffs[i].spellid = buffs[i].spellid;
 			m_pp.buffs[i].bard_modifier = buffs[i].instrumentmod;
@@ -1616,7 +1617,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	if(stripbuffs)
 	{
 		Log(Logs::General, Logs::EQMac, "Removing buffs from %s. HP is: %i MaxHP is: %i BaseHP is: %i HP from items is: %i HP from spells is: %i", GetName(), GetHP(), GetMaxHP(), GetBaseHP(), itembonuses.HP, spellbonuses.HP);
-		BuffFadeAll(true);
+		BuffFadeNonPersistDeath(true);
 		SetHP(itembonuses.HP);
 	}
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -277,7 +277,7 @@ public:
 	void BuffFadeBySpellID(uint16 spell_id, bool message = true);
 	void BuffFadeByEffect(int effectid, int skipslot = -1);
 	void BuffFadeAll(bool skiprez = false, bool message = false);
-	void BuffFadeNonPersistDeath();
+	void BuffFadeNonPersistDeath(bool skiprez = false);
 	void BuffFadeDetrimental();
 	void BuffFadeBySlot(int slot, bool iRecalcBonuses = true, bool message = true, bool update = true);
 	void BuffFadeDetrimentalByCaster(Mob *caster);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3509,14 +3509,19 @@ void Mob::BuffFadeAll(bool skiprez, bool message)
 	CalcBonuses();
 }
 
-void Mob::BuffFadeNonPersistDeath()
+void Mob::BuffFadeNonPersistDeath(bool skiprez)
 {
 	int buff_count = GetMaxTotalSlots();
 	for (int j = 0; j < buff_count; j++) {
 		if (buffs[j].spellid != SPELL_UNKNOWN)
 		{
-			if (spells[buffs[j].spellid].persist_through_death != 1)
-				BuffFadeBySlot(j, false, false);
+			if (skiprez && IsResurrectionEffects(buffs[j].spellid))
+				continue;
+			
+			if (SpellPersistsThroughDeath(buffs[j].spellid))
+				continue;
+			
+			BuffFadeBySlot(j, false, false);
 		}
 	}
 	//we tell BuffFadeBySlot not to recalc, so we can do it only once when were done

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -167,7 +167,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 	}
 
 	if (target_zone_id == Zones::AIRPLANE)
-		BuffFadeAll(true);
+		BuffFadeNonPersistDeath(true);
 
 	std::string export_string = fmt::format(
 		"{} {}",


### PR DESCRIPTION
Prevent removal of persistent buffs in the following scenarios:

- Zoning at low HP (where HP bonus from items exceeds remaining HP)
- Zoning into Plane of Air
- Being Sacrificed by another player