### PR TITLE
Allow SKs to learn research for Necro spells (self found support)

### DIFF
--- a/utils/sql/git/required/2025_05_11_SK_SelfFound_Research.sql
+++ b/utils/sql/git/required/2025_05_11_SK_SelfFound_Research.sql
@@ -1,0 +1,6 @@
+-- Adds SK ability to research necro spells, same level/skill caps at Necros to train.
+-- Note: Also requires dll patch to allow clicking the Combine button.
+
+-- Copys all Necro (11) Skill Caps for research to SK (5)
+INSERT INTO skill_caps (skill_id, class_id, `level`, cap, class_)
+SELECT skill_id, 5, `level`, cap, class_ FROM skill_caps sc WHERE sc.class_id = 11 and sc.skill_id = 58; 


### PR DESCRIPTION
- Allows self-found SKs to finally obtain 'Spell: Harmshield' (research only)
- SKs can train Research at the skill training, and has the same Skill Caps as Necromancers.
- Client DLL patch is also required for client-side support.