### PR TITLE
Patch: Dll Versioning Support and Song Window V1/V2 detection

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -59,7 +59,10 @@ namespace AppearanceType {
 
 // Feature Flag IDs used by the above ClientDllFeature/ClientZealFeature handshake messages.
 namespace ClientFeature {
-	constexpr uint16 BuffStackingPatchHandshake = 1;
+	constexpr uint16 BuffStackingPatchHandshakeV1 = 1; // Deprecated. Sent by the initial/beta version of the eqgame.dll
+	constexpr uint16 BuffStackingPatchWithSongWindowHandshake = 2; // Sent by the official/stable release of the eqgame.dll (New UI users)
+	constexpr uint16 BuffStackingPatchWithoutSongWindowHandshake = 3; // Sent by the official/stable release of the eqgame.dll (Old UI users)
+	constexpr uint16 CodeVersion = 4; // Sent by eqgame.dll, provides its DLL_VERSION value to the server. Could theoretically be used by Zeal too if desired.
 }
 
 // solar: Animations for AnimationType:Animation

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -334,6 +334,7 @@ RULE_INT(Quarm, PVPInstanceGraveyardTime, 30, "")
 RULE_REAL(Quarm, PVPDayVariance, 7, "")
 RULE_BOOL(Quarm, EnablePVPInstances, false, "Enables or disables PVP instance book entry via guild 1.")
 RULE_BOOL(Quarm, UseFixedShowHelmBehavior, true, "Fixes ShowHelm to be a personal toggle that works like other MMOs. Also adds full compatibility with Zeal's ShowHelm feature and Velious Helms support.")
+RULE_INT(Quarm, WarnDllVersionBelow, 1, "Sends a Client-out-of-date warning message to clients below this dll version.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(SelfFound)

--- a/zone/client.h
+++ b/zone/client.h
@@ -75,9 +75,6 @@ struct ItemData;
 #define ASSIST_RANGE		250 // range for /assist
 #define MAX_SPECIALIZED_SKILL 50
 
-#define BUFFSTACKING_PATCH_V2 2 // Buff Stacking Patch + 6 Buff Song Window (Requires New UI)
-#define BUFFSTACKING_PATCH_V1 1 // Buff Stacking Patch only (Old UI)
-
 constexpr int SONG_WINDOW_BUFF_SLOTS = 6; // Buffstacking patch enables song window support
 constexpr int CLIENT_MAX_BUFF_SLOTS = (15 + SONG_WINDOW_BUFF_SLOTS);
 constexpr int CLIENT_TOTAL_BUFF_SLOTS = (15 + SONG_WINDOW_BUFF_SLOTS + 1); // add 1 for disc slot
@@ -1587,6 +1584,9 @@ private:
 
 	bool m_buff_stacking_patch = false; // Flag for whether the client has a buffstacking patch installed. See Handle_OP_SpawnAppearance for how this is negotiated.
 	uint8 m_song_window_slots = 0; // If buffstacking patch is on, this is the number of song window slots available
+
+	uint16 m_dll_version = 0; // Sent by newer versions of the eqgame.dll when connecting to a zone.
+	bool m_old_feature_detected = false; // If set before ConnectComplete() automatically notifies the client with an out-of-date message.
 };
 
 #endif

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -674,6 +674,10 @@ void Client::CompleteConnect()
 		return;
 	}
 
