### PR TITLE
Making PoM cards stackable

### DIFF
--- a/utils/sql/git/content/2025_04_14_PlaneOfMischief_Cards_Stackable.sql
+++ b/utils/sql/git/content/2025_04_14_PlaneOfMischief_Cards_Stackable.sql
@@ -1,0 +1,20 @@
+-- Makes PoM cards stackable
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a black throne' WHERE id = 24550;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a black crown' WHERE id = 24551;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a black knight' WHERE id = 24552;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a black squire' WHERE id = 24553;
+
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a red throne' WHERE id = 24554;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a red crown' WHERE id = 24555;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a red knight' WHERE id = 24556;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a red squire' WHERE id = 24557;
+
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a blue throne' WHERE id = 24558;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a blue crown' WHERE id = 24559;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a blue knight' WHERE id = 24560;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a blue squire' WHERE id = 24561;
+
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a white throne' WHERE id = 24562;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a white crown' WHERE id = 24563;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a white knight' WHERE id = 24564;
+UPDATE items SET itemtype = 17, stackable = 1, stacksize = 20, maxcharges = 1, lore = 'a white squire' WHERE id = 24565;


### PR DESCRIPTION
- Makes PoM cards stackable.

These are pretty frustrating to sort through/manage, especially on self-found because we can't even mule them to banker alts. So we are limited to 1-per-card and have to resort to storing on corpses. Stackable would be really helpful.