### PR TITLE
Tweak: Supports Weapon tint colors sent on zone entry

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1938,6 +1938,7 @@ void Client::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 		else
 		{
 			ns->spawn.equipment[i] = GetEquipmentMaterial(i);
+			ns->spawn.colors.Slot[i].Color = GetEquipmentColor(i);
 		}
 	}
 


### PR DESCRIPTION
Has no effect atm.

Improves tint support if we use it in the future.