### PR TITLE
Fix: Raid detection for raid loot rights and lockouts when ungrouped.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2266,7 +2266,7 @@ void NPC::CreateCorpse(Mob* killer, int32 dmg_total, bool &corpse_bool)
 	if (killer != 0 && killer->IsClient())
 	{
 		
-		Raid* raid = killer->IsRaidGrouped() ? killer->GetRaid() : nullptr;
+		Raid* raid = killer->GetRaid();
 		Group* group = killer->GetGroup();
 		ChallengeRules::RuleParams ruleset = raid ? raid->GetRuleSetParams() : group ? group->GetRuleSetParams() : killer->CastToClient()->GetRuleSetParams();
 

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -2262,7 +2262,7 @@ void Corpse::ProcessLootLockouts(Client* give_exp_client, NPC* in_npc)
 	if (give_exp_client)
 	{
 
-		if (give_exp_client->IsGrouped())
+		if (give_exp_client->GetRaid() == nullptr && give_exp_client->GetGroup() != nullptr)
 		{
 			Group* kg = give_exp_client->GetGroup();
 			for (int i = 0; i < MAX_GROUP_MEMBERS; i++) {
@@ -2361,7 +2361,7 @@ void Corpse::ProcessLootLockouts(Client* give_exp_client, NPC* in_npc)
 				}
 			}
 		}
-		else if (give_exp_client->IsRaidGrouped())
+		else if (give_exp_client->GetRaid() != nullptr)
 		{
 			Raid* kr = give_exp_client->GetRaid();
 			if(kr)

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -800,7 +800,7 @@ void Client::SetLevel(uint8 set_level, bool command)
 
 	level = set_level;
 
-	if(IsRaidGrouped()) {
+	{
 		Raid *r = this->GetRaid();
 		if(r){
 			r->UpdateLevel(GetName(), set_level);


### PR DESCRIPTION
- **Fixed bug where raid does not get loot rights if the 'killer' is not assigned to a group in the raid.**
  - Note: _I think_ this is the reason why some mobs in a self-found raid were unlootable, as well as in normal raids, from time to time.
  - I think I broke this when adjusting things for SF+ and moved a couple calls around.
- **Fixed bug where raid does not get loot lockout if the 'killer' is not assigned to a group in the raid.**
  - Note: This is still handled via engagement records, so likely hasn't been exploited.


Comments:
- The `IsRaidGrouped()` check merely checks if the member in a raid is currently assigned to a group or not, and should not be used to determine the actual presence of the raid, because it's possible to be in a raid and also ungrouped.