### PR TITLE
Feature: SelfFound+

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -718,4 +718,100 @@ enum ChatChannelNames : uint16
 	ChatChannel_UNKNOWN_GMSAY = 18
 };
 
+// Quarm Rulesets that affect loot/grouping/exp rules.
+namespace ChallengeRules {
+
+	enum RuleSet : uint8 {
+		SOLO = 0,
+		NULL_CLASS = 1,
+		SELF_FOUND_FLEX = 2,
+		SELF_FOUND_CLASSIC = 3,
+		NORMAL = 4
+	};
+
+	static bool IsFteRequired(ChallengeRules::RuleSet type) {
+		return type == ChallengeRules::RuleSet::SOLO
+			|| type == ChallengeRules::RuleSet::SELF_FOUND_CLASSIC
+			|| type == ChallengeRules::RuleSet::NULL_CLASS;
+	}
+
+	static bool IsSelfFoundAny(ChallengeRules::RuleSet type) {
+		return type != ChallengeRules::RuleSet::NORMAL;
+	}
+
+	static bool InLevelRange(uint8 level, uint8 max_level) {
+		if (max_level < 6u)
+			return true;
+		else if (max_level < 10u && level >(max_level - 5u))
+			return true;
+		else if (level >= (max_level * 10u / 15u))
+			return true;
+		return false;
+	}
+
+	static bool CanGroupWith(ChallengeRules::RuleSet self, ChallengeRules::RuleSet group_type) {
+		switch (self) {
+		case ChallengeRules::RuleSet::NULL_CLASS:
+			return group_type == ChallengeRules::RuleSet::NULL_CLASS;
+		case ChallengeRules::RuleSet::SOLO:
+			return false;
+		case ChallengeRules::RuleSet::SELF_FOUND_CLASSIC:
+			return group_type == ChallengeRules::RuleSet::SELF_FOUND_CLASSIC
+				|| group_type == ChallengeRules::RuleSet::SELF_FOUND_FLEX;
+		case ChallengeRules::RuleSet::SELF_FOUND_FLEX:
+			return group_type == ChallengeRules::RuleSet::NORMAL
+				|| group_type == ChallengeRules::RuleSet::SELF_FOUND_FLEX
+				|| group_type == ChallengeRules::RuleSet::SELF_FOUND_CLASSIC;
+		case ChallengeRules::RuleSet::NORMAL:
+			return group_type == ChallengeRules::RuleSet::NORMAL
+				|| group_type == ChallengeRules::RuleSet::SELF_FOUND_FLEX;
+		}
+		return false;
+	}
+
+	static bool CanGetExpCreditWith(ChallengeRules::RuleSet self, uint8 level, uint8 level2, ChallengeRules::RuleSet group, uint8 max_level, uint8 max_level2) {
+		switch (self) {
+		case ChallengeRules::RuleSet::NULL_CLASS:
+			return group == ChallengeRules::RuleSet::NULL_CLASS
+				&& InLevelRange(level, max_level)
+				&& InLevelRange(level2, max_level2);
+		case ChallengeRules::RuleSet::SOLO:
+			return group == ChallengeRules::RuleSet::SOLO; // Allowed (assuming it's yourself)
+		case ChallengeRules::RuleSet::SELF_FOUND_CLASSIC:
+			return (group == ChallengeRules::RuleSet::SELF_FOUND_CLASSIC || group == ChallengeRules::RuleSet::SELF_FOUND_FLEX)
+				&& InLevelRange(level, max_level)
+				&& InLevelRange(level2, max_level2);
+		case ChallengeRules::RuleSet::SELF_FOUND_FLEX:
+			return InLevelRange(level, max_level);
+		case ChallengeRules::RuleSet::NORMAL:
+			return InLevelRange(level, max_level);
+		}
+		return true;
+	}
+
+	static bool CanGetLootCreditWith(ChallengeRules::RuleSet self, uint8 level, uint8 level2, ChallengeRules::RuleSet group, uint8 max_level, uint8 max_level2) {
+		switch (self) {
+		case ChallengeRules::RuleSet::NULL_CLASS:
+			return group == ChallengeRules::RuleSet::NULL_CLASS
+				&& InLevelRange(level, max_level)
+				&& InLevelRange(level2, max_level2);
+		case ChallengeRules::RuleSet::SOLO:
+			return group == ChallengeRules::RuleSet::SOLO; // Allowed (assuming it's yourself)
+		case ChallengeRules::RuleSet::SELF_FOUND_CLASSIC:
+			return (group == ChallengeRules::RuleSet::SELF_FOUND_CLASSIC || group == ChallengeRules::RuleSet::SELF_FOUND_FLEX)
+				&& InLevelRange(level, max_level)
+				&& InLevelRange(level2, max_level2);
+		case ChallengeRules::RuleSet::SELF_FOUND_FLEX:
+			return InLevelRange(level, max_level);
+		case ChallengeRules::RuleSet::NORMAL:
+			return true;
+		}
+		return true; // should not reach
+	}
+
+	static bool CanHelp(ChallengeRules::RuleSet self_type, uint8 self_level, uint8 self_level2, ChallengeRules::RuleSet target, uint8 target_level, uint8 target_level2) {
+		return CanGetLootCreditWith(target, target_level, target_level2, self_type, self_level, self_level2);
+	}
+}
+
 #endif

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -2808,13 +2808,30 @@ struct LootItemLockout
 	}
 };
 
+namespace ChallengeRules {
+
+	struct RuleParams {
+		ChallengeRules::RuleSet type;
+		uint8 min_level;
+		uint8 max_level;
+		uint8 max_level2;
+		uint32 character_id; // If not a group, the ID of the player
+
+		bool IsFteRequired() {
+			return ChallengeRules::IsFteRequired(type);
+		}
+	};
+
+}
+
 struct PlayerEngagementRecord
 {
 	bool isFlagged = false;
 	uint32 character_id = 0;
 	char character_name[64] = { 0 };
-	bool isSelfFound = false;
-	bool isSoloOnly = false;
+	uint8 character_level = 0;
+	uint8 character_level2 = 0;
+	ChallengeRules::RuleSet character_ruleset = ChallengeRules::RuleSet::NORMAL;
 	LootLockout lockout = LootLockout();
 
 	bool HasLockout(time_t curTime)
@@ -2826,6 +2843,22 @@ struct PlayerEngagementRecord
 			return false;
 
 		return true;
+	}
+
+	bool IsSelfFoundAny() {
+		return ChallengeRules::IsSelfFoundAny(character_ruleset);
+	}
+
+	bool IsFteRequired() {
+		return ChallengeRules::IsFteRequired(character_ruleset);
+	}
+
+	bool CanGetLootCreditWith(ChallengeRules::RuleParams& group) {
+		return ChallengeRules::CanGetLootCreditWith(character_ruleset, character_level, character_level2, group.type, group.max_level, group.max_level2);
+	}
+
+	bool CanGetLootCreditWith(ChallengeRules::RuleParams& group, bool sf_credit_check) {
+		return CanGetLootCreditWith(group) && (sf_credit_check || !IsFteRequired());
 	}
 };
 

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -1243,10 +1243,8 @@ struct ServerGroupInvite_Struct {
 		/*128*/	char unknown[65];		// Comment: 
 		/*193*/
 
-		// Custom:
-		uint8 self_found;
-		// Custom:
-		uint8 is_null;
+		// Custom
+		ChallengeRules::RuleSet group_ruleset; // See GroupType (Normal, SF, Null, Solo, etc)
 };
 
 struct ServerEarthquakeImminent_Struct {

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1188,19 +1188,9 @@ bool Mob::IsBeneficialAllowed(Mob *target)
 				c1 = mob1->CastToClient();
 				c2 = mob2->CastToClient();
 
-				if (c2->IsSoloOnly())
+				if (!c1->CanHelp(c2)) // challenge mode check
 				{
-					// if the target is solo, don't allow anyone to buff it
-					// if the caster is solo, it's fine if they try to buff someone
 					return false;
-				}
-
-				if (c2->IsSelfFound() == true)
-				{
-					bool can_get_experience = c1->IsInLevelRange(c2->GetLevel2()) && c2->IsInLevelRange(c1->GetLevel2());
-					bool compatible = c1->IsSelfFound() == c2->IsSelfFound();
-					if (!compatible || compatible && !can_get_experience)
-						return false;
 				}
 
 				if (c1->IsDueling() || c2->IsDueling())

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2276,7 +2276,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 			if (raid == nullptr && group == nullptr) {
 				corpse->AllowPlayerLoot(killer);
 				if (sf_solo_credit || !killer->CastToClient()->IsFteRequired()) {
-					corpse->AddKillCredit(killer->GetCleanName());
+					corpse->AddKillCredit(killer->GetCleanName(), killer->CastToClient()->IsSelfFoundAny());
 				}
 			}
 			if (raid == nullptr && group)
@@ -2289,7 +2289,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 							corpse->AllowPlayerLoot(group->members[i]);
 							bool kill_credit = group->members[i]->CastToClient()->CanGetLootCreditWith(ruleset, sf_group_credit);
 							if (kill_credit) {
-								corpse->AddKillCredit(group->members[i]->CastToClient()->GetCleanName());
+								corpse->AddKillCredit(group->members[i]->CastToClient()->GetCleanName(), group->members[i]->CastToClient()->IsSelfFoundAny());
 							}
 						}
 						else
