### PR TITLE
Self Found - Add support to recharge/repurchase items from vendors

### DIFF
--- a/common/patches/mac.cpp
+++ b/common/patches/mac.cpp
@@ -934,6 +934,18 @@ namespace Mac {
   
 			mac_pop_item->ItemClass = item->ItemClass;
 			strcpy(mac_pop_item->Name,item->Name);
+
+			// Append '*' to SelfFound item names
+			if (inst->GetSelfFoundCharacterID())
+			{
+				int namelen = strlen(mac_pop_item->Name);
+				if (namelen + 1 < sizeof(mac_pop_item->Name))
+				{
+					mac_pop_item->Name[namelen++] = '*';
+					mac_pop_item->Name[namelen] = '\0';
+				}
+			}
+
 			strcpy(mac_pop_item->Lore,item->Lore);       
 			strcpy(mac_pop_item->IDFile,item->IDFile);  
 			mac_pop_item->Weight = item->Weight;      

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -342,6 +342,8 @@ RULE_CATEGORY_END()
 
 RULE_CATEGORY(SelfFound)
 RULE_BOOL(SelfFound, PetLootSupport, true, "Allow solo/self-found players to loot their own SF items back from pet/npc corpses. This allows SF players to recover their items they gave to charmed pets.")
+RULE_BOOL(SelfFound, TempMerchantSupport, true, "Allow solo/self-found players to repurchase their own SF Items sold to Merchant temp inventory, up to the amount of SF items sold that belonged to them. This allows SF players to vendor recharge their own items. Also makes temp inventory visible, but will get an error message if trying purchase items they are not permitted to buy.")
+RULE_BOOL(SelfFound, TempMerchantFiltering, false, "Make solo/self-found players only see merchant temp inventory for their own purchasable items, hiding the rest. If disabled, they can see the whole temp inventory, but can still only purchase their valid SF items back.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Map )

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2084,6 +2084,7 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 		if (IsNPC() && ismerchant && RuleB(Merchant, ClearTempList)) {
 			database.DeleteMerchantTempList(GetNPCTypeID());
 			zone->tmpmerchanttable[GetNPCTypeID()].clear();
+			zone->tmpmerchanttable_ssf_purchase_limits[GetNPCTypeID()].clear();
 		}
 	}
 	else

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4955,6 +4955,30 @@ void EntityList::SendTraderUpdateMessage(Client* merchant, const EQ::ItemData* i
 }
 
 
+void EntityList::SendDeletedSelfFoundMerchantInventory(Mob* merchant, int32 slotid, uint32 itemid)
+{
+	if (!merchant || !merchant->IsNPC())
+		return;
+
+	for (auto it = client_list.begin(); it != client_list.end(); ++it)
+	{
+		Client* c = it->second;
+		if (c && c->IsSelfFoundAny() && c->GetMerchantSession() == merchant->GetID())
+		{
+			if (zone->GetSelfFoundPurchaseLimit(merchant->GetNPCTypeID(), itemid, c->CharacterID()) == 0) {
+				auto delitempacket = new EQApplicationPacket(OP_ShopDelItem, sizeof(Merchant_DelItem_Struct));
+				Merchant_DelItem_Struct* delitem = (Merchant_DelItem_Struct*)delitempacket->pBuffer;
+				delitem->itemslot = slotid;
+				delitem->npcid = merchant->GetID();
+				delitem->playerid = c->GetID();
+				delitempacket->priority = 6;
+				c->QueuePacket(delitempacket);
+				safe_delete(delitempacket);
+			}
+		}
+	}
+}
+
 void EntityList::SendMerchantInventory(Mob* merchant, int32 slotid, bool isdelete)
 {
 

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -451,6 +451,7 @@ public:
 	uint8 GetClientCountByBoatNPCID(uint32 boatid);
 	uint8 GetClientCountByBoatID(uint32 entityid);
 	void SendMerchantEnd(Mob* merchant);
+	void SendDeletedSelfFoundMerchantInventory(Mob* merchant, int32 slotid, uint32 itemid);
 	void SendMerchantInventory(Mob* merchant, int32 slotid = -1, bool isdelete = false);
 	void SendTraderEnd(Client* merchant);
 	bool TraderHasCustomer(Client* merchant);


### PR DESCRIPTION
- SF can repurchase items they sold to a vendor, equal to the amount they have sold (non-stackables only)