### PR TITLE
Fix SF loot deny bug caused by Mez

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2358,7 +2358,7 @@ void Mob::WipeHateList(bool from_memblur)
 	{
 		SetTarget(nullptr);
 		hate_list.Wipe(from_memblur);
-		DamageTotalsWipe();
+		DamageTotalsWipe(from_memblur);
 	}
 
 	if (!from_memblur)


### PR DESCRIPTION
- SF loot was  sometimes being denied after Mez (memblur), because the from_memblur flag was not propagated.

This flag needed to be propagated, otherwise the progress towards doing majority damage kept getting reset every Mez if a blur procced.

There might be more going on with the SF loot deny bugs, but this one was a simple fix.