+	if (m_dll_version < RuleI(Quarm, WarnDllVersionBelow) || m_old_feature_detected)
+	{
+		Message(Chat::Red, "You are running on an older version of the client. Please run the patcher or manually download the server files.");
+	}
 
 	//enforce some rules..
 	if (!CanBeInZone()) {
@@ -1033,39 +1037,60 @@ void Client::Handle_Connect_OP_SpawnAppearance(const EQApplicationPacket *app)
 		uint32 feature_value = sa->parameter & 0xFFFFu; // feature value is encoded in the lo-word of SpawnAppearance->parameter.
 
 		switch (feature_id) {
-			// -----------------------------------------------------------------------------------------------------------------------------------
-			// Any unknown feature is ignored.
-			// -----------------------------------------------------------------------------------------------------------------------------------
-		default:
-			return;
-			// -----------------------------------------------------------------------------------------------------------------------------------
-			// Buff Stacking Patch - Client can enable a patch to fix its broken buffstacking code, but the server must mirror it's logic.
-			// If they both agree to turn on this patch, the server will respond to the client with the feature enabled.
-			// See buffstacking.cpp for where this is mirrored on the server.
-			// * Handshake Type: Client initiates the request when zoning, server responds.
-			// -----------------------------------------------------------------------------------------------------------------------------------
-		case ClientFeature::BuffStackingPatchHandshake: // == 1
+		default: // Unknown message
 		{
-			if (!RuleB(Spells, AllowBuffstackingPatch)) {
-				feature_value = 0; // Feature disabled
+			return; // no response
+		}
+		case ClientFeature::CodeVersion: // Client is telling us its version
+		{
+			if (sa->type == AppearanceType::ClientDllMessage)
+				m_dll_version = feature_value;
+			return; // no response
+		}
+		case ClientFeature::BuffStackingPatchHandshakeV1: // Deprecated handshake of older eqgame.dll's buffstacking patch, no longer supported.
+		{
+			m_old_feature_detected = true; // Tells the user their eqgame.dll is out of date
+			return; // no response
+		}
+		case ClientFeature::BuffStackingPatchWithSongWindowHandshake: // Enables BuffStacking + Song Window (NewUI Uesrs)
+		{
+			if (!RuleB(Spells, AllowBuffstackingPatch))
+			{
+				feature_value = 0;
+				SetBuffStackingPatch(false);
+				SetSongWindowSlots(0);
 			}
-			else if (feature_value == 0 || feature_value == 0xFFFF) {
-				feature_value = 0; // Disabled
+			else if (feature_value >= 1)
+			{
+				feature_value = 1;
+				SetBuffStackingPatch(true);
+				SetSongWindowSlots(SONG_WINDOW_BUFF_SLOTS);
 			}
-			else if (feature_value >= BUFFSTACKING_PATCH_V2) {
-				send_response |= feature_value > BUFFSTACKING_PATCH_V2;
-				feature_value = BUFFSTACKING_PATCH_V2;
+			else
+			{
+				feature_value = 0;
+				SetBuffStackingPatch(false);
+				SetSongWindowSlots(0);
 			}
-			// Handshake complete, set the flags
-			if (feature_value == BUFFSTACKING_PATCH_V2) {
-				SetBuffStackingPatch(true); // New buffstacking logic
-				SetSongWindowSlots(SONG_WINDOW_BUFF_SLOTS); // 6 song window slots
+			break;
+		}
+		case ClientFeature::BuffStackingPatchWithoutSongWindowHandshake: // Enables BuffStacking, but no Song Window (OldUI Users)
+		{
+			if (!RuleB(Spells, AllowBuffstackingPatch))
+			{
+				feature_value = 0;
+				SetBuffStackingPatch(false);
+				SetSongWindowSlots(0);
 			}
-			else if (feature_value == BUFFSTACKING_PATCH_V1) {
-				SetBuffStackingPatch(true); // New buffstacking logic
-				SetSongWindowSlots(0); // No song window slots
+			else if (feature_value >= 1)
+			{
+				feature_value = 1;
+				SetBuffStackingPatch(true);
+				SetSongWindowSlots(0);
 			}
-			else {
+			else
+			{
+				feature_value = 0;
 				SetBuffStackingPatch(false);
 				SetSongWindowSlots(0);
 			}


### PR DESCRIPTION
Server now sends an out-of-date warning message to clients using an old eqgame.dll
- Rule `Quarm:WarnDllVersionBelow` controls who gets the warning message.
- eqgame.dll defines its DLL_VERSION in eqgame.cpp and sends it during zone connection.
- All previous versions will show up as version 0. The new version going live soon will show up as version 1.

![image](https://github.com/user-attachments/assets/80199b46-6446-4f5a-b877-10a9a62be00c)

Improved Buff Stacking / Song Window handshake process.
- The upcoming (New/Fixed) eqgame.dll will be able to turn on Buff Stacking / Song Window.
- The existing/current versions will only get the "out-of-date" message and remain disabled.