### PR TITLE
Fixed hate for Velious era wizard bane spells

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1732,8 +1732,8 @@ int32 Mob::CheckAggroAmount(uint16 spell_id, Mob* target)
 		combinedHate = (combinedHate * hateMult) / 100;
 	}
 
-	// spells on 'belly caster' NPCs do no hate if outside of melee range unless spell has no resist check
-	if (spells[spell_id].resisttype != RESIST_NONE && target->GetSpecialAbility(SpecialAbility::CastingFromRangeImmunity) && !CombatRange(target))
+	// spells on 'belly caster' NPCs do no hate if outside of melee range
+	if (target->GetSpecialAbility(SpecialAbility::CastingFromRangeImmunity) && !CombatRange(target))
 		return 0;
 
 	return combinedHate;


### PR DESCRIPTION
The bane spells did no or very little hate if casting from out of melee range, but they did full hate if standing inside melee range.  I verified this on Live servers just now.

The solution was to remove the resist type check which was allowing unresistable spells to still do hate.  I had put that there in 2015 because on Live I think I noticed Tash and Terror spells still doing hate but both of these lines had their hate generation characteristics changed after our timeline so I think it's likely they didn't do hate on bellycasters in our era.