### PR TITLE
Fix SSF players being able to buff each other

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -822,8 +822,26 @@ namespace ChallengeRules {
 		return true; // should not reach
 	}
 
-	static bool CanHelp(ChallengeRules::RuleSet self_type, uint8 self_level, uint8 self_level2, ChallengeRules::RuleSet target, uint8 target_level, uint8 target_level2) {
-		return CanGetLootCreditWith(target, target_level, target_level2, self_type, self_level, self_level2);
+	static bool CanHelp(ChallengeRules::RuleSet caster_ruleset, uint8 caster_level, uint8 caster_level2, ChallengeRules::RuleSet target_ruleset, uint8 target_level, uint8 target_level2)
+	{
+		switch (target_ruleset)
+		{
+		case ChallengeRules::NULL_CLASS:
+			return caster_ruleset == ChallengeRules::RuleSet::NULL_CLASS
+				&& InLevelRange(target_level, caster_level)
+				&& InLevelRange(target_level2, caster_level2);
+		case ChallengeRules::SOLO:
+			return false;
+		case ChallengeRules::SELF_FOUND_CLASSIC:
+			return IsSelfFoundAny(caster_ruleset)
+				&& InLevelRange(target_level, caster_level)
+				&& InLevelRange(target_level2, caster_level2);
+		case ChallengeRules::SELF_FOUND_FLEX:
+			return InLevelRange(target_level, caster_level);
+		case ChallengeRules::NORMAL:
+			return true;
+		}
+		return true; // should not reach
 	}
 }
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7184,6 +7184,14 @@ bool Client::CanGetExpCreditWith(ChallengeRules::RuleSet other, uint8 max_level,
 bool Client::CanGetLootCreditWith(ChallengeRules::RuleSet group, uint8 max_level, uint8 max_level2) {
 	return ChallengeRules::CanGetLootCreditWith(GetRuleSet(), GetLevel(), GetLevel2(), group, max_level, max_level2);
 }
+bool Client::CanHelp(Client* target)
+{
+	if (!target)
+		return false;
+	if (target == this)
+		return true;
+	return ChallengeRules::CanHelp(GetRuleSet(), GetLevel(), GetLevel2(), target->GetRuleSet(), target->GetLevel(), target->GetLevel2());
+}
 
 std::vector<int> Client::GetMemmedSpells() {
 	std::vector<int> memmed_spells;

--- a/zone/client.h
+++ b/zone/client.h
@@ -514,7 +514,7 @@ public:
 	bool CanGetExpCreditWith(ChallengeRules::RuleParams& data) { return CanGetExpCreditWith(data.type, data.max_level, data.max_level2); }
 	bool CanGetLootCreditWith(ChallengeRules::RuleParams& data, bool sf_fte) { return CanGetLootCreditWith(data) && (sf_fte || !IsFteRequired()); }
 	bool CanGetExpCreditWith(ChallengeRules::RuleParams& data, bool sf_fte) { return CanGetExpCreditWith(data) && (sf_fte || !IsFteRequired()); }
-	bool CanHelp(Client* target) { return target == this || target->CanGetLootCreditWith(GetRuleSet(), GetLevel(), GetLevel2()); }
+	bool CanHelp(Client* target);
 
 	inline void SetHardcore(uint8 in_hardcore) { m_epp.hardcore = in_hardcore; }
 	inline void SetSoloOnly(uint8 in_solo_only) { m_epp.solo_only = in_solo_only; }

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -186,7 +186,7 @@ namespace {
 			return false;
 
 		// For whitelisted spells - Allow target to benefit if it was only a level-range conflict:
-		if (target->CanGetLootCreditWith(caster->GetRuleSet(), 1, 1)) {
+		if (ChallengeRules::CanHelp(caster->GetRuleSet(), 1, 1, target->GetRuleSet(), 1, 1)) {
 			if (spell_id == SPELL_WIND_OF_THE_NORTH || spell_id == SPELL_WIND_OF_THE_SOUTH ||
 				spell_id == SPELL_TISHANS_RELOCATION || spell_id == SPELL_MARKARS_RELOCATION)
 				return true;


### PR DESCRIPTION
- Fixed a bug that allowed solo-self-found players to buff each other.

The `ChallengeRules::CanHelp()`, function had an incorrect assumption for Solo players since it was sharing code with Loot Rules, which does allow a Solo player to "loot with itself" (to simplify the Loot/Exp code, since they can't group with anyone but "themselves"). But caused a bug with buffing logic, since that can be done out of group, thus becoming "buff any Solo" rather than "buff myself".

Fixed by adding a dedicated  `ChallengeRules::CanHelp()` function that doesn't share code with Loot Rules, which always returns `false` for Solos receiving help.