### PR TITLE
Fix - Handle edge case for SSF Charm Pet items

### DIFF
--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -1064,6 +1064,7 @@ bool NPC::MoveItemToGeneralInventory(LootItem* weapon)
 	uint8_t weapon_max_level = weapon->max_level;
 	uint8_t weapon_min_looter_level = weapon->min_looter_level;
 	uint32_t loot_lockout_timer = weapon->item_loot_lockout_timer;
+	QuarmItemData& quarm_item_data = weapon->quarm_item_data;
 
 	l.item_id = weaponid;
 	l.item_charges = weaponcharges;
@@ -1078,7 +1079,7 @@ bool NPC::MoveItemToGeneralInventory(LootItem* weapon)
 		RemoveItem(weapon);
 
 		Log(Logs::Detail, Logs::Trading, "%s is moving %d in slot %d to general inventory. quantity: %d", GetCleanName(), weaponid, slot, weaponcharges);
-		AddLootDrop(item, l, false, false, quest, pet, false);
+		AddLootDrop(item, l, false, false, quest, pet, false, quarm_item_data);
 
 		return true;
 	}

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -741,7 +741,7 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry)
 									}
 									else if (RuleB(NPC, ReturnNonQuestItems))
 									{
-										SummonItem(baginst->GetID(), baginst->GetCharges(), EQ::legacy::SLOT_QUEST, true);
+										SummonItem(baginst->GetID(), baginst->GetCharges(), EQ::legacy::SLOT_QUEST, true, baginst->GetQuarmItemData());
 										if (npc->CanTalk())
 											npc->Say_StringID(NO_NEED_FOR_ITEM, GetName());
 										Log(Logs::General, Logs::Trading, "Non-Quest NPC %s is returning %s (bag) because it does not require it.", npc->GetName(), bagitem->Name);


### PR DESCRIPTION
Overlooked this edge case when you give a charm pet more items than it can equip, since it deletes & re-creates the item before moving it to the general inventory, so I missed this case for the S/SF information to be propagated.

> Fixed a S/SF Charm Pet loot bug that prevented looting pet items when you give a pet more weapons than it can equip.


E.g.
- Give pet 2 weapons to dual wield.
- **Give pet a 3rd weapon** (replaces one of the old weapons)
- SSF player can no longer loot the replaced weapon (bug, should be able to loot)