### PR TITLE
Feature - S/SF charm pet item loot support.

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -410,6 +410,7 @@ SET(common_headers
 	profanity_manager.h
 	profiler.h
 	ptimer.h
+	quarm_item_data.h
 	queue.h
 	races.h
 	random.h

--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -1253,3 +1253,31 @@ int16 EQ::InventoryProfile::_HasItemByUse(ItemInstQueue& iqueue, uint8 use, uint
 
 	return INVALID_INDEX;
 }
+
+void EQ::InventoryProfile::MarkItemsSelfFound(uint32 self_found_character_id, const char* character_name)
+{
+	for (auto& kv : m_worn) {
+		if (kv.second) {
+			kv.second->SetSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+	for (auto& kv : m_inv) {
+		if (kv.second) {
+			kv.second->SetSelfFoundCharacter(self_found_character_id, character_name);
+			kv.second->SetContentsSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+	for (auto& kv : m_bank) {
+		if (kv.second) {
+			kv.second->SetSelfFoundCharacter(self_found_character_id, character_name);
+			kv.second->SetContentsSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+	for (auto iter = m_cursor.cbegin(); iter != m_cursor.cend(); ++iter) {
+		EQ::ItemInstance* inst = *iter;
+		if (inst != nullptr) {
+			inst->SetSelfFoundCharacter(self_found_character_id, character_name);
+			inst->SetContentsSelfFoundCharacter(self_found_character_id, character_name);
+		}
+	}
+}

--- a/common/inventory_profile.h
+++ b/common/inventory_profile.h
@@ -170,6 +170,8 @@ namespace EQ
 		void SetCustomItemData(uint32 character_id, int16 slot_id, std::string identifier, float value);
 		void SetCustomItemData(uint32 character_id, int16 slot_id, std::string identifier, bool value);
 		std::string GetCustomItemData(int16 slot_id, std::string identifier);
+
+		void MarkItemsSelfFound(uint32 self_found_character_id, const char* character_name);
 	protected:
 		///////////////////////////////
 		// Protected Methods

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -30,6 +30,7 @@ class ItemParse;			// Parses item packets
 #include "../common/timer.h"
 #include "../common/deity.h"
 #include "../common/memory_buffer.h"
+#include "../common/quarm_item_data.h"
 
 #include <list>
 #include <map>
@@ -68,9 +69,9 @@ namespace EQ
 		/////////////////////////
 
 		// Constructors/Destructor
-		ItemInstance(const EQ::ItemData* item = nullptr, int8 charges = 0);
+		ItemInstance(const EQ::ItemData* item = nullptr, int8 charges = 0, const QuarmItemData& custom_data = EmptyQuarmItemData);
 
-		ItemInstance(SharedDatabase* db, int16 item_id, int8 charges = 0);
+		ItemInstance(SharedDatabase* db, int16 item_id, int8 charges = 0, const QuarmItemData& custom_data = EmptyQuarmItemData);
 
 		ItemInstance(ItemInstTypes use_type);
 
@@ -150,6 +151,15 @@ namespace EQ
 		void SetCustomData(std::string identifier, bool value);
 		void DeleteCustomData(std::string identifier);
 
+		// Quarm-specific data that we store per-ItemInstance
+		const QuarmItemData& GetQuarmItemData() const { return m_quarm_item_data; }
+		QuarmItemData& GetQuarmItemData() { return m_quarm_item_data; }
+
+		uint32 GetSelfFoundCharacterID() const { return m_quarm_item_data.GetSelfFoundCharacterID(); }
+		void SetSelfFoundCharacter(uint32 self_found_character_id, const char* name) { m_quarm_item_data.SetSelfFoundCharacter(m_item, self_found_character_id, name); }
+		void SetContentsSelfFoundCharacter(uint32 id, const char* name);
+		bool IsMatchingSelfFoundCharacterID(uint32 self_found_character_id, bool check_all_bag_contents) const;
+
 		// Allows treatment of this object as though it were a pointer to m_item
 		operator bool() const { return (m_item != nullptr); }
 
@@ -204,6 +214,7 @@ namespace EQ
 		std::map<uint8, ItemInstance*>			m_contents; // Zero-based index: min=0, max=9
 		std::map<std::string, std::string>	m_custom_data;
 		std::map<std::string, ::Timer>		m_timers;
+		QuarmItemData                       m_quarm_item_data; // Quarm-specific data that we store per-ItemInstance
 	};
 }
 

--- a/common/loot.h
+++ b/common/loot.h
@@ -4,6 +4,7 @@
 #include <list>
 #include <string>
 #include "types.h"
+#include "quarm_item_data.h"
 
 struct LootItem {
 	uint32	item_id;	  // uint32	item_id;
@@ -17,6 +18,9 @@ struct LootItem {
 	bool	forced;
 	uint8	min_looter_level;
 	uint32	item_loot_lockout_timer;
+	QuarmItemData quarm_item_data;
+
+	uint32 GetSelfFoundCharacterID() const { return quarm_item_data.GetSelfFoundCharacterID(); }
 };
 
 typedef std::list<LootItem* > LootItems;

--- a/common/quarm_item_data.h
+++ b/common/quarm_item_data.h
@@ -1,0 +1,42 @@
+#ifndef QUARM_ITEM_DATA_H
+#define QUARM_ITEM_DATA_H
+
+#include <string>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <cstring>
+#include "types.h"
+#include "item_data.h"
+
+// This is extra data that we keep per-instance on items to support Quarm-specific features.
+// This struct is meant to be a trivially copiable.
+// This structure is passed through between ItemInstances, LootItems, and ground Objects to preserve the attributes when an item is dropped, traded to (or looted from) an NPC.
+struct QuarmItemData {
+
+	uint32 self_found_character_id = 0;
+	char self_found_character_name[32] = { 0 };
+
+	static bool IsSupportsSelfFound(const EQ::ItemData* item) { return item && !item->Stackable; }
+
+	bool HasSelfFoundCharacterID() const { return self_found_character_id != 0; }
+	uint32 GetSelfFoundCharacterID() const { return self_found_character_id; }
+	bool HasSelfFoundCharacterName() const { return self_found_character_name[0] != 0; }
+
+	void SetSelfFoundCharacter(const EQ::ItemData* item, uint32 in_self_found_character_id, const char* in_name)
+	{
+		if (!self_found_character_id && in_self_found_character_id && IsSupportsSelfFound(item)) {
+			// Only sets the SF character data if it hasn't already been set.
+			self_found_character_id = in_self_found_character_id;
+			if (in_name && in_name[0]) {
+				strncpy(self_found_character_name, in_name, sizeof(self_found_character_name) - 1);
+				self_found_character_name[sizeof(self_found_character_name) - 1] = '\0';
+			}
+		}
+	}
+
+};
+
+static const QuarmItemData EmptyQuarmItemData = QuarmItemData();
+
+#endif /*QUARM_ITEM_DATA_H*/

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -323,6 +323,11 @@ RULE_BOOL(Quarm, PreNerfSneakHide, true, "This should be false during Luclin.")
 RULE_BOOL(Quarm, ProjectSpeedieBroadcastUnknownZone, true, "")
 RULE_INT(Quarm, BeastlordMaxLevel, 30, "")
 RULE_CATEGORY_END()
+
+RULE_CATEGORY(SelfFound)
+RULE_BOOL(SelfFound, PetLootSupport, true, "Allow solo/self-found players to loot their own SF items back from pet/npc corpses. This allows SF players to recover their items they gave to charmed pets.")
+RULE_CATEGORY_END()
+
 RULE_CATEGORY( Map )
 //enable these to help prevent mob hopping when they are pathing
 RULE_BOOL ( Map, FixPathingZWhenLoading, true, "increases zone boot times a bit to reduce hopping.")

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1001,14 +1001,14 @@ std::string SharedDatabase::GetBook(const char *txtfile)
 }
 
 // Create appropriate ItemInst class
-EQ::ItemInstance* SharedDatabase::CreateItem(uint32 item_id, int8 charges)
+EQ::ItemInstance* SharedDatabase::CreateItem(uint32 item_id, int8 charges, const QuarmItemData& quarm_item_data)
 {
 	const EQ::ItemData* item = nullptr;
 	EQ::ItemInstance* inst = nullptr;
 
 	item = GetItem(item_id);
 	if (item) {
-		inst = CreateBaseItem(item, charges);
+		inst = CreateBaseItem(item, charges, quarm_item_data);
 
 		if (inst == nullptr) {
 			LogError("Error: valid item data returned a null reference for EQ::ItemInstance creation in SharedDatabase::CreateItem()");
@@ -1022,11 +1022,11 @@ EQ::ItemInstance* SharedDatabase::CreateItem(uint32 item_id, int8 charges)
 
 
 // Create appropriate ItemInst class
-EQ::ItemInstance* SharedDatabase::CreateItem(const EQ::ItemData* item, int8 charges)
+EQ::ItemInstance* SharedDatabase::CreateItem(const EQ::ItemData* item, int8 charges, const QuarmItemData& quarm_item_data)
 {
 	EQ::ItemInstance* inst = nullptr;
 	if (item) {
-		inst = CreateBaseItem(item, charges);
+		inst = CreateBaseItem(item, charges, quarm_item_data);
 
 		if (inst == nullptr) {
 			LogError("Error: valid item data returned a null reference for EQ::ItemInstance creation in SharedDatabase::CreateItem()");
@@ -1038,7 +1038,7 @@ EQ::ItemInstance* SharedDatabase::CreateItem(const EQ::ItemData* item, int8 char
 	return inst;
 }
 
-EQ::ItemInstance* SharedDatabase::CreateBaseItem(const EQ::ItemData* item, int8 charges)
+EQ::ItemInstance* SharedDatabase::CreateBaseItem(const EQ::ItemData* item, int8 charges, const QuarmItemData& quarm_item_data)
 {
 	EQ::ItemInstance* inst = nullptr;
 	if (item) {
@@ -1047,7 +1047,7 @@ EQ::ItemInstance* SharedDatabase::CreateBaseItem(const EQ::ItemData* item, int8 
 		if (charges == 0 && item->MaxCharges == -1)
 			charges = 1;
 
-		inst = new EQ::ItemInstance(item, charges);
+		inst = new EQ::ItemInstance(item, charges, quarm_item_data);
 
 		if (inst == nullptr) {
 			LogError("Error: valid item data returned a null reference for EQ::ItemInstance creation in SharedDatabase::CreateBaseItem()");

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -75,9 +75,9 @@ public:
 	/*
 	* Item Methods
 	*/
-	EQ::ItemInstance* CreateItem(uint32 item_id, int8 charges=0);
-	EQ::ItemInstance* CreateItem(const EQ::ItemData* item, int8 charges=0);
-	EQ::ItemInstance* CreateBaseItem(const EQ::ItemData* item, int8 charges=0);
+	EQ::ItemInstance* CreateItem(uint32 item_id, int8 charges=0, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
+	EQ::ItemInstance* CreateItem(const EQ::ItemData* item, int8 charges=0, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
+	EQ::ItemInstance* CreateBaseItem(const EQ::ItemData* item, int8 charges=0, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
 
 		// Web Token Verification
 		bool VerifyToken(std::string token, int& status);

--- a/zone/client.h
+++ b/zone/client.h
@@ -936,7 +936,7 @@ public:
 	void	QSSwapItemAuditor(MoveItem_Struct* move_in, bool postaction_call = false);
 	void	PutLootInInventory(int16 slot_id, const EQ::ItemInstance &inst, LootItem** bag_item_data = 0);
 	bool	AutoPutLootInInventory(EQ::ItemInstance& inst, bool try_worn = false, bool try_cursor = true, LootItem** bag_item_data = 0);
-	bool	SummonItem(uint32 item_id, int8 quantity = -1, uint16 to_slot = EQ::invslot::slotCursor, bool force_charges = false);
+	bool	SummonItem(uint32 item_id, int8 quantity = -1, uint16 to_slot = EQ::invslot::slotCursor, bool force_charges = false, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
 	void	DropItem(int16 slot_id);
 	void	SendLootItemInPacket(const EQ::ItemInstance* inst, int16 slot_id);
 	void	SendItemPacket(int16 slot_id, const EQ::ItemInstance* inst, ItemPacketType packet_type, int16 fromid = 0, int16 toid = 0, int16 skill = 0);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1225,6 +1225,14 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		RemoveNoRent(false);
 	}
 
+	if (m_epp.solo_only || m_epp.self_found) {
+		// Any items in their possesion that are missing self-found tag should get a self-found tag on them.
+		// This is for players that haven't logged in since this self-found tagging system was implemented
+		if (loaditems) {
+			m_inv.MarkItemsSelfFound(cid, m_pp.name);
+		}
+	}
+
 	if (m_pp.platinum_cursor > 0 || m_pp.silver_cursor > 0 || m_pp.gold_cursor > 0 || m_pp.copper_cursor > 0) {
 		bool changed = false;
 		uint64 new_coin = 0;

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -96,7 +96,7 @@ class Corpse : public Mob {
 	int32 GetPlayerKillItem() { return player_kill_item; } 
 	void RemoveItem(uint16 lootslot);
 	void RemoveItem(LootItem* item_data);
-	void AddItem(uint32 itemnum, int8 charges, int16 slot = 0);
+	void AddItem(uint32 itemnum, int8 charges, int16 slot = 0, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
 	
 	/* Corpse: Coin */
 	void SetCash(uint32 in_copper, uint32 in_silver, uint32 in_gold, uint32 in_platinum);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1450,6 +1450,10 @@ void NPC::PickPocket(Client* thief)
 						{
 							if(slotid >= 0)
 							{
+								if (thief->IsSoloOnly() || thief->IsSelfFound())
+								{
+									inst->SetSelfFoundCharacter(thief->CharacterID(), thief->GetName());
+								}
 								thief->SendPickPocketResponse(this, 0, PickPocketItem, slotid, inst);
 								LootItem* sitem = GetItem(EQ::invslot::slotGeneral1, steal_items[random]);
 								RemoveItem(sitem);

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -176,8 +176,8 @@ public:
 	virtual void FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho);
 
 	//loot
-	void AddItem(const EQ::ItemData *item, int8 charges, bool equip_item = true, bool quest = false,  bool pet = false, bool force_equip = false, uint8 min_looter_level = 0, uint32 item_loot_lockout_timer = 0);
-	void AddItem(uint32 itemid, int8 charges, bool equipitem = true, bool quest = false);
+	void AddItem(const EQ::ItemData *item, int8 charges, bool equip_item = true, bool quest = false,  bool pet = false, bool force_equip = false, uint8 min_looter_level = 0, uint32 item_loot_lockout_timer = 0, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
+	void AddItem(uint32 itemid, int8 charges, bool equipitem = true, bool quest = false, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
 	void AddLootTable();
 	void AddLootTable(uint32 loottable_id, bool is_global = false);
 	void AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop);
@@ -204,8 +204,8 @@ public:
 	void	CleanQuestLootItems();
 	uint8	CountQuestItem(uint16 itemid);
 	uint8	CountQuestItems();
-	bool	AddQuestLoot(int16 itemid, int8 charges = 1);
-	bool	AddPetLoot(int16 itemid, int8 charges = 1, bool fromquest = false);
+	bool	AddQuestLoot(int16 itemid, int8 charges = 1, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
+	bool	AddPetLoot(int16 itemid, int8 charges = 1, bool fromquest = false, const QuarmItemData& quarm_item_data = EmptyQuarmItemData);
 	void	DeleteQuestLoot(int16 itemid1, int16 itemid2 = 0, int16 itemid3 = 0, int16 itemid4 = 0);
 	void	DeleteInvalidQuestLoot();
 
@@ -227,7 +227,8 @@ public:
 		bool wearchange = false, 
 		bool quest = false, 
 		bool pet = false, 
-		bool force_equip = false
+		bool force_equip = false,
+		const QuarmItemData& quarm_item_data = EmptyQuarmItemData
 	);
 
 	void	DeleteEquipment(int16 slotid);

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -577,7 +577,7 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 			if(database.ItemQuantityType(item_id) != EQ::item::Quantity_Charges && charges < 1)
 				charges = 1;
 
-			if (sender->SummonItem(item_id, charges, 0, true))
+			if (sender->SummonItem(item_id, charges, 0, true, m_inst->GetQuarmItemData()))
 			{
 				EQ::ItemInstance* curitem = sender->GetInv().GetItem(EQ::invslot::slotCursor);
 				if (curitem && curitem->IsType(EQ::item::ItemClassBag))

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1162,7 +1162,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 
 						EQ::ItemInstance *SubItem = database.CreateItem(spell.base[i], charges);
 						if (SubItem != nullptr) {
-							SubItem->SetSelfFoundCharacter(CastToClient()->CharacterID(), CastToClient()->GetName());
+							if (CastToClient()->IsSoloOnly() || CastToClient()->IsSelfFound()) {
+								SubItem->SetSelfFoundCharacter(CastToClient()->CharacterID(), CastToClient()->GetName());
+							}
 							SummonedItem->PutItem(slot, *SubItem);
 							safe_delete(SubItem);
 						}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1058,10 +1058,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 							quantity = 1;
 
 						if (SummonedItem) {
-							c->SummonItem(SummonedItem->GetID(), SummonedItem->GetCharges());
+							c->SummonItem(SummonedItem->GetID(), SummonedItem->GetCharges(), 0, false, SummonedItem->GetQuarmItemData());
 							safe_delete(SummonedItem);
 						}
 						SummonedItem = database.CreateItem(spell.base[i], quantity);
+						if (SummonedItem && (c->IsSelfFound() || c->IsSoloOnly())) {
+							SummonedItem->SetSelfFoundCharacter(c->CharacterID(), c->GetName());
+						}
 					}
 				} else if (IsPet()) {
 					int max = spell.max[i];
@@ -1128,7 +1131,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 					// Destroy duplicate items on charmed pets and nodrop items.
 					if (item->NoDrop != 0 && (!IsCharmedPet() || (IsCharmedPet() && CastToNPC()->CountQuestItem(item->ID) == 0)))
 					{
-						CastToNPC()->AddPetLoot(item->ID, charges);
+						QuarmItemData quarm_item_data = QuarmItemData();
+						if (caster && caster->IsClient() && (caster->CastToClient()->IsSelfFound() || caster->CastToClient()->IsSoloOnly())) {
+							quarm_item_data.SetSelfFoundCharacter(item, caster->CastToClient()->CharacterID(), caster->CastToClient()->GetName());
+						}
+						CastToNPC()->AddPetLoot(item->ID, charges, false, quarm_item_data);
 					}
 				} else
 				if (!SummonedItem || !SummonedItem->IsClassBag()) {
@@ -1155,6 +1162,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 
 						EQ::ItemInstance *SubItem = database.CreateItem(spell.base[i], charges);
 						if (SubItem != nullptr) {
+							SubItem->SetSelfFoundCharacter(CastToClient()->CharacterID(), CastToClient()->GetName());
 							SummonedItem->PutItem(slot, *SubItem);
 							safe_delete(SubItem);
 						}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1087,10 +1087,15 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 					// Destroy duplicate items on charmed pets and nodrop items.
 					if (item->NoDrop != 0 && (!IsCharmedPet() || (IsCharmedPet() && CastToNPC()->CountQuestItem(item->ID) == 0)))
 					{
+						QuarmItemData quarm_item_data = QuarmItemData();
+						if (caster && caster->IsClient() && (caster->CastToClient()->IsSelfFound() || caster->CastToClient()->IsSoloOnly())) {
+							quarm_item_data.SetSelfFoundCharacter(item, caster->CastToClient()->CharacterID(), caster->CastToClient()->GetName());
+						}
+
 						// For pets, all items are added to inventory, even if the
 						// item is summoned into a bag so that the pet can equip
 						// the item, if possible.
-						CastToNPC()->AddPetLoot(item->ID, quantity);
+						CastToNPC()->AddPetLoot(item->ID, quantity, false, quarm_item_data);
 					}
 				} else if (caster) {
 					caster->Message_StringID(Chat::SpellFailure, SPELL_NO_EFFECT);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -689,7 +689,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 						DeleteItemInInventory(i);
 						if (npc->CanTalk())
 							npc->Say_StringID(zone->random.Int(TRADE_BAD_FACTION1, TRADE_BAD_FACTION4));
-						SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true);
+						SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true, inst->GetQuarmItemData());
 						Log(Logs::General, Logs::Trading, "Quest NPC %s is returning %s because the faction check has failed.", npc->GetName(), item->Name);
 
 					}
@@ -700,7 +700,8 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 						{
 							auto loot_drop_entry = LootdropEntriesRepository::NewNpcEntity();
 							loot_drop_entry.item_charges = static_cast<int8>(inst->GetCharges());
-							npc->AddLootDrop(item, loot_drop_entry, true, true);
+							bool pet = true; // setting pet(traded) flag to prevent self-found from looting this like a normal drop
+							npc->AddLootDrop(item, loot_drop_entry, true, true, false, pet, false, inst->GetQuarmItemData());
 							Log(Logs::General, Logs::Trading, "Adding loot item %s to Quest NPC %s due to bad faction.", item->Name, npc->GetName());
 						}
 					}
@@ -734,7 +735,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 										else if (bagitem->NoDrop != 0 &&
 											(!npc->IsCharmedPet() || (npc->IsCharmedPet() && npc->CountQuestItem(bagitem->ID) == 0)))
 										{
-											npc->AddPetLoot(bagitem->ID, baginst->GetCharges());
+											npc->AddPetLoot(bagitem->ID, baginst->GetCharges(), false, baginst->GetQuarmItemData());
 											Log(Logs::General, Logs::Trading, "Adding loot item %s (bag) to non-Quest pet %s", bagitem->Name, npc->GetName());
 										}
 									}
@@ -749,7 +750,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 									{
 										if (bagitem->NoDrop != 0 && npc->CountQuestItem(bagitem->ID) == 0)
 										{
-											npc->AddQuestLoot(bagitem->ID, baginst->GetCharges());
+											npc->AddQuestLoot(bagitem->ID, baginst->GetCharges(), baginst->GetQuarmItemData());
 											Log(Logs::General, Logs::Trading, "Adding loot item %s (bag) to non-Quest NPC %s", bagitem->Name, npc->GetName());
 										}
 									}
@@ -768,7 +769,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 					else if(item->NoDrop != 0 && 
 						(!npc->IsCharmedPet() || (npc->IsCharmedPet() && npc->CountQuestItem(item->ID) == 0)))
 					{
-						npc->AddPetLoot(item->ID, inst->GetCharges());
+						npc->AddPetLoot(item->ID, inst->GetCharges(), false, inst->GetQuarmItemData());
 						Log(Logs::General, Logs::Trading, "Adding loot item %s to non-Quest pet %s", item->Name, npc->GetName());
 					}
 				}
@@ -776,7 +777,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 				else if (RuleB(NPC, ReturnNonQuestItems)) 
 				{
 					DeleteItemInInventory(i);
-					SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true);
+					SummonItem(inst->GetID(), inst->GetCharges(), EQ::legacy::SLOT_QUEST, true, inst->GetQuarmItemData());
 					if(npc->CanTalk())
 						npc->Say_StringID(NO_NEED_FOR_ITEM, GetName());
 					Log(Logs::General, Logs::Trading, "Non-Quest NPC %s is returning %s because it does not require it.", npc->GetName(), item->Name);
@@ -789,7 +790,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 					{
 						if (GetGM() || (item->NoDrop != 0 && npc->CountQuestItem(item->ID) == 0))
 						{
-							npc->AddQuestLoot(item->ID, inst->GetCharges());
+							npc->AddQuestLoot(item->ID, inst->GetCharges(), inst->GetQuarmItemData());
 							Log(Logs::General, Logs::Trading, "Adding loot item %s to non-Quest NPC %s", item->Name, npc->GetName());
 						}
 					}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -431,8 +431,9 @@ void ZoneDatabase::LoadWorldContainer(uint32 parentid, EQ::ItemInstance* contain
         uint8 index = (uint8)atoi(row[0]);
         uint32 item_id = (uint32)atoi(row[1]);
         int8 charges = (int8)atoi(row[2]);
+        QuarmItemData quarm_item_data = EmptyQuarmItemData; // NYI: object_contents persistence for QuarmItemData
 
-        EQ::ItemInstance* inst = database.CreateItem(item_id, charges);
+        EQ::ItemInstance* inst = database.CreateItem(item_id, charges, quarm_item_data);
         if (inst) {
             // Put item inside world container
             container->PutItem(index, *inst);
@@ -465,6 +466,7 @@ void ZoneDatabase::SaveWorldContainer(uint32 zone_id, uint32 parent_id, const EQ
 		}
 
         uint32 item_id = inst->GetItem()->ID;
+        // NYI: object_contents persistence for QuarmItemData
 
         std::string query = StringFormat("REPLACE INTO object_contents "
                                         "(zoneid, parentid, bagidx, itemid, charges, droptime) "
@@ -3508,6 +3510,7 @@ bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntr
 		corpse->items[i].charges = atoi(row[r++]); 		// charges,
 		corpse->items[i].min_looter_level = 0;
 		corpse->items[i].item_loot_lockout_timer = 0;
+		corpse->items[i].quarm_item_data = EmptyQuarmItemData; // NYI: Corpse Persistence for QuarmItemData
 		r = 0;
 		i++;
 	}


### PR DESCRIPTION
# SSF Features - Part 1 - Charm Pet Loot Support

![image](https://github.com/user-attachments/assets/a70cc374-2064-48ff-a7b2-e59b5f5c704f)

Quick Test:
(1)
 - Player 1 (Non-SSF) Gave **Combine Dagger** to A Bat.
 - Player 2 (SSF) Gave **Rusty Short Sword** to A Bat.
 - Player 2 (SSF) Kills the Bat.
 - Player 2 (SSF) able to loot **Rusty Short Sword**
 - Player 2 (SSF) CANNOT loot **Combine Dagger** (Player 1's item)
 
 (2)
 - Player 2 (SSF) Casts **Sword of Runes** on their pet charmed with puppet strings. Pet equips the Sword of Runes.
 - Player 2 (SSF) Kills their pet.
 - Player 2 (SSF) Loots **Sword of Runes**

(3)
- Player 2 (SSF) Casts **Summon Phantom Leather** on their charmed pet. Pet equips the whole satchel of gear.
- Player 2 (SSF) Kills their pet.
- Player 2 (SSF) Loots each summoned item from the corpse.

## Notes
Adds the groundwork for future SSF/Quarm-specific item features. But easier to split this up into smaller chunks.

This first chunk is just for things we can do in-memory without any DB changes. And the first feature on that list to support is Charm Pet items.

Unlike the first attempt, this one does not use maps or objects that need destruction. So it's much more trivial to add this without having to rework any memcpy / free logic in the code, which was a cause of crashes with the last attempt.

## Limited Scope
Future PRs will handle slowly expanding the scope of this as we go. Such as:
 - DB Persistance (needed for other features)
 - Lua integration
 - etc