@@ -2299,7 +2299,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 								corpse->AllowPlayerLoot(group->membername[i]);
 								bool kill_credit = record->second.CanGetLootCreditWith(ruleset, sf_group_credit);
 								if (kill_credit) {
-									corpse->AddKillCredit(group->membername[i]);
+									corpse->AddKillCredit(group->membername[i], record->second.IsSelfFoundAny());
 								}
 							}
 						}
@@ -2315,7 +2315,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 					r->VerifyRaid();
 					
 					for (auto& sf_fte_name : this->sf_fte_list) {
-						corpse->AddKillCredit(sf_fte_name);
+						corpse->AddKillCredit(sf_fte_name, true);
 					}
 
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
@@ -2348,7 +2348,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 						{
 							bool kill_credit = r->members[x].member->CanGetLootCreditWith(ruleset, sf_raid_credit);
 							if (kill_credit) {
-								corpse->AddKillCredit(r->members[x].member->GetCleanName());
+								corpse->AddKillCredit(r->members[x].member->GetCleanName(), r->members[x].member->IsSelfFoundAny());
 							}
 						}
 						else if (r->members[x].membername[0])
@@ -2357,7 +2357,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 							if (record != m_EngagedClientNames.end()) {
 								bool kill_credit = record->second.CanGetLootCreditWith(ruleset, sf_raid_credit);
 								if (kill_credit) {
-									corpse->AddKillCredit(r->members[x].membername);
+									corpse->AddKillCredit(r->members[x].membername, record->second.IsSelfFoundAny());
 								}
 							}
 						}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1340,10 +1340,13 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 
 			if (IsSoloOnly())
 			{
-				rulesets.append(" Solo");
+				rulesets.append(" Solo Self Found");
+			} 
+			else if (IsSelfFoundClassic())
+			{
+				rulesets.append(" Classic Self Found");
 			}
-
-			if (IsSelfFound())
+			else if (IsSelfFoundFlex())
 			{
 				rulesets.append(" Self Found");
 			}
@@ -2012,6 +2015,7 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 				killer->GetName(), killer->GetGroup() || killer->GetRaid() ? "'s group/raid " : "", dmg_amt, GetName());
 		}
 	}
+
 	bool is_majority_ds_damage = (float)ds_damage - (float)ssf_ds_damage > (float)GetMaxHP() * 0.45f;
 	bool is_majority_killer_dmg = (float)ssf_player_damage + (float)npc_damage > (float)GetMaxHP() * 0.45f;
 
