### PR TITLE
Move PvP toasts to gloabl PvP channel

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1401,7 +1401,9 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 				killedby = Killed_PVP;
 				std::string pvpKilledGuildName = GetGuildName();
 				std::string pvpKillerGuildName = killerMob->CastToClient()->GetGuildName();
-				entity_list.Message(0, 15, "[PVP] %s of <%s> has been killed in combat by %s of <%s>!", GetCleanName(), pvpKilledGuildName.empty() ? " " : pvpKilledGuildName.c_str(), killerMob->GetCleanName(), pvpKillerGuildName.empty() ? " " : pvpKillerGuildName.c_str());
+				char msg[256];
+				snprintf(msg, sizeof(msg), "[PVP] %s of <%s> has been killed in combat by %s of <%s>!", GetCleanName(), pvpKilledGuildName.empty() ? " " : pvpKilledGuildName.c_str(), killerMob->GetCleanName(), pvpKillerGuildName.empty() ? " " : pvpKillerGuildName.c_str());
+				worldserver.SendChannelMessage("PVP_Druzzil_Ro", ChatChannel_Broadcast, 0, 0, 100, msg);
 			}
 			else
 			{


### PR DESCRIPTION
This is completely untested and I'm in unfamiliar waters here. But this should hopefully move the XXX has killed YYYY pvp toasts to the global pvp channel rather than just the local zone.