### PR TITLE
Improve usability of #wc command

### DIFF
--- a/zone/gm_commands/wc.cpp
+++ b/zone/gm_commands/wc.cpp
@@ -1,9 +1,23 @@
 #include "../client.h"
 
+uint32 command_wc_parse_int(char* str)
+{
+	if (!str)
+		return 0;
+
+	if (str[0] == '0' && str[1] == 'x')
+		return strtoul(&str[2], nullptr, 16);
+
+	if (str[0] == '0' && str[1] == 'b')
+		return strtoul(&str[2], nullptr, 2);
+	
+	return strtoul(str, nullptr, 10);
+}
+
 void command_wc(Client *c, const Seperator *sep){
 	if (sep->argnum < 2)
 	{
-		c->Message(Chat::White, "Usage: #wc slot material [color] [unknown06]");
+		c->Message(Chat::White, "Usage: #wc slot material [color], or #wc slot material [r g b] [mask]");
 	}
 	else if (c->GetTarget() == nullptr) {
 		c->Message(Chat::Red, "You must have a target to do a wear change.");
@@ -14,9 +28,21 @@ void command_wc(Client *c, const Seperator *sep){
 		uint16 texture = atoi(sep->arg[2]);
 		uint32 color = 0;
 		
-		if (sep->argnum > 2)
+		if (sep->argnum == 3) // [color]
 		{
-			color = atoi(sep->arg[3]);
+			color = command_wc_parse_int(sep->arg[3]);
+		}
+		else if (sep->argnum == 5 || sep->argnum == 6) // [r] [g] [b] [mask]
+		{
+			uint32 red = command_wc_parse_int(sep->arg[3]) & 0xFF;
+			uint32 green = command_wc_parse_int(sep->arg[4]) & 0xFF;
+			uint32 blue = command_wc_parse_int(sep->arg[5]) & 0xFF;
+			uint32 mask = sep->argnum == 6 ? command_wc_parse_int(sep->arg[6]) & 0xFF : 0;
+			color = (mask << 24) | (red << 16) | (green << 8) | blue;
+		}
+		else if (sep->argnum > 2)
+		{
+			c->Message(Chat::White, "Usage: #wc slot material [color], or #wc slot material red green blue [mask]");
 		}
 
 		c->GetTarget()->WearChange(wearslot, texture, color);


### PR DESCRIPTION
Added extra user-friendly syntax for `#wc` command. All existing syntax still works.
- Can write any color value as base-10, base-16 (`0x` prefix) or base-2 (`0b` prefix)

Additionally supports `#wc <slot> <item> <Red> <Green> <Blue> [Alpha]`
- Allows expressing the color as discrete R G B values (0-255 each)
- Can optionally add a 4th value `[Alpha]`, which has no official use. But Quarm can use this as a `TintMask` for new tint features such as selective tinting.

Examples:
- `#wc 7 1 1052688` (old command, base10)
- `#wc 7 1 0x101010` (old command, base16)
- `#wc 7 1 16 16 16` (new command, individual rgb)
- `#wc 7 1 16 16 16 0b101` (new command that sets bit `1` and `3` of `TintMask`)