### PR TITLE
Fix - #togglepvp message

### DIFF
--- a/zone/gm_commands/togglepvp.cpp
+++ b/zone/gm_commands/togglepvp.cpp
@@ -23,8 +23,7 @@ void command_togglepvp(Client* c, const Seperator* sep)
 	c->Message(
 		Chat::White,
 		fmt::format(
-			"YOu now follows the ways of {}.",
-			c->GetCleanName(),
+			"You now follow the ways of {}.",
 			pvp_state ? "Discord" : "Order"
 		).c_str()
 	);


### PR DESCRIPTION
Fixing this message
![image](https://github.com/user-attachments/assets/30e52881-9ba5-4d9a-aa78-1e952e856316)

Can optionally remove it entirely, the red message also prints both ways.
