### PR TITLE
Ceticious Cloud spell hardcodes

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -197,6 +197,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 					caster->SetHP(caster->GetMaxHP() * 2 / 10 + 1);
 					caster->SendHPUpdate();
 				}
+				else if (spell_id == 844)	// Ceticious Cloud; this spell did not do damage in any of our eras
+				{
+					dmg = -1;	// making it -1 instead of 0 so players get the spell land text
+				}
 
 				//do any AAs apply to these spells?
 				if(dmg < 0) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4097,8 +4097,8 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 	if (use_classic_resists && IsClient())
 	{
 		if (caster->IsNPC()) {
-			if (spell_id == 837 || spell_id == 843) {
-				// Stun Breath & Immolating Breath; these were not given a -mod in the revamp for some reason
+			if (spell_id == 837 || spell_id == 843 || spell_id == 844) {
+				// Stun Breath, Immolating Breath, Ceticious Cloud; these were not given a -mod in the revamp for some reason
 				resist_modifier = -150;
 			}
 


### PR DESCRIPTION
This spell is Severilous and Wuoshi's AoE.  In all of our eras (including PoP) this spell did no damage.  Before the September 4 2002 resists revamp the spell was lure and difficult to resist.  Sony may have hardcoded it to not do damage because the spell data seemingly had a mistake in it which is the spell has no recast delay on it, which means the dragons casted it every few seconds.  Why they didn't just put a delay on it to fix it instead I don't know.

I made the spell do 1 dmage instead of zero because if set to zero damage the server doesn't send a spell packet to the client due to the way our logic works it would require more "if spell_id ==" crap to make it send packets at zero damage and I didn't want to clutter up the code with more of it.