### PR TITLE
QoL: Correctly added Hand of Glory keyring + a couple other Key Rings

### DIFF
--- a/utils/sql/git/content/2025_03_01_AddKeyRing_HandOfGlory_Hole_Paineel.sql
+++ b/utils/sql/git/content/2025_03_01_AddKeyRing_HandOfGlory_Hole_Paineel.sql
@@ -1,0 +1,8 @@
+-- Hand of Glory (only the door behind Drusella, at the exit pad)
+UPDATE doors SET nokeyring = 0 WHERE keyitem = 17274 and altkeyitem = 0;
+
+-- Hole Key
+UPDATE doors SET nokeyring = 0 WHERE keyitem = 6379 AND altkeyitem = 0;
+
+-- Paineel Key
+UPDATE doors SET nokeyring = 0 WHERE keyitem = 6378 AND altkeyitem = 0;

--- a/utils/sql/git/content/2025_03_01_AddKeyRing_HandOfGlory_Hole_Paineel.sql
+++ b/utils/sql/git/content/2025_03_01_AddKeyRing_HandOfGlory_Hole_Paineel.sql
@@ -1,8 +1,20 @@
 -- Hand of Glory (only the door behind Drusella, at the exit pad)
 UPDATE doors SET nokeyring = 0 WHERE keyitem = 17274 and altkeyitem = 0;
 
+INSERT INTO keyring_data (key_item, key_name, zoneid, stage)
+SELECT 17274, 'Hand of Glory', 105, 0
+WHERE NOT EXISTS (SELECT 1 FROM keyring_data WHERE key_item = 17274);
+
 -- Hole Key
 UPDATE doors SET nokeyring = 0 WHERE keyitem = 6379 AND altkeyitem = 0;
 
+INSERT INTO keyring_data (key_item, key_name, zoneid, stage)
+SELECT 6379, 'Hole Key', 75, 0
+WHERE NOT EXISTS (SELECT 1 FROM keyring_data WHERE key_item = 6379);
+
 -- Paineel Key
 UPDATE doors SET nokeyring = 0 WHERE keyitem = 6378 AND altkeyitem = 0;
+
+INSERT INTO keyring_data (key_item, key_name, zoneid, stage)
+SELECT 6378, 'Bone Crafted Key', 75, 0
+WHERE NOT EXISTS (SELECT 1 FROM keyring_data WHERE key_item = 6378);


### PR DESCRIPTION
Added key ring support for:
- Paineel Key
- Hole Key
- Hand of Glory*
  - *Only gets added if you use the FINAL door in East Wing, behind Drusella's room at the exit pad (see screenshot)
  - This door is HoG-only, so this door is safe to use as the keyring trigger, without causing the bugs that would previously happen that caused the NO RENT keyrings items to get saved. After using this final door with HoG, the whole zone is unlocked.

### Hole Key (rock from Paineel -> Hole)
![image](https://github.com/user-attachments/assets/d27dbe94-5bbf-4617-be87-a39d92793624)

### Paineel Key (Paineel elevator)
![image](https://github.com/user-attachments/assets/53e4787f-12b8-4db5-afbb-4adad71bca5a)

### Hand of Glory (Howling Stones, added when used on final door)
![image](https://github.com/user-attachments/assets/7c164866-b4b1-4799-84e8-fa8832d97de3)

### /keys output
![image](https://github.com/user-attachments/assets/45960220-97d1-412f-84f7-14357d511935)
