### PR TITLE
Resist system fixes

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4198,7 +4198,8 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 		}
 	}
 
-	if (use_classic_resists && !tick_save)	// this DID apply to tick saves in classic but it would enrage people to apply it on the emus (huge charm nerf)
+	// this DID apply to tick saves in classic but it would enrage people to apply it on the emus (huge charm nerf)
+	if (use_classic_resists && !tick_save && (!IsPartialCapableSpell(spell_id) || !IsDOTSpell(spell_id)))	// exclude druid dots, necro fire dots
 	{	// these floors are doubled here because of the 0-200 roll
 		if (IsNPC())
 		{
@@ -4247,7 +4248,7 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 				}
 
 				if (target_level >= 30 && (caster_level <= 50 || use_classic_resists)) {
-					partial_modifier += (caster_level - 25);
+					partial_modifier += (target_level - 25);
 				}
 
 				if(target_level < 15) {


### PR DESCRIPTION
Please forgive the number of commits on this.  It's rather complicated to have two systems inside one method.

This commit will make druid dots and necro fire dots ignore the classic resist floors.

It also fixes a problem with both resist systems.  A partial damage modifier looked incorrect and I suspect that Prathun's pseudocode was wrong here or Sony otherwise botched it at some point after our era.  The Kunark decompiles show it the way I fixed it.