### PR TITLE
Update spell Imperceptibility (ID  2037) to have zonetype = -1 , which should allow this Shrink spell to work in the same types of zones as Shrink (ID 345)

### DIFF
--- a/utils/sql/git/content/2025_08_10_Update_Imperceptibility.sql
+++ b/utils/sql/git/content/2025_08_10_Update_Imperceptibility.sql
@@ -1,0 +1,2 @@
+-- Update Imperceptibility spell to match Shrink's zonetype, allowing usage in more zones
+UPDATE spells_new SET zonetype = -1 WHERE id = 2037


### PR DESCRIPTION
Update spell Imperceptibility (ID  2037) to have zonetype = -1 , which should allow this Shrink spell to work in the same types of zones as Shrink (ID 345) , and Grow (ID 2522)

Shrink: https://www.pqdi.cc/spell/345 
Grow: https://www.pqdi.cc/spell/2522

Imperceptibility: https://www.pqdi.cc/spell/2037  . This is the right-click effect of the Wand of Imperceptibility item - https://www.pqdi.cc/item/19725 . 

