### PR TITLE
Support SF+ being detected on leaderboards

### DIFF
--- a/zone/gm_commands/leaderboard.cpp
+++ b/zone/gm_commands/leaderboard.cpp
@@ -11,19 +11,19 @@ void command_leaderboard(Client *c, const Seperator *sep)
 
 	if(strncasecmp(sep->arg[1], "SFHCOnly", 8) == 0)
 	{
-		query += "e_solo_only = 0 AND e_self_found = 1 AND e_hardcore = 1";
+		query += "e_solo_only = 0 AND e_self_found >= 1 AND e_hardcore >= 1";
 	}
 	else if(strncasecmp(sep->arg[1], "SFHC", 4) == 0)
 	{
-		query += "e_self_found = 1 AND e_hardcore = 1";
+		query += "(e_self_found >= 1 OR e_solo_only >= 1) AND e_hardcore >= 1";
 	}
 	else if(strncasecmp(sep->arg[1], "SSFHC", 5) == 0)
 	{
-		query += "e_solo_only = 1 AND e_self_found = 1 AND e_hardcore = 1";
+		query += "e_solo_only >= 1 AND e_hardcore >= 1";
 	}
 	else if(strncasecmp(sep->arg[1], "HC", 2) == 0)
 	{
-		query += "e_hardcore = 1";
+		query += "e_hardcore >= 1";
 	}
 	else
 	{


### PR DESCRIPTION
Some SFHC players mentioned that SF+ w/ HC wasn't showing on the leaderboard and suggested this fix.

Future proofing all the logic to `>= 1` instead of `= 1` for now as well, incase future adjustments are made. But we can revisit as needed.