### PR TITLE
Pseudoclassic Resists Updated

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4087,50 +4087,57 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 		}
 	}
 
-	bool use_classic_resists = RuleR(World, CurrentExpansion) < (float)ExpansionEras::LuclinEQEra + 0.79;
+	bool use_classic_resists = RuleR(World, CurrentExpansion) < (float)ExpansionEras::LuclinEQEra + 0.79;	// mimic resists in the eras before Sept 4 2002
+	bool no_partial = false;
 
 	//Add our level, resist and -spell resist modifier to our roll chance
 	resist_chance += target_resist;
 	resist_chance += level_mod;
-	if (use_classic_resists && IsClient()) {
-		if (resist_chance > 200 && spells[spell_id].targettype == ST_Tap) {
-			resist_chance = 200;
-		}
 
+	if (use_classic_resists && IsClient())
+	{
 		if (caster->IsNPC()) {
-			if (spell_id == 837) {
-				// Stun Breath
-				resist_modifier = -50;
+			if (spell_id == 837 || spell_id == 843) {
+				// Stun Breath & Immolating Breath; these were not given a -mod in the revamp for some reason
+				resist_modifier = -150;
 			}
 
-			if (spell_id == 843) {
-				// Immolating Breath
-				resist_modifier = -100;
+			if (resist_modifier == -100 && ((spell_id >= 1468 && spell_id <= 1488) || (spell_id >= 2157 && spell_id <= 2162))) {
+				// CHA -4 spells; weaker lure than -6.  Mostly ToV spells, including bosses.  Some VT spells
+				no_partial = true;
+				resist_modifier = -70;
 			}
+			else if (resist_modifier == -150 || (resist_modifier == -200 && spell_id >= 1949 && spell_id <= 2131 && spells[spell_id].targettype != ST_Tap)) {
+				// CHA -6; Raid boss spells (many dragon AoEs; Luclin stuff too)
+				no_partial = true;
+				resist_chance += 20;
+				resist_modifier = -110; // Kunark decompiles show a 45% cap and nothing I've found makes me think it changed later
 
-			if (resist_modifier == -150) {
-				// dragon aoes
-				resist_modifier = -100;
+				if (spell_id == 837 && zone->GetZoneID() == Zones::VEESHAN)
+					resist_modifier = -50; // making Stun Breath easier to resist in VP because we don't have LOS enabled in the zone; is also Zlandicar spell
+			}
+			else if (resist_modifier == -300) {
+				// CHA -5 lures.  nearly unresistable
+				no_partial = true;
+				resist_modifier = -170;
+			}
+			else if (resist_chance > 0)
+			{
+				// classic resists for non-lures were more potent because a 0-99 roll was used back then
+				resist_chance = resist_chance * 3 / 2;
+
+				if (spell_id == 1492)	// Thunder Blast
+					no_partial = true;
 			}
 		}
-
-		int hardcap = 350;
-		if (!content_service.IsTheScarsOfVeliousEnabled()) {
-			hardcap = 250;
-		}
-
-		if (resist_chance > hardcap) {
-			resist_chance = hardcap;
-		}
-
 		if (resist_chance > 200) {
-			resist_chance = 200 + (resist_chance - 200) / 2;
+			resist_chance = 200;	// classic had low resist caps
 		}
 	}
 
 	resist_chance += resist_modifier;
 	
-	if (use_classic_resists && caster->IsNPC() && caster->GetLevel() > 24 && zone->GetZoneID() != Zones::SIRENS
+	if (use_classic_resists && caster->IsNPC() && caster->GetLevel() > 24 && zone->GetZoneID() != Zones::SIRENS && zone->GetZoneID() != Zones::TEMPLEVEESHAN
 		&& (caster->GetClass() == Class::Enchanter || caster->GetClass() == Class::EnchanterGM))
 	{
 		if (GetLevel() < resist_chance) {
@@ -4144,6 +4151,7 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 
 	if (tick_save) {
 		// See http://www.eqemulator.org/forums/showthread.php?t=43370
+		// For classic accuracy these values would have to be doubled if using the 0-200 roll
 		if (IsCharmSpell(spell_id)) {
 			if (resist_chance < RuleI(Spells, CharmMinResist)) {	// this value is 5 for non-custom servers
 				resist_chance = RuleI(Spells, CharmMinResist);
@@ -4181,12 +4189,37 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 	}
 
 	// PvP
-	if (caster->IsClient() && target && target->IsClient()) {
+	if (caster->IsClient() && target && target->IsClient() && !use_classic_resists) {
 		if (resist_chance > 1 && resist_chance < 200) {
 			resist_chance = resist_chance * 400 / (200 + resist_chance);		// this changes the curve from linear to the bow shape seen in parses
 		}
 		if (resist_chance > 196) {
 			resist_chance = 196;		// minimum 2% chance for spells to land
+		}
+	}
+
+	if (use_classic_resists && !tick_save)	// this DID apply to tick saves in classic but it would enrage people to apply it on the emus (huge charm nerf)
+	{	// these floors are doubled here because of the 0-200 roll
+		if (IsNPC())
+		{
+			if (leveldiff > -11 && target_level > 14 && resist_chance < 20) {	// ten levels under the caster or higher unless it's a newbie mob
+				resist_chance = 20;
+			}
+			else if (leveldiff < -20 || target_level < 15) {		// deep greens and newbie mobs
+				if (resist_chance < 4)
+					resist_chance = 4;
+			}
+			else if (resist_chance < 10) {
+				resist_chance = 10;		// everything in between
+			}
+		}
+		else {
+			if (resist_chance < 4 && resist_modifier == 0) {
+				resist_chance = 4;	// in classic there was a 2% minimum chance to resist non-lure spells and a 1% minimum chance for spells to land on players
+			}
+			else if (resist_chance > 198) {
+				resist_chance = 198;
+			}
 		}
 	}
 
@@ -4197,15 +4230,16 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 		return 100;
 	}
 	else {
-		if(!IsPartialCapableSpell(spell_id) || resist_chance == 0) {
+		if ((!IsPartialCapableSpell(spell_id) || no_partial) || resist_chance == 0) {
 			return 0;
 		}
 		else {
-			if (use_classic_resists && resist_chance > 200 && IsClient()) {
-				resist_chance = 200;
-			}
 
 			int partial_modifier = ((150 * (resist_chance - roll)) / resist_chance);
+
+			if (use_classic_resists && IsClient()) {
+				partial_modifier = (resist_chance * 100 + roll * -100) / resist_chance;
+			}
 
 			if (IsNPC()) {
 				if (target_level > caster_level && target_level >= 17 && (caster_level <= 50 || use_classic_resists)) {


### PR DESCRIPTION
This commit makes the classic era resists that I had previously implemented much more classic-like.  The previous commit was very incomplete and did not handle many Velious and Luclin boss spells and this is needed to fix that.  I've since better learned how resists were.  I will outline the changes because it probably looks strange as everybody is used to the new resist system and doesn't remember what it used to be like.

First it's important to understand that in classic, resists rolled a 0-99 instead of a 0-199.  Classic resists were more potent and in some ways resists became more unforgiving after the September 4 2002 revamp.  Post revamp, non-lure spells landed on players easier and also spells landing on NPCs became easier, which was a large DPS boost to caster players.  This meant that the all-or-nothing immunity threshold was 99 instead of 200.  So generally spellcaster NPCs in classic were actually much less threatening.  It was much easier to become fear immune to Nagafen for example and you did not need much resist gear.  Lured spells however were often harder to resist.

I could not apply most of this logic to NPCs because when Sony changed the roll to 200 they also added resists to many NPCs and applying this stuff to NPCs would require many database edits plus it's difficult to impossible to know which NPCs would need to be edited.  So players will still benefit from being able to land spells easier on most NPCs.  This commit should be not be considered a comprehensive reversion and it omits several things, most notably the lull and bard mez MR overrides (lull was near useless at higher levels in classic) and a collection of more trivial things.

Classic eras had resist caps.  Post revamp the cap is very high, 500.  In classic the PC resist cap -- against non-lures -- was 99.  Yes, 99.  I'm certain of this because the decompiles show it explicitly and the logs agree with this.  This would be the equivalent to 200 in the new system.  These caps were not apparent in the UI but they existed.  A result of this cap is that DD partial hit damage could not be mitigated beyond 50% average damage.

Classic also had resist floors.  It was not possible to debuff resists to 0 in classic.  I have implemented these floors (on NPCs and PCs) but since we're using a 200 roll I had to double them to make the resist rates the same as it was in classic.  I excluded tick saves when applying the floors even though they did apply to tick saves in classic because they would heavily nerf charm.  Any servers who want real accuracy will need to make the floors apply to tick saves.  Charm was much less powerful in classic.

In classic, lures did a separate resist roll, and this is why resists over 99 were still relevant back then.  The -resist adjust field in the spell data did not exist until September 4 2002 and before then spells had negative charisma in the first slot to denote lure behavior.  Lures back then would subtract an amount from the target's resist then halve the remainder and then apply a hardcap.  There were four types of lures back then: -3, -4, -5, -6.  For the most part resists against lure spells back then capped around 180-190 before level difference is factored in, so add another 50 to that against level 70 bosses.

I made CHA -6 resist spells resist at the same rate as they did in classic, with the same cap which is 45%.  Quarm players will notice that Kunark dragon AoEs will now resist less and this is intentional.  My previous logic was too lenient.  These became much easier to resist post-revamp because players can become immune after around 350-400 resist using bards in the new system.

-4 lure spells on the other hand had a high cap in classic and post-revamp Sony neglected to flag them not-partialable (all classic lures could not partial hit), so in PoP these were very hard to resist after previously being rather easy to.  The revamp made some encounters MUCH harder. (e.g. Lady Nev)  I made these spells no-partial but still somewhat harder (by 10%) to resist than in classic for a few reasons: first they became much harder to resist after the revamp as mentioned; second Sony arguably made these too easy to resist (the cap was 75%) in classic and in some cases the lure effect made the spells resist MORE than if they were just normal DDs (they still will); third players are still benefiting from some of the post-revamp changes.

When saving against non-lure spells I multiplied player resists by 1.5 because of the 200 roll.  Why not 2x?  Because resists were largely useless in classic and I didn't want to make them useless.  Also players still benefit from the lower NPC resists so I didn't want player resists buffed too much.

I added classic's partial damage formula but it requires more resist to reach 50% mitigation due to the 1.5x multiplier.

Players could not attain 100% spell immunity in classic and there is now a 1% minimum chance to land any spell on players.