### PR TITLE
Bug: Fixed issue where Ranged Attack could not be used while singing

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -420,8 +420,14 @@ void Client::OPCombatAbility(const EQApplicationPacket *app)
 	if(!GetTarget() || GetTarget() == this)
 		return;
 
+	if (spellend_timer.Enabled())
+	{
+		if (GetBaseClass() != Class::Bard || !IsValidSpell(casting_spell_id) || !spells[casting_spell_id].bardsong)
+			return;
+	}
+
 	//make sure were actually able to use such an attack.
-	if(spellend_timer.Enabled() || IsFeared() || IsStunned() || IsMezzed() || DivineAura() || dead)
+	if(IsFeared() || IsStunned() || IsMezzed() || DivineAura() || dead)
 		return;
 
 	CombatAbility_Struct* ca_atk = (CombatAbility_Struct*) app->pBuffer;


### PR DESCRIPTION
- Fixed issue where Ranged Attack could not be used while singing

Bards were unable to throw items while in the middle of a song. Client-side decompiles (as well as just pushing the button being allowed) seems to indicate that it's allowed for bards, same as how most actions are allowed during bard songs.

From EQPlayer::DoAttack (used for combat abilities), see the CastingSpellId check. In fact it looks like it allows it for any spell, but allowing it just during songs seems fine.
![image](https://github.com/user-attachments/assets/1d33e206-befc-49df-9c28-7c95f3c57532)
