### PR TITLE
Modify #mystats to allow limited info for players

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4895,6 +4895,21 @@ void Client::SendStats(Client* client)
 	}
 }
 
+void Client::SendStatsToPlayer(Client* client)
+{
+	int shield_ac = 0;
+	GetRawACNoShield(shield_ac);
+
+	client->Message(Chat::Yellow, "~~~~~ %s %s ~~~~~", GetCleanName(), GetLastName());
+	client->Message(Chat::White, " AAs: %i  HP: %i/%i  Per: %0.2f HP Regen: %i/%i", GetAAPoints() + GetSpentAA(), GetHP(), GetMaxHP(), GetHPRatio(), CalcHPRegen(), CalcHPRegenCap());
+	client->Message(Chat::White, " AC: %i (Mit.: %i/%i + Avoid.: %i/%i) | Item AC: %i  Buff AC: %i  Shield AC: %i  DS: %i", CalcAC(), GetMitigation(), GetMitigation(true), GetAvoidance(true), GetAvoidance(), itembonuses.AC, spellbonuses.AC, shield_ac, GetDS());
+	client->Message(Chat::White, " Offense: %i  To-Hit: %i  Displayed ATK: %i  Worn +ATK: %i (cap: %i)  Spell +ATK: %i  Dmg Bonus: %i", GetOffenseByHand(), GetToHitByHand(), GetATK(), GetATKBonusItem(), RuleI(Character, ItemATKCap), GetATKBonusSpell(), GetDamageBonus());
+	client->Message(Chat::White, " Haste: %i (cap %i) (Item: %i + Spell: %i + Over: %i)  Double Attack: %i%%  Dual Wield: %i%%", GetHaste(), GetHasteCap(), itembonuses.haste, spellbonuses.haste + spellbonuses.hastetype2, spellbonuses.hastetype3 + ExtraHaste, GetDoubleAttackChance(), GetDualWieldChance());
+	if(CalcMaxMana() > 0)
+		client->Message(Chat::White, " Mana: %i/%i  Mana Regen: %i/%i", GetMana(), GetMaxMana(), CalcManaRegen(), CalcManaRegenCap());
+	client->Message(Chat::White, " Runspeed: %0.2f  Walkspeed: %0.2f Encumbered: %i", GetRunspeed(), GetWalkspeed(), IsEncumbered());
+}
+
 void Client::SendQuickStats(Client* client)
 {
 	client->Message(Chat::Yellow, "~~~~~ %s %s ~~~~~", GetCleanName(), GetLastName());

--- a/zone/client.h
+++ b/zone/client.h
@@ -818,6 +818,7 @@ public:
 	void	SetLanguageSkill(int langid, int value);
 
 	void	SendStats(Client* client);
+	void    SendStatsToPlayer(Client* client);  // Limited subset allowed for AccountStatus::Player.
 	void	SendQuickStats(Client* client);
 
 	uint16 MaxSkill(EQ::skills::SkillType skill_id, uint8 class_id, uint8 level) const;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -256,7 +256,7 @@ int command_init(void)
 		command_add("mule", "[account name] [0/1] - Toggles the mule status of the specified account ", AccountStatus::GMImpossible, command_mule) ||
 		command_add("mysql", "Mysql CLI, see 'help' for options.", AccountStatus::GMImpossible, command_mysql) ||
 		command_add("mysqltest", "Akkadius MySQL Bench Test.", AccountStatus::GMImpossible, command_mysqltest) ||
-		command_add("mystats", "Show details about you or your pet.", AccountStatus::Guide, command_mystats) ||
+		command_add("mystats", "Show details about you or your pet.", AccountStatus::Player, command_mystats) ||
 
 		command_add("ngpermaclass", "<class> [deity] [city] [stats...] [force] - Change your or your target's class (disconnects client). Optionally change deity, home city, and stats.", AccountStatus::GMMgmt, command_ngperma_class) ||
 		command_add("ngpermarace", "<race> [deity] [city] [stats...] [force] - Change your or your target's race (zone to take effect). Optionally change deity, home city, and stats.", AccountStatus::GMMgmt, command_ngperma_race) ||

--- a/zone/gm_commands/mystats.cpp
+++ b/zone/gm_commands/mystats.cpp
@@ -1,7 +1,9 @@
 #include "../client.h"
 
 void command_mystats(Client *c, const Seperator *sep){
-	if (c->GetTarget() && c->GetPet()) {
+	if (c->Admin() < AccountStatus::Guide)
+		c->SendStatsToPlayer(c);
+	else if (c->GetTarget() && c->GetPet()) {
 		if (c->GetTarget()->IsPet() && c->GetTarget() == c->GetPet())
 			c->GetTarget()->ShowStats(c);
 		else


### PR DESCRIPTION
- Allow AccountStatus::Player access to #mystats
- AccountStatus < Guide is routed to a new SendStatsToPlayer() with limited information exposing server calculated values for things like capped mitigation, attack, haste, etc

Example:
![mystats](https://github.com/user-attachments/assets/08fce271-5551-4cd4-a4a3-1c10fe620857)
