### PR TITLE
PvP: Speed effects enabled in outdoor zones. Bard Selos is self only.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1743,6 +1743,10 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			targetType = ST_ProjectIllusion;
 	}
 
+	// PvP - Bard Selo is self only
+	if (zone->GetGuildID() == 1 && spells[spell_id].bardsong && spells[spell_id].goodEffect && GetSpellEffectIndex(spell_id, SE_MovementSpeed) != -1)
+		targetType = ST_Self;
+
 	switch (targetType)
 	{
 		// single target spells

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1069,7 +1069,6 @@ bool Zone::Init(bool is_static) {
 	if (guildid == 1)
 	{
 		pvpzone = true;
-		can_castoutdoor = false;
 		reducedspawntimers = false;
 	}
 


### PR DESCRIPTION
## Context
Based on discord PvP feedback, it seems everyone has been receptive to the following adjustments. So this PR enables:
- Allowing Selo's to be self-only.
- Allowing movement speed effects in outdoor PvP zones.

![image](https://github.com/user-attachments/assets/92014041-2c14-4f8e-99a9-b64a590aff45)

## Tested
- [x] Selos works self-only in Skyfire,
- [x] Selos doesn't work indoors in Seb.


