### PR TITLE
Feature - Clean up ShowHelm to work as personal helm toggle that is compatible with Zeal and Velious features

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -328,6 +328,7 @@ RULE_INT(Quarm, MaxPVPPBAOETargets, 72, "")
 RULE_REAL(Quarm, PVPMobLeashUnits, 300.0, "")
 RULE_INT(Quarm, PVPInstanceMinimumSpawnTime, 72, "")
 RULE_INT(Quarm, PVPInstanceGraveyardTime, 30, "")
+RULE_BOOL(Quarm, UseFixedShowHelmBehavior, true, "Fixes ShowHelm to be a personal toggle that works like other MMOs. Also adds full compatibility with Zeal's ShowHelm feature and Velious Helms support.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(SelfFound)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1929,7 +1929,9 @@ void Client::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 		if (i < EQ::textures::weaponPrimary)
 		{
 			int16 texture = 0; uint32 color = 0;
-			GetPCEquipMaterial(i, texture, color);
+			if (i != EQ::textures::armorHead || ShowHelm() || !RuleB(Quarm, UseFixedShowHelmBehavior)) {
+				GetPCEquipMaterial(i, texture, color);
+			}
 			ns->spawn.equipment[i] = texture;
 			ns->spawn.colors.Slot[i].Color = color;
 		}

--- a/zone/gm_commands/showhelm.cpp
+++ b/zone/gm_commands/showhelm.cpp
@@ -1,42 +1,68 @@
 #include "../client.h"
+#include "../../common/rulesys.h"
 
 void command_showhelm(Client *c, const Seperator *sep)
 {
 	bool state = atobool(sep->arg[1]);
 	bool current_state = c->ShowHelm();
+	bool changed = state != current_state;
 	bool all = strcasecmp(sep->arg[2], "all") == 0 ? true : false;
+	bool silent = strcasecmp(sep->arg[2], "silent") == 0 || strcasecmp(sep->arg[3], "silent") == 0 ? true : false;
 
 	if (sep->arg[1][0] != 0) 
 	{
 		c->SetShowHelm(state);
-		if (!state && current_state)
+		if (!state)
 		{
-			c->WearChange(EQ::textures::armorHead, 0, 0, c);
-			entity_list.HideHelms(c);
+			if (RuleB(Quarm, UseFixedShowHelmBehavior))
+			{
+				c->WearChange(EQ::textures::armorHead, 0, 0);
+			}
+			else
+			{
+				c->WearChange(EQ::textures::armorHead, 0, 0, c);
+				entity_list.HideHelms(c);
+			}
 			if (all)
 			{
 				database.SaveAccountShowHelm(c->AccountID(), state);
 			}
 		}
-		else if(state && !current_state)
+		else if(state)
 		{
-			c->SendWearChange(EQ::textures::armorHead, c);
-			entity_list.SendHelms(c);
+			if (RuleB(Quarm, UseFixedShowHelmBehavior))
+			{
+				c->SendWearChange(EQ::textures::armorHead, nullptr, false, true, false);
+			}
+			else
+			{
+				// Displays everyone's helms to you.
+				c->SendWearChange(EQ::textures::armorHead, c);
+				entity_list.SendHelms(c);
+			}
 			if (all)
 			{
 				database.SaveAccountShowHelm(c->AccountID(), state);
 			}
 		}
-		else
-		{
-			c->Message(Chat::White, "There was no change in your showhelm setting.");
-			return;
+
+		if (!silent) {
+			if (RuleB(Quarm, UseFixedShowHelmBehavior))
+			{
+				c->Message(Chat::Yellow, "You will %s display your helm.", state ? "now" : "no longer");
+			}
+			else if (!changed)
+			{
+				c->Message(Chat::White, "There was no change in your showhelm setting.");
+			}
+			else
+			{
+				c->Message(Chat::Yellow, "You will %s display helms.", state ? "now" : "no longer");
+			}
 		}
-		
-		c->Message(Chat::Yellow, "You will %s display helms.", state ? "now" : "no longer");
 	}
 	else
-		c->Message(Chat::White, "Usage: #showhelm on/off [all]");
+		c->Message(Chat::White, "Usage: #showhelm on/off [all] [silent]");
 
 	return;
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2379,9 +2379,11 @@ uint32 Mob::RandomTimer(int min,int max) {
 // This sends a WearChange while determining the mob's current apperance.
 void Mob::SendWearChange(uint8 material_slot, Client* sendto, bool skip_if_zero, bool update_textures, bool illusioned)
 {
-	if (material_slot == EQ::textures::armorHead && sendto && !sendto->ShowHelm())
-	{
-		return;
+	if (!RuleB(Quarm, UseFixedShowHelmBehavior)) {
+		if (material_slot == EQ::textures::armorHead && sendto && !sendto->ShowHelm())
+		{
+			return;
+		}
 	}
 
 	if (IsClient() && !IsPlayableRace(GetRace()) && material_slot < EQ::textures::weaponPrimary)
@@ -5242,6 +5244,9 @@ void Mob::ApplyIllusion(const SPDat_Spell_Struct &spell, int i, Mob* caster)
 		int8 helmtexture = spell.max[i];
 		if (IsRacialIllusion(spell_id))
 		{
+			if (RuleB(Quarm, UseFixedShowHelmBehavior) && IsClient() && CastToClient()->ShowHelm()) {
+				helmtexture = 0xFF;
+			}
 			texture = GetTexture();
 		}
 		// Great Bear - Ogre is Grizzly texture 0.


### PR DESCRIPTION
The big ol' helm patch that makes helms work again. Majority of the code is on the Zeal side (0.6.3), but these server tweaks are the final thing we need to make the client/server compatibility the best it can be (I'd say perfect but donna wanna jinx it).

> ShowHelm now works as a personal toggle. Helm support will be fully compatible with next Zeal releases (0.6.3), fixing all known helm display issues.

People should never run into all the various janky helmet bugs again, and this sets us all up to have working helms for Velious as well. Also mostly handled by Zeal, but I did see a few IDs missing on the server (570 and 575) that I fixed.

Zeal PR is already merged into 0.6.3 branch, and it's working fine so far. https://github.com/iamclint/Zeal/pull/218

![image](https://github.com/user-attachments/assets/8cc7f9e5-a1be-4262-9cf8-9741c101220d)
