### PR TITLE
Feature: Adds support for Item casttime overrides while in current expansion Instances and PvP zones.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2875,7 +2875,9 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 
 				if ((item->Click.Type == EQ::item::ItemEffectClick) || (item->Click.Type == EQ::item::ItemEffectExpendable) || (item->Click.Type == EQ::item::ItemEffectEquipClick) || (item->Click.Type == EQ::item::ItemEffectClick2))
 				{
-					int32 casttime_ = item->CastTime;
+					int32 casttime_ = item->CastTime_ != 0 && zone->GetGuildID() != 0 && zone->GetZoneExpansion() == content_service.GetCurrentExpansion()
+						? item->CastTime_ // cast time override for current expansion instances
+						: item->CastTime; // normal cast time
 					// Clickies with 0 casttime and expendable items had no level or regeant requirement on AK. Also, -1 casttime was instant cast.
 					if(casttime_ <= 0 || inst->IsExpendable())
 					{


### PR DESCRIPTION
This patch makes it so we can use the `item.casttime_` field as the Instance/PVP override for clicky cast times, allowing us to nerf items in current expansion instances and pvp.

The Item table has a `casttime` and `casttime_` field, the latter was unused. So we can use that.

### Notes
- If `casttime_` is `0` (default), it falls back to the default `casttime`.
- If `casttime_` is `-1` the spell becomes instant.
- Double checked all existing items, and `casttime_` is either 0 or equal to `casttime`, so it will not affect any current items.
- DB changes not included, that's up to ya'll on what you'd like to nerf or un-nerf in whichever scenarios.
- Tested both variations and they're working (casttime -> instant, and instant -> casttime)

## Example
```
UPDATE items set casttime_ = 4000 WHERE name like '%Undeads Recourse%';
```

## PvP and Instance (Cast time 4.0 sec)

https://github.com/user-attachments/assets/c3c871d6-43c5-433a-9cf0-7b5d294d1ac1

## Open World (Cast time instant)

https://github.com/user-attachments/assets/f7dce3b8-ee01-4f3d-aade-5291cdc94ab3

