### PR TITLE
AA fix for Extended Notes (for Beneficial AEs)

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4401,7 +4401,7 @@ float Mob::GetAOERange(uint16 spell_id) {
 
 	if (IsClient()) {
 
-		if(IsBardSong(spell_id) && IsBeneficialSpell(spell_id) && (spells[spell_id].targettype == ST_Group || spells[spell_id].targettype == ST_GroupTeleport)) {
+		if(IsBardSong(spell_id) && IsBeneficialSpell(spell_id) && (spells[spell_id].targettype == ST_Group || spells[spell_id].targettype == ST_GroupTeleport || spells[spell_id].targettype == ST_AEBard)) {
 			//Live AA - Extended Notes, SionachiesCrescendo
 			float song_bonus = static_cast<float>(aabonuses.SongRange + spellbonuses.SongRange + itembonuses.SongRange);
 			range += range*song_bonus /100.0f;


### PR DESCRIPTION
There was a PoP-era fix so that Extended Notes also increases the range of beneficial AE songs (not just their group version)
- Ancient: Lcea's Lament
- Chorus of Replenisment/Marr
- Elemental/Purifying Chorus

# Reference
https://everquest.allakhazam.com/history/patches-2003-1.html
(LoY didn't launch until Feb 24, 2003)

```
------------------------------
February 4, 2003
------------------------------

** Alternate Advancement ** 

- Extended Notes now works on area of Effect songs as well as group 
songs. 
```
