### PR TITLE
Add /consent #raid support

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -375,6 +375,7 @@ Client::Client(EQStreamInterface* ieqs) : Mob(
 	ranged_attack_leeway_timer.Disable();
 	last_fatigue = 0;
 	mule_initiated = false;
+	raid_consent = false;
 }
 
 Client::~Client() {
@@ -819,6 +820,14 @@ bool Client::PermaRaceClass(
 	}
 
 	return true;
+}
+
+void Client::SetRaidConsent(bool consent)
+{
+	raid_consent = consent;
+	Raid *r = GetRaid();
+	if (r)
+		r->SetConsent(GetName(), consent);
 }
 
 bool Client::SaveAA(){

--- a/zone/client.h
+++ b/zone/client.h
@@ -286,6 +286,10 @@ public:
 	int GetHandToHandDelay();
 	uint16 GetWeaponEffectID(int slot = EQ::invslot::slotPrimary);
 	
+	// Support for automatically consenting all raid members.
+	void SetRaidConsent(bool consent);
+	bool IsRaidConsent() const { return raid_consent; }
+
 	void PermaGender(uint32 gender);
 
 	float GetQuiverHaste();
@@ -1555,6 +1559,7 @@ private:
 	int8 last_fatigue;
 	bool mule_initiated;
 	uint32 pending_marriage_character_id;
+	bool raid_consent;
 };
 
 #endif

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -470,6 +470,7 @@ void Client::CompleteConnect()
 				raid->SendGroupLeader(gid, this);
 			}
 			raid->SendRaidMembers(this);
+			raid_consent = raid->IsConsent(GetName());  // Restore from raid_members db value.			
 		}
 	}
 	if (!raid) {
@@ -3509,6 +3510,19 @@ void Client::Handle_OP_Consent(const EQApplicationPacket *app)
 		std::transform(gname.begin(), gname.end(), gname.begin(), ::tolower);
 		std::string oname = GetName();
 		std::transform(oname.begin(), oname.end(), oname.begin(), ::tolower);
+
+		// Support consenting of raid members (not stored in the db `character_consent` table).
+		if (!gname.empty() && gname[0] == '#')  // Prefix of # is the special command flag.
+		{
+			if (gname == "#raid on")
+				SetRaidConsent(true);
+			else if (gname == "#raid off")
+				SetRaidConsent(false);
+			else if (gname == "#raid")
+				SetRaidConsent(!IsRaidConsent());
+			Message(Chat::White, "Auto-raid consent set to %s", IsRaidConsent() ? "on" : "off");
+			return;
+		}
 
 		if (GetCorpseCount() < 1)
 		{

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -2098,6 +2098,8 @@ bool Corpse::Summon(Client* client, bool spell, bool CheckDistance) {
 				break;
 			}
 		}
+		if (!consented && client->GetRaid() && client->GetRaid()->IsConsent(this->GetOwnerName()))
+			consented = true;		
 		if (!consented) {
 			client->Message_StringID(Chat::White, CONSENT_NONE);
 			return false;

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -66,6 +66,7 @@ struct RaidMember{
 	bool IsGuildOfficer;
 	bool IsRaidLeader;
 	bool IsLooter;
+	bool IsConsent;	
 };
 
 class Raid : public GroupIDConsumer {
@@ -99,6 +100,8 @@ public:
 	bool	IsRaidMember(const char *name);
 	void	UpdateLevel(const char *name, int newLevel);
 	void	UpdatePlayer(Client* update);
+	void	SetConsent(const char *name, bool grant_consent_to_raid_members);
+	bool	IsConsent(const char *name) const;	
 
 	uint32	GetFreeGroup();
 	uint8	GroupCount(uint32 gid);


### PR DESCRIPTION
If approved, Zeal would add an options toggle that would automatically send a `/raid #consent on` command before joining a raid.

Non-zeal users can simply type `/consent #raid on` to consent when desired.

-----
Enable support for granting consent automatically to all raid members using a new column in the `raid_members` table

/consent #raid on: Enables auto-raid consent
/consent #raid off: Disables auto-raid consent
/consent #raid: Toggles auto-raid consent

Requires the addition of an `is_consent` column to the `raid_members` player database table (tinyint(1), default 0)

The commands control flags in the client which are used when joining a raid to set the is_consent value.

Supports granting and revoking consent across zones.