### PR TITLE
Fix minor resists bugs

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4204,7 +4204,7 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 	{	// these floors are doubled here because of the 0-200 roll
 		if (IsNPC())
 		{
-			if (leveldiff > -11 && target_level > 14 && resist_chance < 20) {	// ten levels under the caster or higher unless it's a newbie mob
+			if (leveldiff > -11 && target_level > 14 && resist_chance < 10) {	// ten levels under the caster or higher unless it's a newbie mob
 				resist_chance = 10;
 			}
 			else if (leveldiff < -20 || target_level < 15) {		// deep greens and newbie mobs

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4199,7 +4199,7 @@ float Mob::CheckResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, Mob
 	}
 
 	// this DID apply to tick saves in classic but it would enrage people to apply it on the emus (huge charm nerf)
-	if (use_classic_resists && !tick_save && spells[spell_id].ResistDiff > -300							// exclude unresistables (rapture, dictate etc) and wiz lures
+	if (use_classic_resists && !tick_save && spells[spell_id].ResistDiff >= -300							// exclude unresistables (rapture, dictate etc) and wiz lures
 		&& !IsLifetapSpell(spell_id) && (!IsPartialCapableSpell(spell_id) || !IsDOTSpell(spell_id)))	// exclude druid dots, necro fire dots
 	{	// these floors are doubled here because of the 0-200 roll
 		if (IsNPC())


### PR DESCRIPTION
This PR fixes some bugs introduced introduced around Apr 5:
- Fixed a condition that wasn't updated when resist floor was change from 10% to 5%
- Fixed a condition that would exclude lures from ignoring the resist floor (wiz lures are -300 and would have been excluded) 