### PR TITLE
Add Velious helmet graphics to a few helms

### DIFF
--- a/utils/sql/git/content/2025_04_26_AddVelious_HelmetGraphics.sql
+++ b/utils/sql/git/content/2025_04_26_AddVelious_HelmetGraphics.sql
@@ -1,0 +1,21 @@
+-- Adds Velious 'custom helmet' graphics to some Velious helms that have colors defined, but were missing a helmet graphic.
+-- Adds more fashion variety on chase items and a few new colors to choose from.
+
+-- 'Helmet of Rallos Zek' (Avatar of War). (Color: Default)
+-- Note: IT241 is a special ID that is a 'Rallos Zek'-style helmet when ogres equip it (looks like a regular Custom Helm on other races).
+UPDATE items set idfile = 'IT241' WHERE id = 25209;
+
+-- 'Imbued Royal Velium Helmet' (No Drop, blacksmithing, part of Shawl 8). This is a full fashion set but helm had no graphic. (Color 10/20/100)
+UPDATE items set idfile = 'IT240' WHERE id = 9281;
+
+-- 'Royal Velium Frosted Helmet' (No drop, from Icewell keep guards). This is a full fashion set but helm had no graphic. (Color: 0/100/125)
+UPDATE items set idfile = 'IT240' WHERE id = 25850;
+
+-- 'Helm of the Deep Sea' (No drop, Lord Koi`Doken). Missing graphic. (Color: 0/50/0)
+UPDATE items set idfile = 'IT240' WHERE id = 31311; 
+
+-- PoM Class Crowns
+UPDATE items set idfile = 'IT240' WHERE id = 6845; -- Mischievous Dazzler Crown (Color: 80/0/180)
+UPDATE items set idfile = 'IT240' WHERE id = 6852; -- Maleficent Crown (Color: 0/250/250)
+UPDATE items set idfile = 'IT240' WHERE id = 6859; -- Wily Warlock Crown (Color: 50/0/150)
+UPDATE items set idfile = 'IT240' WHERE id = 6866; -- Sly Summoner's Crown (Color: 0/250/250)


### PR DESCRIPTION
- Adds Velious 'custom helmet' graphics to some Velious helms that already had colors defined, but were missing a helmet graphic.
- Also adds a special graphic to Helmet of Rallos Zek (which previously had no visual).

Helmet of Rallos Zek
- Note: 'IT241' is a special unused ID that is a 'Rallos Zek'-style helmet when Ogres equip it. Looks like a regular Custom Helm on other races. 
![image](https://github.com/user-attachments/assets/d0833276-7898-459a-aa07-62abe03afd61)

Imbued Royal Velium Helmet
- No Drop. Blacksmithing. Part of Shawl 8 and fashion set.
![image](https://github.com/user-attachments/assets/07b51bf4-b537-48fa-848e-6b07eb7945c3)

Royal Velium Frosted Helmet
- No Drop. Icewell Keep guards. Part of fashion set.
![image](https://github.com/user-attachments/assets/7706febb-734f-4058-80e9-11879ef08b60)

Helm of the Deep Sea
- No Drop. Lord Koi`Doken.
![image](https://github.com/user-attachments/assets/2b15bec5-bded-4ce8-afb3-b5d0035ecdf6)

Mischievous Dazzler Crown
- No Drop. PoM class crown.
![image](https://github.com/user-attachments/assets/a9c82c70-341d-42af-ad3a-6f0bea22e0ef)

Maleficent Crown
- No Drop. PoM class crown.
![image](https://github.com/user-attachments/assets/b27888b4-e94c-49ff-af35-249a31f95293)

Wily Warlock Crown
- No Drop. PoM class crown.
![image](https://github.com/user-attachments/assets/f2221b11-eaa3-4642-bf0f-0b7c347da97a)

Sly Summoner's Crown
- No Drop. PoM class crown.
![image](https://github.com/user-attachments/assets/b27888b4-e94c-49ff-af35-249a31f95293)