@@ -2029,10 +2033,11 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 
 			if (give_exp_client)
 			{
-				bool is_solo_only = give_exp_client->IsSoloOnly();
-				bool is_self_found = give_exp_client->IsSelfFound();
+				Raid* raid = give_exp_client->GetRaid();
+				Group* group = give_exp_client->GetGroup();
+				ChallengeRules::RuleParams ruleset = raid ? raid->GetRuleSetParams() : group ? group->GetRuleSetParams() : give_exp_client->GetRuleSetParams();
 
-				if (!is_solo_only && !is_self_found)
+				if (!ruleset.IsFteRequired())
 				{
 					LogDeathDetail("{} will receive XP credit.", give_exp_client->GetName());
 
@@ -2041,9 +2046,9 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 				}
 				else
 				{
-					bool is_raid_solo_fte_credit = give_exp_client->GetRaid() ? give_exp_client->GetRaid()->GetID() == solo_raid_fte : false;
-					bool is_group_solo_fte_credit = give_exp_client->GetGroup() ? give_exp_client->GetGroup()->GetID() == solo_group_fte : false;
-					bool is_solo_fte_credit = give_exp_client->CharacterID() == solo_fte_charid ? true : false;
+					bool is_raid_solo_fte_credit = raid ? raid->GetID() == solo_raid_fte : false;
+					bool is_group_solo_fte_credit = group ? group->GetID() == solo_group_fte : false;
+					bool is_solo_fte_credit = give_exp_client->CharacterID() == solo_fte_charid;
 
 					if (is_raid_solo_fte_credit || is_group_solo_fte_credit || is_solo_fte_credit)
 					{
@@ -2252,177 +2257,109 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 
 	if (killer != 0 && killer->IsClient())
 	{
-		bool is_solo_only = killer->CastToClient()->IsSoloOnly();
-		bool is_self_found = killer->CastToClient()->IsSelfFound();
+		
+		Raid* raid = killer->IsRaidGrouped() ? killer->GetRaid() : nullptr;
+		Group* group = killer->GetGroup();
+		ChallengeRules::RuleParams ruleset = raid ? raid->GetRuleSetParams() : group ? group->GetRuleSetParams() : killer->CastToClient()->GetRuleSetParams();
 
-		if (is_solo_only || is_self_found)
+		bool is_solo_fte_charid = solo_fte_charid == killer->CastToClient()->CharacterID();
+		bool is_raid_solo_fte_credit = raid ? raid->GetID() == CastToNPC()->solo_raid_fte : false;
+		bool is_group_solo_fte_credit = group ? group->GetID() == CastToNPC()->solo_group_fte : false;
+		bool is_majority_ds_damage = (float)ds_damage - (float)ssf_ds_damage > (float)GetMaxHP() * 0.45f;
+		bool is_majority_killer_dmg = (float)ssf_player_damage + (float)npc_damage > (float)GetMaxHP() * 0.45f;
+
+		bool sf_solo_credit = is_solo_fte_charid && !is_raid_solo_fte_credit && !is_group_solo_fte_credit;
+		bool sf_group_credit = is_group_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg;
+		bool sf_raid_credit = is_raid_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg;
+
 		{
-			bool is_solo_fte_charid = solo_fte_charid == killer->CastToClient()->CharacterID();
-			Group* group = entity_list.GetGroupByClient(killer->CastToClient());
-			Raid* raid = entity_list.GetRaidByClient(killer->CastToClient());
-			bool is_raid_solo_fte_credit = raid ? raid->GetID() == CastToNPC()->solo_raid_fte : false;
-			bool is_group_solo_fte_credit = group ? group->GetID() == CastToNPC()->solo_group_fte : false;
-			bool is_majority_ds_damage = (float)ds_damage - (float)ssf_ds_damage > (float)GetMaxHP() * 0.45f;
-			bool is_majority_killer_dmg = (float)ssf_player_damage + (float)npc_damage > (float)GetMaxHP() * 0.45f;
-
-			if (is_solo_fte_charid && !is_raid_solo_fte_credit && !is_group_solo_fte_credit)
-			{
+			if (raid == nullptr && group == nullptr) {
 				corpse->AllowPlayerLoot(killer);
+				if (sf_solo_credit || !killer->CastToClient()->IsFteRequired()) {
+					corpse->AddKillCredit(killer->GetCleanName());
+				}
 			}
-			if (killer->IsGrouped())
+			if (raid == nullptr && group)
 			{
-				if (group != nullptr) {
-					float groupHighestLevel = group->GetHighestLevel2();
+				{
 					for (int i = 0; i < MAX_GROUP_MEMBERS; i++)
 					{
 						if (group->members[i] != nullptr)
 						{
-							bool can_get_experience = group->members[i]->CastToClient()->IsInLevelRange(groupHighestLevel);
-							bool is_self_found = group->members[i]->CastToClient()->IsSelfFound();
-							if (!is_self_found || is_self_found && can_get_experience && is_group_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg)
-								corpse->AllowPlayerLoot(group->members[i]);
-						}
-					}
-				}
-			}
-			else if (killer->HasRaid())
-			{
-				Raid* r = entity_list.GetRaidByClient(killer->CastToClient());
-				if (r) {
-					r->VerifyRaid();
-					float raidHighestLevel = r->GetHighestLevel2();
-					corpse->SetInitialAllowedLooters(this->sf_fte_list);
-					int i = 0;
-					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
-					{
-						switch (r->GetLootType())
-						{
-						case 0:
-						case 1:
-							if (r->members[x].member && r->members[x].IsRaidLeader)
-							{
-								bool can_get_experience = r->members[x].member->IsInLevelRange(r->GetHighestLevel2());
-								bool is_self_found = r->members[x].member->IsClient() && r->members[x].member->CastToClient()->IsSelfFound();
-								if (!is_self_found || is_self_found && can_get_experience && is_raid_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg)
-									corpse->AllowPlayerLoot(r->members[x].member);
-								i++;
+							corpse->AllowPlayerLoot(group->members[i]);
+							bool kill_credit = group->members[i]->CastToClient()->CanGetLootCreditWith(ruleset, sf_group_credit);
+							if (kill_credit) {
+								corpse->AddKillCredit(group->members[i]->CastToClient()->GetCleanName());
 							}
-							break;
-						case 2:
-							if (r->members[x].member && r->members[x].IsRaidLeader)
-							{
-								bool can_get_experience = r->members[x].member->IsInLevelRange(r->GetHighestLevel2());
-								bool is_self_found = r->members[x].member->IsClient() && r->members[x].member->CastToClient()->IsSelfFound();
-								if (!is_self_found || is_self_found && can_get_experience && is_raid_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg)
-									corpse->AllowPlayerLoot(r->members[x].member);
-								i++;
-							}
-							else if (r->members[x].member && r->members[x].IsGroupLeader)
-							{
-								bool can_get_experience = r->members[x].member->IsInLevelRange(r->GetHighestLevel2());
-								bool is_self_found = r->members[x].member->IsClient() && r->members[x].member->CastToClient()->IsSelfFound();
-								if (!is_self_found || is_self_found && can_get_experience && is_raid_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg)
-									corpse->AllowPlayerLoot(r->members[x].member);
-								i++;
-							}
-							break;
-						case 3:
-							if (r->members[x].member && r->members[x].IsRaidLeader)
-							{
-								bool can_get_experience = r->members[x].member->IsInLevelRange(r->GetHighestLevel2());
-								bool is_self_found = r->members[x].member->IsClient() && r->members[x].member->CastToClient()->IsSelfFound();
-								if (!is_self_found || is_self_found && can_get_experience && is_raid_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg)
-									corpse->AllowPlayerLoot(r->members[x].member);
-								i++;
-							}
-							else if (r->members[x].member && r->members[x].IsLooter)
-							{
-								bool can_get_experience = r->members[x].member->IsInLevelRange(r->GetHighestLevel2());
-								bool is_self_found = r->members[x].member->IsClient() && r->members[x].member->CastToClient()->IsSelfFound();
-								if (!is_self_found || is_self_found && can_get_experience && is_raid_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg)
-									corpse->AllowPlayerLoot(r->members[x].member);
-								i++;
-							}
-							break;
-						case 4:
-							if (r->members[x].member)
-							{
-								bool can_get_experience = r->members[x].member->IsInLevelRange(r->GetHighestLevel2());
-								bool is_self_found = r->members[x].member->IsClient() && r->members[x].member->CastToClient()->IsSelfFound();
-								if (!is_self_found || is_self_found && can_get_experience && is_raid_solo_fte_credit && !is_majority_ds_damage && is_majority_killer_dmg)
-									corpse->AllowPlayerLoot(r->members[x].member);
-								i++;
-							}
-							break;
-						}
-					}
-				}
-			}
-		}
-		else
-		{
-			if(!killer->IsRaidGrouped())
-				corpse->AllowPlayerLoot(killer);
-			if (killer->IsGrouped())
-			{
-				Group* group = entity_list.GetGroupByClient(killer->CastToClient());
-				if (group != 0) {
-					float groupHighestLevel = group->GetHighestLevel2();
-					for (int i = 0; i < MAX_GROUP_MEMBERS; i++)
-					{
-						if (group->members[i] != nullptr)
-						{
-							bool can_get_experience = group->members[i]->CastToClient()->IsInLevelRange(groupHighestLevel);
-							bool is_self_found = group->members[i]->CastToClient()->IsSelfFound();
-							if (!is_self_found || is_self_found && can_get_experience)
-								corpse->AllowPlayerLoot(group->members[i]);
 						}
 						else
 						{
-							if (m_EngagedClientNames.find(group->membername[i]) != m_EngagedClientNames.end())
+							auto record = m_EngagedClientNames.find(group->membername[i]);
+							if (record != m_EngagedClientNames.end()) {
 								corpse->AllowPlayerLoot(group->membername[i]);
+								bool kill_credit = record->second.CanGetLootCreditWith(ruleset, sf_group_credit);
+								if (kill_credit) {
+									corpse->AddKillCredit(group->membername[i]);
+								}
+							}
 						}
 					}
 				}
 			}
-			else if (killer->HasRaid())
+			else
 			{
-				Raid* r = entity_list.GetRaidByClient(killer->CastToClient());
+				Raid* r = raid;
 				if (r) {
 					r->GetRaidDetails();
 					r->LearnMembers();
 					r->VerifyRaid();
-					float raidHighestLevel = r->GetHighestLevel2();
-					int i = 0;
+					
+					for (auto& sf_fte_name : this->sf_fte_list) {
+						corpse->AddKillCredit(sf_fte_name);
+					}
+
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 					{
 						if (!r->members[x].membername[0])
 							continue;
 
+						bool add_looter = false;
 						switch (r->GetLootType())
 						{
 						case 0:
 						case 1:
-							if (r->members[x].IsRaidLeader)
-							{
-								corpse->AllowPlayerLoot(r->members[x].membername);
-							}
+							add_looter = r->members[x].IsRaidLeader;
 							break;
 						case 2:
-							if (r->members[x].IsRaidLeader || r->members[x].IsGroupLeader)
-							{
-								corpse->AllowPlayerLoot(r->members[x].membername);
-							}
+							add_looter = (r->members[x].IsRaidLeader || r->members[x].IsGroupLeader);
 							break;
 						case 3:
-							if (r->members[x].IsRaidLeader || r->members[x].IsLooter)
-							{
-								corpse->AllowPlayerLoot(r->members[x].membername);
-							}
+							add_looter = (r->members[x].IsRaidLeader || r->members[x].IsLooter);
 							break;
 						case 4:
-							corpse->AllowPlayerLoot(r->members[x].membername);
+							add_looter = true;
 							break;
+						}
+						if (add_looter)
+						{
+							corpse->AllowPlayerLoot(r->members[x].membername);
+						}
+						if (r->members[x].member)
+						{
+							bool kill_credit = r->members[x].member->CanGetLootCreditWith(ruleset, sf_raid_credit);
+							if (kill_credit) {
+								corpse->AddKillCredit(r->members[x].member->GetCleanName());
+							}
+						}
+						else if (r->members[x].membername[0])
+						{
+							auto record = m_EngagedClientNames.find(r->members[x].membername);
+							if (record != m_EngagedClientNames.end()) {
+								bool kill_credit = record->second.CanGetLootCreditWith(ruleset, sf_raid_credit);
+								if (kill_credit) {
+									corpse->AddKillCredit(r->members[x].membername);
+								}
+							}
 						}
 					}
 				}
@@ -2674,8 +2611,9 @@ void Mob::AddToHateList(Mob* other, int32 hate, int32 damage, bool bFrenzy, bool
 			record.lockout = LootLockout();
 			strncpy(record.character_name, other->CastToClient()->GetCleanName(), 64);
 			record.character_id = other->CastToClient()->CharacterID();
-			record.isSelfFound = other->CastToClient()->IsSelfFound();
-			record.isSoloOnly = other->CastToClient()->IsSoloOnly();
+			record.character_level = other->CastToClient()->GetLevel();
+			record.character_level2 = other->CastToClient()->GetLevel2();
+			record.character_ruleset = other->CastToClient()->GetRuleSet();
 
 			auto lootLockoutItr = other->CastToClient()->loot_lockouts.find(npctype_id);
 			if (lootLockoutItr != other->CastToClient()->loot_lockouts.end())
@@ -2698,8 +2636,9 @@ void Mob::AddToHateList(Mob* other, int32 hate, int32 damage, bool bFrenzy, bool
 				record.lockout = LootLockout();
 				strncpy(record.character_name, petowner->CastToClient()->GetCleanName(), 64);
 				record.character_id = petowner->CastToClient()->CharacterID();
-				record.isSelfFound = petowner->CastToClient()->IsSelfFound();
-				record.isSoloOnly = petowner->CastToClient()->IsSoloOnly();
+				record.character_level = petowner->CastToClient()->GetLevel();
+				record.character_level2 = petowner->CastToClient()->GetLevel2();
+				record.character_ruleset = petowner->CastToClient()->GetRuleSet();
 
 				auto lootLockoutItr = petowner->CastToClient()->loot_lockouts.find(npctype_id);
 				if (lootLockoutItr != petowner->CastToClient()->loot_lockouts.end())
@@ -3232,10 +3171,10 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 					bool is_solo_fte_credit = ultimate_owner->CharacterID() == CastToNPC()->solo_fte_charid ? true : false;
 					if (is_solo_fte_credit || is_raid_solo_fte_credit || is_group_solo_fte_credit)
 					{
-						ssf_player_damage += damage;
+						ssf_player_damage += adj_damage;
 						if (FromDamageShield)
 						{
-							ssf_ds_damage += damage;
+							ssf_ds_damage += adj_damage;
 						}
 					}
 				}
@@ -3247,7 +3186,7 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 					npc_damage += adj_damage;
 
 				if (IsValidSpell(spell_id) && spells[spell_id].targettype == ST_AECaster)
-					pbaoe_damage += damage;
+					pbaoe_damage += adj_damage;
 			}
 
 			// only apply DS if physical damage (no spell damage) damage shield calls this function with spell_id set, so its unavoidable

--- a/zone/client.h
+++ b/zone/client.h
@@ -492,9 +492,24 @@ public:
 	
 	inline uint8 IsHardcore() const { return m_epp.hardcore; }
 	inline uint8 IsSoloOnly() const { return m_epp.solo_only; }
-	inline uint8 IsSelfFound() const { return m_epp.self_found; }
+	inline bool IsSelfFoundAny() { return m_epp.solo_only || m_epp.self_found > 0; }; // Solo, Self Found Classic, or Self Found Flex
+	inline bool IsSelfFoundClassic() { return m_epp.self_found == 1; }
+	inline bool IsSelfFoundFlex() { return m_epp.self_found == 2; }
 	inline uint8 HasBetaBuffGearFlag() const { return m_epp.betabuff_gear_flag; }
-	std::string GetSSFLooterName();
+
+	// Functions for checking player compatibility for solo/null/self-found modes
+	ChallengeRules::RuleSet GetRuleSet();
+	ChallengeRules::RuleParams GetRuleSetParams();
+	bool IsFteRequired() { return ChallengeRules::IsFteRequired(GetRuleSet()); }
+	bool CanGroupWith(ChallengeRules::RuleSet group_type, uint32 character_id = 0);
+	bool CanGroupWith(Client* other) { return CanGroupWith(other->GetRuleSet(), other->CharacterID()); }
+	bool CanGetExpCreditWith(ChallengeRules::RuleSet other, uint8 max_level, uint8 max_level2);
+	bool CanGetLootCreditWith(ChallengeRules::RuleSet other, uint8 max_level, uint8 max_level2);
+	bool CanGetLootCreditWith(ChallengeRules::RuleParams& data) { return CanGetLootCreditWith(data.type, data.max_level, data.max_level2); }
+	bool CanGetExpCreditWith(ChallengeRules::RuleParams& data) { return CanGetExpCreditWith(data.type, data.max_level, data.max_level2); }
+	bool CanGetLootCreditWith(ChallengeRules::RuleParams& data, bool sf_fte) { return CanGetLootCreditWith(data) && (sf_fte || !IsFteRequired()); }
+	bool CanGetExpCreditWith(ChallengeRules::RuleParams& data, bool sf_fte) { return CanGetExpCreditWith(data) && (sf_fte || !IsFteRequired()); }
+	bool CanHelp(Client* target) { return target == this || target->CanGetLootCreditWith(GetRuleSet(), GetLevel(), GetLevel2()); }
 
 	inline void SetHardcore(uint8 in_hardcore) { m_epp.hardcore = in_hardcore; }
 	inline void SetSoloOnly(uint8 in_solo_only) { m_epp.solo_only = in_solo_only; }

--- a/zone/client.h
+++ b/zone/client.h
@@ -492,7 +492,8 @@ public:
 	
 	inline uint8 IsHardcore() const { return m_epp.hardcore; }
 	inline uint8 IsSoloOnly() const { return m_epp.solo_only; }
-	inline bool IsSelfFoundAny() { return m_epp.solo_only || m_epp.self_found > 0; }; // Solo, Self Found Classic, or Self Found Flex
+	inline uint8 GetSelfFound() const { if (m_epp.solo_only) return 1; return m_epp.self_found; } // Legacy flag for Lua
+	inline bool IsSelfFoundAny() { return GetSelfFound() > 0; }; // Solo, Self Found Classic, or Self Found Flex
 	inline bool IsSelfFoundClassic() { return m_epp.self_found == 1; }
 	inline bool IsSelfFoundFlex() { return m_epp.self_found == 2; }
 	inline uint8 HasBetaBuffGearFlag() const { return m_epp.betabuff_gear_flag; }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1230,6 +1230,11 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	}
 
 	if (m_epp.solo_only || m_epp.self_found) {
+
+		// Ensure 'solo' players also have the 'self-found' tag
+		if (m_epp.solo_only == 1)
+			m_epp.self_found = 1;
+
 		// Any items in their possesion that are missing self-found tag should get a self-found tag on them.
 		// This is for players that haven't logged in since this self-found tagging system was implemented
 		if (loaditems) {

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -997,7 +997,7 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid)
 			merlist.push_back(ml);
 			++i;
 		}
-		if (!IsSoloOnly() && !IsSelfFound())
+		if (!IsSelfFoundAny())
 		{
 			std::list<TempMerchantList> origtmp_merlist = zone->tmpmerchanttable[npcid];
 			tmp_merlist.clear();

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -254,7 +254,7 @@ Corpse::Corpse(NPC* in_npc, LootItems* in_itemlist, uint32 in_npctypeid, uint32 
 		corpse_delay_timer.Start(GetDecayTime() / 2);
 
 	allowed_looters.clear();
-	kill_credit.clear();
+	sf_kill_credit.clear();
 	if (is_client_pet)
 	{
 		allowed_looters.emplace("000");		// corpses without looters are apparently lootable by anybody, so doing this to make it unlootable
@@ -339,7 +339,7 @@ Corpse::Corpse(Client* client, int32 in_rezexp, uint8 in_killedby) : Mob (
 	corpse_graveyard_moved_timer.Disable();
 
 	allowed_looters.clear();
-	kill_credit.clear();
+	sf_kill_credit.clear();
 
 	is_corpse_changed		= true;
 	rez_experience			= in_rezexp;
@@ -1106,9 +1106,9 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 					return false;
 				}
 			}
-			else if (kill_credit.find(playername) == kill_credit.end())
+			else if (sf_kill_credit.find(playername) == sf_kill_credit.end())
 			{
-				c->Message(Chat::Red, "You are not allowed to loot this NPC because you do not have the self-found loot credit.");
+				c->Message(Chat::Red, "You are not allowed to loot this NPC because you did not earn credit for this kill.");
 				return false;
 			}
 		}
@@ -1263,11 +1263,15 @@ void Corpse::AllowPlayerLoot(std::string character_name) {
 
 }
 
-void Corpse::AddKillCredit(std::string character_name) {
+void Corpse::AddKillCredit(std::string character_name, bool is_self_found_any) {
 	if (character_name.size() == 0)
 		return;
-	if (kill_credit.find(character_name) == kill_credit.end())
-		kill_credit.emplace(character_name);
+	
+	if (is_self_found_any)
+	{
+		if (sf_kill_credit.find(character_name) == sf_kill_credit.end())
+			sf_kill_credit.emplace(character_name);
+	}
 }
 
 void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* app) {

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -253,12 +253,11 @@ Corpse::Corpse(NPC* in_npc, LootItems* in_itemlist, uint32 in_npctypeid, uint32 
 	if(RuleB(Quarm, CorpseUnlockIsHalvedDecayTime))
 		corpse_delay_timer.Start(GetDecayTime() / 2);
 
-	initial_allowed_looters.clear();
 	allowed_looters.clear();
+	kill_credit.clear();
 	if (is_client_pet)
 	{
 		allowed_looters.emplace("000");		// corpses without looters are apparently lootable by anybody, so doing this to make it unlootable
-		initial_allowed_looters.emplace("000");
 		corpse_decay_timer.Start(3000);
 	}
 
@@ -339,8 +338,8 @@ Corpse::Corpse(Client* client, int32 in_rezexp, uint8 in_killedby) : Mob (
 	}
 	corpse_graveyard_moved_timer.Disable();
 
-	initial_allowed_looters.clear();
 	allowed_looters.clear();
+	kill_credit.clear();
 
 	is_corpse_changed		= true;
 	rez_experience			= in_rezexp;
@@ -1077,113 +1076,8 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 	uint8 looters = 0;
 
 	Client* c = entity_list.GetClientByName(playername.c_str());
-	if (c && c->IsSelfFound() || c && c->IsSoloOnly())
-	{
-		std::string appendedCharName = c->GetSSFLooterName();
-		auto temporarily_allowed_itr = temporarily_allowed_looters.find(appendedCharName);
 
-		if (temporarily_allowed_itr == temporarily_allowed_looters.end() && c->IsLootLockedOutOfNPC(npctype_id) && npctype_id != 0)
-		{
-			return false;
-		}
-
-		if (denied_looters.find(appendedCharName) != denied_looters.end()) {
-			return false;
-		}
-
-		if (!c->HasRaid()) {
-			if (initial_allowed_looters.find(appendedCharName) != initial_allowed_looters.end()) {
-				return true;
-			}
-		}
-		else
-		{
-			if (allowed_looters.empty() && initial_allowed_looters.find(appendedCharName) != initial_allowed_looters.end())
-			{
-				// Clearing allowed_looters is the mechanism by which a corpse is opened
-				// to FFA looting. For SF players, the corpse is only unlocked for those
-				// players who were present at the moment of FTE in an eligible raid,
-				// which is indicated by being in initial_allowed_looters.
-				c->Message(Chat::Cyan, "You were in an eligible raid that was first to engage, so you are allowed to loot.");
-				return true;
-			}
-			else if (allowed_looters.find(appendedCharName) == allowed_looters.end() && initial_allowed_looters.find(appendedCharName) != initial_allowed_looters.end())
-			{
-				Raid* raid = c->GetRaid();
-				if (raid->GetLootType() == 3) // Looter / Raid Leader loot
-				{
-					if (raid->IsRaidLooter(c->GetCleanName()))
-					{
-						for (int x = 0; x < MAX_RAID_MEMBERS; x++)
-						{
-							if (raid->members[x].member)
-							{
-								if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
-								{
-									c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid with another eligible member of the raid.");
-									AllowPlayerLoot(appendedCharName);
-									break;
-								}
-							}
-						}
-					}
-				}
-				else if (raid->GetLootType() == 2) // Group Leader / Raid Leader loot
-				{
-					if (raid->IsRaidLeader(c->GetCleanName()) || raid->IsGroupLeader(c->GetCleanName()))
-					{
-						for (int x = 0; x < MAX_RAID_MEMBERS; x++)
-						{
-							if (raid->members[x].member)
-							{
-								if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
-								{
-									c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid and you're a group or raid leader.");
-									AllowPlayerLoot(appendedCharName);
-									break;
-								}
-							}
-						}
-					}
-				}
-				else if (raid->GetLootType() == 1 && raid->IsRaidLeader(c->GetCleanName())) // Raid Leader loot
-				{
-					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
-					{
-						if (raid->members[x].member)
-						{
-							if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
-							{
-								c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid and you're the new raid leader.");
-								AllowPlayerLoot(appendedCharName);
-								break;
-							}
-						}
-					}
-				}
-				else if (raid->GetLootType() == 4) // Raid Leader loot
-				{
-					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
-					{
-						if (raid->members[x].member)
-						{
-							if (allowed_looters.find(raid->members[x].member->GetSSFLooterName()) != allowed_looters.end())
-							{
-								c->Message(Chat::Cyan, "Adding you to the looter list of this corpse. You are in a raid and the loot is set to free-for-all.");
-								AllowPlayerLoot(appendedCharName);
-								break;
-							}
-						}
-					}
-				}
-			}
-		}
-
-		if (allowed_looters.find(appendedCharName) != allowed_looters.end()) {
-				return true;
-		}
-	}
-	else if(c)
+	if(c)
 	{
 
 		if (npctype_id != 0 && loot_lockout_timer > 0)
@@ -1200,6 +1094,23 @@ bool Corpse::CanPlayerLoot(std::string playername) {
 		if (denied_looters.find(playername) != denied_looters.end()) {
 			c->Message(Chat::Red, "You are not allowed to loot this NPC as you are locked out of the creature in question.");
 			return false;
+		}
+
+		if (c->IsSelfFoundAny())
+		{
+			if (IsPlayerCorpse())
+			{
+				if (char_id != c->CharacterID())
+				{
+					c->Message(Chat::Red, "You are not allowed to loot player corpses.");
+					return false;
+				}
+			}
+			else if (kill_credit.find(playername) == kill_credit.end())
+			{
+				c->Message(Chat::Red, "You are not allowed to loot this NPC because you do not have the self-found loot credit.");
+				return false;
+			}
 		}
 
 		/*
@@ -1314,21 +1225,10 @@ void Corpse::AllowPlayerLoot(Mob *them)
 		return;
 
 	std::string playername = them->CastToClient()->GetCleanName();
-	if (them->CastToClient()->IsSelfFound())
-		playername += "-SF";
-
-	if (them->CastToClient()->IsSoloOnly())
-		playername += "-Solo";
 
 	if (allowed_looters.find(playername) == allowed_looters.end())
 		allowed_looters.emplace(playername);
-
-	if (initial_allowed_looters.find(playername) == initial_allowed_looters.end())
-		initial_allowed_looters.emplace(playername);
-
 }
-
-
 
 void Corpse::DenyPlayerLoot(std::string character_name)
 {
@@ -1336,14 +1236,6 @@ void Corpse::DenyPlayerLoot(std::string character_name)
 		return;
 
 	std::string playername = character_name;
-	std::string playernameSelfFound = character_name;
-	std::string playernameSolo = character_name;
-	std::string playernameSoloSelfFound = character_name;
-	playernameSelfFound += "-SF";
-	playernameSolo += "-Solo";
-
-	playernameSoloSelfFound += "-SF";
-	playernameSoloSelfFound += "-Solo";
 
 	std::unordered_set<std::string>::iterator nameItr = allowed_looters.find(playername);
 	if (nameItr != allowed_looters.end())
@@ -1351,70 +1243,10 @@ void Corpse::DenyPlayerLoot(std::string character_name)
 		allowed_looters.erase(nameItr);
 	}
 
-	nameItr = allowed_looters.find(playernameSelfFound);
-	if (nameItr != allowed_looters.end())
-	{
-		allowed_looters.erase(nameItr);
-	}
-
-	nameItr = allowed_looters.find(playernameSolo);
-	if (nameItr != allowed_looters.end())
-	{
-		allowed_looters.erase(nameItr);
-	}
-
-	nameItr = allowed_looters.find(playernameSoloSelfFound);
-	if (nameItr != allowed_looters.end())
-	{
-		allowed_looters.erase(nameItr);
-	}
-
-	std::unordered_set<std::string>::iterator initialNameItr = initial_allowed_looters.find(playername);
-	if (initialNameItr != initial_allowed_looters.end())
-	{
-		initial_allowed_looters.erase(initialNameItr);
-	}
-
-	initialNameItr = initial_allowed_looters.find(playernameSelfFound);
-	if (initialNameItr != initial_allowed_looters.end())
-	{
-		initial_allowed_looters.erase(initialNameItr);
-	}
-
-	initialNameItr = initial_allowed_looters.find(playernameSolo);
-	if (initialNameItr != initial_allowed_looters.end())
-	{
-		initial_allowed_looters.erase(initialNameItr);
-	}
-
-	initialNameItr = initial_allowed_looters.find(playernameSoloSelfFound);
-	if (initialNameItr != initial_allowed_looters.end())
-	{
-		initial_allowed_looters.erase(initialNameItr);
-	}
-
 	std::unordered_set<std::string>::iterator deniedNameItr = denied_looters.find(playername);
 	if (deniedNameItr == denied_looters.end())
 	{
 		denied_looters.emplace(playername);
-	}
-
-	deniedNameItr = denied_looters.find(playernameSelfFound);
-	if (deniedNameItr == denied_looters.end())
-	{
-		denied_looters.emplace(playernameSelfFound);
-	}
-
-	deniedNameItr = denied_looters.find(playernameSolo);
-	if (deniedNameItr == denied_looters.end())
-	{
-		denied_looters.emplace(playernameSolo);
-	}
-
-	deniedNameItr = denied_looters.find(playernameSoloSelfFound);
-	if (deniedNameItr == denied_looters.end())
-	{
-		denied_looters.emplace(playernameSoloSelfFound);
 	}
 
 }
@@ -1430,6 +1262,14 @@ void Corpse::AllowPlayerLoot(std::string character_name) {
 	// Solo / SF are intentionally excluded from this function as there are exploits related to SSF players being able to loot the body here.
 
 }
+
+void Corpse::AddKillCredit(std::string character_name) {
+	if (character_name.size() == 0)
+		return;
+	if (kill_credit.find(character_name) == kill_credit.end())
+		kill_credit.emplace(character_name);
+}
+
 void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* app) {
 
 	if (!client)
@@ -1782,7 +1622,7 @@ void Corpse::LootCorpseItem(Client* client, const EQApplicationPacket* app) {
 		if (client && inst && item_data) {
 			if (item_data->pet || item_data->quest)
 			{
-				if (client->IsSoloOnly() || client->IsSelfFound())
+				if (client->IsSelfFoundAny())
 				{
 					bool can_loot = false;
 
@@ -1854,7 +1694,7 @@ void Corpse::LootCorpseItem(Client* client, const EQApplicationPacket* app) {
 			client->AddLootedLegacyItem(item_data->item_id, expiration_timestamp);
 		}
 
-		if (client->IsSoloOnly() || client->IsSelfFound()) {
+		if (client->IsSelfFoundAny()) {
 			// Mark the looter as the self-found owner.
 			inst->SetSelfFoundCharacter(client->CharacterID(), client->GetName());
 		}
@@ -2486,13 +2326,6 @@ void Corpse::ProcessLootLockouts(Client* give_exp_client, NPC* in_npc)
 						database.SaveCharacterLootLockout(playerItr->second.character_id, lootLockout.expirydate, in_npc->GetNPCTypeID(), in_npc->GetCleanName());
 
 						std::string appendedCharName = kg->membername[i];
-
-						if (playerItr->second.isSelfFound)
-							appendedCharName += "-SF";
-
-						if (playerItr->second.isSoloOnly)
-							appendedCharName += "-Solo";
-
 						temporarily_allowed_looters.emplace(appendedCharName);
 						records.erase(playerItr);
 					}
@@ -2592,15 +2425,7 @@ void Corpse::ProcessLootLockouts(Client* give_exp_client, NPC* in_npc)
 							}
 
 							std::string appendedCharName = kr->members[i].membername;
-
-							if (playerItr->second.isSelfFound)
-								appendedCharName += "-SF";
-
-							if (playerItr->second.isSoloOnly)
-								appendedCharName += "-Solo";
-
 							temporarily_allowed_looters.emplace(appendedCharName);
-
 
 							//if they're not in zone, this will be loaded once they are.
 							database.SaveCharacterLootLockout(playerItr->second.character_id, lootLockout.expirydate, in_npc->GetNPCTypeID(), in_npc->GetCleanName());
@@ -2683,14 +2508,6 @@ void Corpse::ProcessLootLockouts(Client* give_exp_client, NPC* in_npc)
 					database.SaveCharacterLootLockout(playerItr->second.character_id, lootLockout.expirydate, in_npc->GetNPCTypeID(), in_npc->GetCleanName());
 
 					std::string appendedCharName = give_exp_client->GetCleanName();
-
-					if (playerItr->second.isSelfFound)
-						appendedCharName += "-SF";
-
-					if (playerItr->second.isSoloOnly)
-						appendedCharName += "-Solo";
-
-
 					temporarily_allowed_looters.emplace(appendedCharName);
 					records.erase(playerItr);
 				}
@@ -2759,13 +2576,6 @@ void Corpse::ProcessLootLockouts(Client* give_exp_client, NPC* in_npc)
 			}
 			
 			std::string appendedCharName = record.second.character_name;
-
-			if (record.second.isSelfFound)
-				appendedCharName += "-SF";
-
-			if (record.second.isSoloOnly)
-				appendedCharName += "-Solo";
-
 			temporarily_allowed_looters.emplace(appendedCharName);
 		}
 		else
@@ -2839,14 +2649,6 @@ void Corpse::AddPlayerLockout(Client* c)
 		database.SaveCharacterLootLockout(c->CharacterID(), lootLockout.expirydate, npctype_id, GetCleanNPCName().c_str());
 
 		std::string appendedCharName = c->GetCleanName();
-
-		if (c->IsSelfFound())
-			appendedCharName += "-SF";
-
-		if (c->IsSoloOnly())
-			appendedCharName += "-Solo";
-
-
 		temporarily_allowed_looters.emplace(appendedCharName);
 	}
 }

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -122,14 +122,13 @@ class Corpse : public Mob {
 	void	AllowPlayerLoot(Mob *them);
 	void	DenyPlayerLoot(std::string character_name);
 	void	AllowPlayerLoot(std::string character_name);
+	void    AddKillCredit(std::string character_name);
 	void	AddLooter(Mob *who);
 	uint32	CountItems();
 	bool	CanPlayerLoot(std::string playername);
 	bool    ContainsLegacyItem();
 	void	ProcessLootLockouts(Client* give_exp_client, NPC* in_npc);
 	void	AddPlayerLockout(Client* c);
-	void	SetInitialAllowedLooters(const std::vector<std::string>& in) { initial_allowed_looters = std::unordered_set<std::string>(in.begin(), in.end()); }
-
 
 	inline void	Lock()				{ is_locked = true; }
 	inline void	UnLock()			{ is_locked = false; }
@@ -189,9 +188,9 @@ private:
 	bool		rez; /*Sets if a corpse has been rezzed or not to determine if XP should be given*/
 	bool		become_npc;
 	std::unordered_set<std::string>	allowed_looters; // People allowed to loot the corpse, character name
-	std::unordered_set<std::string>	initial_allowed_looters; // People initially allowed to loot the corpse, character name
 	std::unordered_set<std::string>	denied_looters; // People not allowed to loot the corpse, character name
-	std::unordered_set<std::string>	temporarily_allowed_looters; // People allowed to loot the corpse, character name
+	std::unordered_set<std::string>	temporarily_allowed_looters; // People that are eligible to loot a corpse that has a loot-lockout
+	std::unordered_set<std::string> kill_credit; // Names of players who got the initial kill credit (for self-found mostly)
 	Timer		corpse_decay_timer; /* The amount of time in millseconds in which a corpse will take to decay (Depop/Poof) */
 	Timer		corpse_rez_timer; /* The amount of time in millseconds in which a corpse can be rezzed */
 	Timer		corpse_delay_timer;

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -122,7 +122,7 @@ class Corpse : public Mob {
 	void	AllowPlayerLoot(Mob *them);
 	void	DenyPlayerLoot(std::string character_name);
 	void	AllowPlayerLoot(std::string character_name);
-	void    AddKillCredit(std::string character_name);
+	void    AddKillCredit(std::string character_name, bool is_self_found_any);
 	void	AddLooter(Mob *who);
 	uint32	CountItems();
 	bool	CanPlayerLoot(std::string playername);
@@ -190,7 +190,7 @@ private:
 	std::unordered_set<std::string>	allowed_looters; // People allowed to loot the corpse, character name
 	std::unordered_set<std::string>	denied_looters; // People not allowed to loot the corpse, character name
 	std::unordered_set<std::string>	temporarily_allowed_looters; // People that are eligible to loot a corpse that has a loot-lockout
-	std::unordered_set<std::string> kill_credit; // Names of players who got the initial kill credit (for self-found mostly)
+	std::unordered_set<std::string> sf_kill_credit; // Names of self-found players who got the initial kill credit
 	Timer		corpse_decay_timer; /* The amount of time in millseconds in which a corpse will take to decay (Depop/Poof) */
 	Timer		corpse_rez_timer; /* The amount of time in millseconds in which a corpse can be rezzed */
 	Timer		corpse_delay_timer;

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -97,14 +97,17 @@ public:
 	bool	HasOOZMember(std::string& member);
 	std::string GetMemberNamesAsCsv(const std::vector<std::string>& excludes = {});
 
+	// Describes the group composition (normal, self-found, etc). See: GroupType
+	ChallengeRules::RuleParams GetRuleSetParams() { SetLevels(); return groupData; }
+	ChallengeRules::RuleSet GetRuleSet() { return GetRuleSetParams().type; }
+
 	Mob* members[MAX_GROUP_MEMBERS];
 	char	membername[MAX_GROUP_MEMBERS][64];
 	char	leadername[64];
 	char	oldleadername[64]; // Keeps the previous leader name, so when the entity is destroyed we can still transfer leadership.
 	bool	disbandcheck;
 	bool	castspell;
-	uint8	maxlevel;
-	uint8	minlevel;
+	ChallengeRules::RuleParams groupData; // contains the group ruleset, min level, max levels, etc
 
 private:
 	Mob*	leader;

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -1043,7 +1043,7 @@ void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAd
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 					{
 						auto member = kr->members[x].member;
-						if (member && member->CanGetLootCreditWith(raid_data))
+						if (member && member->CanGetLootCreditWith(raid_data) && member->IsSelfFoundAny())
 						{
 							owner->CastToNPC()->sf_fte_list.emplace_back(member->GetCleanName());
 						}

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -1039,13 +1039,13 @@ void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAd
 				{
 					owner->CastToNPC()->solo_raid_fte = kr->GetID();
 					owner->CastToNPC()->sf_fte_list.clear();
-					const uint32 highest_level_in_raid = kr->GetHighestLevel2();
+					ChallengeRules::RuleParams raid_data = kr->GetRuleSetParams();
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++)
 					{
 						auto member = kr->members[x].member;
-						if (member && member->IsInLevelRange(highest_level_in_raid))
+						if (member && member->CanGetLootCreditWith(raid_data))
 						{
-							owner->CastToNPC()->sf_fte_list.emplace_back(member->GetSSFLooterName());
+							owner->CastToNPC()->sf_fte_list.emplace_back(member->GetCleanName());
 						}
 					}
 				}

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -241,7 +241,7 @@ bool Client::SummonItem(uint32 item_id, int8 quantity, uint16 to_slot, bool forc
 		return false;
 	}
 
-	if (IsSoloOnly() || IsSelfFound()) {
+	if (IsSelfFoundAny()) {
 		inst->SetSelfFoundCharacter(CharacterID(), GetName());
 	}
 
@@ -869,7 +869,7 @@ bool Client::PushItemOnCursorWithoutQueue(EQ::ItemInstance* inst, bool drop)
 		return false;
 	}
 
-	if (inst && (IsSoloOnly() || IsSelfFound())) {
+	if (inst && IsSelfFoundAny()) {
 		inst->SetSelfFoundCharacter(CharacterID(), GetName());
 		inst->SetContentsSelfFoundCharacter(CharacterID(), GetName());
 	}
@@ -1009,7 +1009,7 @@ void Client::PutLootInInventory(int16 slot_id, const EQ::ItemInstance &inst, Loo
 				continue;
 
 			EQ::ItemInstance *bagitem = database.CreateItem(bag_item_data[i]->item_id, bag_item_data[i]->charges, bag_item_data[i]->quarm_item_data);
-			if (bagitem && (IsSoloOnly() || IsSelfFound())) {
+			if (bagitem && IsSelfFoundAny()) {
 				bagitem->SetSelfFoundCharacter(CharacterID(), name);
 			}
 			interior_slot = EQ::InventoryProfile::CalcSlotId(slot_id, i);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1004,7 +1004,7 @@ void Lua_Client::SetSelfFound(int self_found) {
 
 int Lua_Client::IsSelfFound() {
 	Lua_Safe_Call_Int();
-	return self->IsSelfFound();
+	return self->IsSelfFoundAny();
 }
 
 void Lua_Client::SetSoloOnly(int solo_only) {

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1004,7 +1004,7 @@ void Lua_Client::SetSelfFound(int self_found) {
 
 int Lua_Client::IsSelfFound() {
 	Lua_Safe_Call_Int();
-	return self->IsSelfFoundAny();
+	return self->GetSelfFound();
 }
 
 void Lua_Client::SetSoloOnly(int solo_only) {

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -105,7 +105,7 @@ void handle_npc_event_trade(
 
 	if (init && init->IsClient())
 	{
-		lua_pushinteger(L, init->CastToClient()->IsSelfFound() != 1 && init->CastToClient()->IsSoloOnly() != 1 ? 1 : 0);
+		lua_pushinteger(L, init->CastToClient()->IsSelfFoundAny() != true ? 1 : 0);
 		lua_setfield(L, -2, "enable_multiquest");
 	}
 	// set a reference to the client inside of the trade object as well for plugins to process

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5603,9 +5603,9 @@ void Mob::AddAllClientsToEngagementRecords()
 				record.lockout = LootLockout();
 				record.character_id = client.second->CharacterID();
 				strncpy(record.character_name, client.second->CastToClient()->GetCleanName(), 64);
-				record.isSelfFound = client.second->IsSelfFound();
-				record.isSoloOnly = client.second->IsSoloOnly();
-				strncpy(record.character_name, client.second->GetCleanName(), 64);
+				record.character_level = client.second->CastToClient()->GetLevel();
+				record.character_level2 = client.second->CastToClient()->GetLevel2();
+				record.character_ruleset = client.second->CastToClient()->GetRuleSet();
 
 				auto lootLockoutItr = client.second->loot_lockouts.find(GetNPCTypeID());
 				if (lootLockoutItr != client.second->loot_lockouts.end())

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1450,7 +1450,7 @@ void NPC::PickPocket(Client* thief)
 						{
 							if(slotid >= 0)
 							{
-								if (thief->IsSoloOnly() || thief->IsSelfFound())
+								if (thief->IsSelfFoundAny())
 								{
 									inst->SetSelfFoundCharacter(thief->CharacterID(), thief->GetName());
 								}

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -177,7 +177,7 @@ Object::Object(const EQ::ItemInstance *inst, float x, float y, float z, float he
 {
 	if (is_player_drop && client) {
 		m_character_id = client->CharacterID();
-		m_ssf_ruleset = client->IsSoloOnly() || client->IsSelfFound();
+		m_ssf_ruleset = client->IsSelfFoundAny();
 	} else {
 		m_character_id = 0;
 		m_ssf_ruleset = false;
@@ -670,11 +670,7 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 
 		if (m_inst && m_inst->IsType(EQ::item::ItemClassBag))
 		{
-			if (sender->IsSoloOnly())
-			{
-				m_inst->Clear();
-			}
-			else if (sender->IsSelfFound())
+			if (sender->IsSelfFoundAny() && user != last_user)
 			{
 				m_inst->Clear();
 			}

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1911,6 +1911,41 @@ uint16 Raid::GetAvgLevel()
 	return (uint16(levelHolder));
 }
 
+ChallengeRules::RuleParams Raid::GetRuleSetParams() {
+
+	ChallengeRules::RuleParams params;
+	memset(&params, 0, sizeof(ChallengeRules::RuleParams));
+	params.min_level = 65;
+	params.max_level = 1;
+	params.max_level2 = 1;
+
+	for (int i = 0; i < MAX_RAID_MEMBERS; i++)
+	{
+		if (members[i].member != nullptr)
+		{
+			Client* cmember = members[i].member;
+			if (cmember && cmember->GetZoneID() == zone->GetZoneID())
+			{
+				if (cmember->GetLevel() > params.max_level)
+					params.max_level = cmember->GetLevel();
+				if (cmember->GetLevel2() > params.max_level2)
+					params.max_level2 = cmember->GetLevel2();
+				if (cmember->GetLevel() < params.min_level)
+					params.min_level = cmember->GetLevel();
+
+				if (params.type < ChallengeRules::RuleSet::NORMAL)
+				{
+					ChallengeRules::RuleSet member_type = cmember->GetRuleSet();
+					if (member_type > params.type)
+						params.type = member_type;
+				}
+			}
+		}
+	}
+
+	return params;
+}
+
 const char *Raid::GetClientNameByIndex(uint8 index)
 {
 	return members[index].membername;

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -112,6 +112,9 @@ public:
 	uint32	GetGroup(const char *name);
 	uint32	GetGroup(Client *c);
 	uint16	GetAvgLevel();
+	// Describes the group composition (normal, self-found, etc). See: GroupType
+	ChallengeRules::RuleParams GetRuleSetParams();
+	ChallengeRules::RuleSet GetRuleSet() { return GetRuleSetParams().type; }
 
 	uint32	GetLootType() { return LootType; }
 	void	ChangeLootType(uint32 type);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1066,7 +1066,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 							safe_delete(SummonedItem);
 						}
 						SummonedItem = database.CreateItem(spell.base[i], quantity);
-						if (SummonedItem && (c->IsSelfFound() || c->IsSoloOnly())) {
+						if (SummonedItem && c->IsSelfFoundAny()) {
 							SummonedItem->SetSelfFoundCharacter(c->CharacterID(), c->GetName());
 						}
 					}
@@ -1095,7 +1095,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 					if (item->NoDrop != 0 && (!IsCharmedPet() || (IsCharmedPet() && CastToNPC()->CountQuestItem(item->ID) == 0)))
 					{
 						QuarmItemData quarm_item_data = QuarmItemData();
-						if (caster && caster->IsClient() && (caster->CastToClient()->IsSelfFound() || caster->CastToClient()->IsSoloOnly())) {
+						if (caster && caster->IsClient() && caster->CastToClient()->IsSelfFoundAny()) {
 							quarm_item_data.SetSelfFoundCharacter(item, caster->CastToClient()->CharacterID(), caster->CastToClient()->GetName());
 						}
 
@@ -1136,7 +1136,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 					if (item->NoDrop != 0 && (!IsCharmedPet() || (IsCharmedPet() && CastToNPC()->CountQuestItem(item->ID) == 0)))
 					{
 						QuarmItemData quarm_item_data = QuarmItemData();
-						if (caster && caster->IsClient() && (caster->CastToClient()->IsSelfFound() || caster->CastToClient()->IsSoloOnly())) {
+						if (caster && caster->IsClient() && caster->CastToClient()->IsSelfFoundAny()) {
 							quarm_item_data.SetSelfFoundCharacter(item, caster->CastToClient()->CharacterID(), caster->CastToClient()->GetName());
 						}
 						CastToNPC()->AddPetLoot(item->ID, charges, false, quarm_item_data);
@@ -1166,7 +1166,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 
 						EQ::ItemInstance *SubItem = database.CreateItem(spell.base[i], charges);
 						if (SubItem != nullptr) {
-							if (CastToClient()->IsSoloOnly() || CastToClient()->IsSelfFound()) {
+							if (CastToClient()->IsSelfFoundAny()) {
 								SubItem->SetSelfFoundCharacter(CastToClient()->CharacterID(), CastToClient()->GetName());
 							}
 							SummonedItem->PutItem(slot, *SubItem);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -906,7 +906,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet& p)
 			if (Invitee && Invitee->IsClient() && Invitee->CastToClient()->GetBaseClass() == 0)
 				is_null_flag = 1;
 
-			if (Invitee && Invitee->IsClient() && !Invitee->IsRaidGrouped() && gis->is_null == is_null_flag && Invitee->CastToClient()->IsSelfFound() == gis->self_found && !Invitee->CastToClient()->IsSoloOnly())
+			if (Invitee && Invitee->IsClient() && !Invitee->IsRaidGrouped() && Invitee->CastToClient()->CanGroupWith(gis->group_ruleset))
 			{
 				auto outapp = new EQApplicationPacket(OP_GroupInvite, sizeof(GroupInvite_Struct));
 				memcpy(outapp->pBuffer, gis, sizeof(GroupInvite_Struct));


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/648449b7-51b6-49c4-9ec5-202794fd4f8e)
Dialogue tree added to drop challenges (unless you are doing Null-class challenge).
- Hardcore -> Softcore
- Solo -> Self-Found Classic -> Self-Found Flex -> Normal

Testing - Confirmed existing behavior that we didn't re-add any of the nasty bugs
- [x] Added new PoD Dialogue for SF+ and removing challenges.
- [x] Can still loot after the 4min/15min timer expires.
- [x] Loot credit granted if you were present for FTE or Kill.
- [x] Must be in level range of the highest level of the group, also respecting the NG+ grouping logic with it's "hidden level2"
- [x] Must be in compatible challenge rulesets for exp/loot.
- [x] Cannot invite someone that would cause the group to have incompatible rulesets.
- [x] Spell casting seems to be accurate in terms of what is allowed.
- [x] The existing logic for FTEs/DS credit is still there for SF, so I think that should still work.
- [x] Cannot put items on NPC corpses and loot them after accepting challenges.

Additional SF Improvements
- [x] [Raids] Loot credit is now also granted if you participated in the fight but happened to miss the exact moments of the FTE and Kill, which could sometimes happen on DT/AE fights. As long as you are still in the raid at the time of kill.
- [x] Accidentally closing a tradeskill container should not delete your items if you immediately re-open the container before someone else touches it.

Notes
 - A lot of the changes here were just about refactoring the logic that got bloated into a more manageable system, and the final result is that it is pretty straightforward to maintain now.
 - Consolidated all the different ruleset variations of exp/loot/group-invite/raid-invite codepaths into a single codepath that is merged into the main exp/loot code (deleted a lot of copy/paste and one-off logic). Now we detect which `ChallengeRuleSet` is on each player, and the dominant `ChallengeRuleSet` for the group/raid (`Normal > SF > SF+ > NullClass`). Each player is individually checked if their character/ruleset meets the loot & exp requirements for their group's ruleset/level during a kill for kill credit and exp, respectively.