### PR TITLE
PC Froglok Support

### DIFF
--- a/common/races.h
+++ b/common/races.h
@@ -101,6 +101,7 @@ namespace Gender {
 #define HORSE				216
 #define TELEPORT_MAN		240
 #define MITHANIEL_MARR		296
+#define GUKTAN              330
 #define EMU_RACE_NPC		131069 // was 65533
 #define EMU_RACE_PET		131070 // was 65534
 #define EMU_RACE_UNKNOWN	131071 // was 65535
@@ -509,6 +510,7 @@ namespace Race {
 	constexpr uint16 CrystalSpider = 327;
 	constexpr uint16 ZebuxoruksCage = 328;
 	constexpr uint16 Portal = 329;
+	constexpr uint16 Guktan = 330;
 
 	constexpr uint16 ALL_RACES_BITMASK = 16383;
 }

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -340,6 +340,7 @@ RULE_BOOL(Quarm, UseFixedShowHelmBehavior, true, "Fixes ShowHelm to be a persona
 RULE_INT(Quarm, WarnDllVersionBelow, 1, "Sends a Client-out-of-date warning message to clients below this dll version.")
 RULE_INT(Quarm, CurrentPVPExpansion, 1, "The currently enabled expansion for PVP zones.")
 RULE_INT(Quarm, SharedBankBags, 10, "The number of shared bank slots the client can deposit to. '0' will only allow withdrawing. '-1' competely disables the client.")
+RULE_BOOL(Quarm, CustomFrogloks, true, "Enable Quarm froglok race 330.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(SelfFound)

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1676,10 +1676,6 @@ void EntityList::QueueWearChange(Mob *sender, const EQApplicationPacket *app, bo
 				else
 					wc->material = 240;
 				break;
-			case 241:
-				if (sender && sender->GetRace() != Race::Ogre)
-					wc->material = 240;
-				break;
 
 				// unfortunately the tint is wrong when a tinted custom helm is worn by a client using old models and there seems to be no good way to work around this.
 				// when the same helm is worn by a luclin model client it just treats it as a normal tinted item so they will appear inconsistent to luclin model using viewers

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5012,7 +5012,7 @@ int32 Mob::GetSkillStat(EQ::skills::SkillType skillid)
 
 bool Mob::IsPlayableRace(uint16 race)
 {
-	if(race > 0 && (race <= GNOME || race == IKSAR || race == VAHSHIR))
+	if(race > 0 && (race <= GNOME || race == IKSAR || race == VAHSHIR || race == GUKTAN))
 	{
 		return true;
 	}
@@ -5238,11 +5238,19 @@ void Mob::ApplyIllusion(const SPDat_Spell_Struct &spell, int i, Mob* caster)
 	}
 	else // Racial Illusions
 	{
+		bool custom_racial_illision = false;
+		if (RuleB(Quarm, CustomFrogloks) && IsClient() && spell_id == 3063)
+		{
+			// Quarm - PCs when using Illusion: Froglok become 'PC Froglok/Guktan' race (330)
+			custom_racial_illision = true;
+			spell_base = Race::Guktan;
+		}
+
 		int8 gender = Mob::GetDefaultGender(spell_base, GetGender());
 		// Texture doesn't seem to be in our spell data :I
 		int8 texture = 0;
 		int8 helmtexture = spell.max[i];
-		if (IsRacialIllusion(spell_id))
+		if (IsRacialIllusion(spell_id) || custom_racial_illision)
 		{
 			if (RuleB(Quarm, UseFixedShowHelmBehavior) && IsClient() && CastToClient()->ShowHelm()) {
 				helmtexture = 0xFF;
@@ -5332,7 +5340,6 @@ void Mob::ApplyIllusion(const SPDat_Spell_Struct &spell, int i, Mob* caster)
 
 				break;
             }
-
 			}
 		}
 


### PR DESCRIPTION
Added server-side support for the froglok stuff
- Race 330 returns true for IsPlayableRace (shared for both Classic/LoY model)
- `Illusion: Froglok` now applies race 330 to Clients.
- WearChange events turned on for race 330.

Misc
- Minor tweak to Velious helm 241 support to work more accurately (this texture is still unused). Unrelated.

![image](https://github.com/user-attachments/assets/ac55a517-fadf-49af-9f4e-f087a8502a25)
