### PR TITLE
[PvP] Era-accurate Resist Debuff mechanic

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -2086,6 +2086,16 @@ struct PickPocket_Struct
     uint8 data[6];
 };
 
+struct RuleSets_Struct
+{
+	/* 0x000 */ uint32 enable_FV;
+	/* 0x004 */ uint32 enable_pvp;
+	/* 0x008 */ uint32 auto_identify;
+	/* 0x00C */ uint32 NameGen;
+	/* 0x010 */ uint32 Gibberish;
+	/* 0x014 */ uint32 test_server;
+};
+
 struct LogServer_Struct
 {
 	/*000*/	uint32	enable_FV; //Is FV ruleset?

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1018,7 +1018,8 @@ void Mob::CalcSpellBonuses(StatBonuses* newbon)
 			uint8 caster_level = i == disc_slot ? GetLevel() : buffs[i].casterlevel; // disciplines are in a fake buff slot at last index and these need the current level
 			ApplySpellsBonuses(buffs[i].spellid, caster_level, newbon, buffs[i].casterid, false, buffs[i].instrumentmod, buffs[i].ticsremaining, i,
 				false, 0, 0, 0, 0,
-				buffs[i].bufftype == 4);
+				buffs[i].bufftype == 4,
+				buffs[i].client);
 		}
 	}
 
@@ -1033,7 +1034,7 @@ void Mob::CalcSpellBonuses(StatBonuses* newbon)
 }
 
 void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* new_bonus, uint16 casterId, bool item_bonus, int16 instrumentmod, uint32 ticsremaining, int buffslot,
-							 bool IsAISpellEffect, uint16 effect_id, int32 se_base, int32 se_limit, int32 se_max, bool is_tap_recourse)
+							 bool IsAISpellEffect, uint16 effect_id, int32 se_base, int32 se_limit, int32 se_max, bool is_tap_recourse, bool buff_from_client)
 {
 	int i, effect_value, base2, max, effectid;
 	Mob *caster = nullptr;
@@ -1283,30 +1284,40 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* ne
 			case SE_ResistFire:
 			{
 				new_bonus->FR += effect_value;
+				if (IsClient() && effect_value < 0 && zone && zone->GetGuildID() == 1 && buffslot >= 0 && buff_from_client)
+					new_bonus->FR += (effect_value / 2); // PvP Servers had 50% bonus to resist debuffs
 				break;
 			}
 
 			case SE_ResistCold:
 			{
 				new_bonus->CR += effect_value;
+				if (IsClient() && effect_value < 0 && zone && zone->GetGuildID() == 1 && buffslot >= 0 && buff_from_client)
+					new_bonus->CR += (effect_value / 2); // PvP Servers had 50% bonus to resist debuffs
 				break;
 			}
 
 			case SE_ResistPoison:
 			{
 				new_bonus->PR += effect_value;
+				if (IsClient() && effect_value < 0 && zone && zone->GetGuildID() == 1 && buffslot >= 0 && buff_from_client)
+					new_bonus->PR += (effect_value / 2); // PvP Servers had 50% bonus to resist debuffs
 				break;
 			}
 
 			case SE_ResistDisease:
 			{
 				new_bonus->DR += effect_value;
+				if (IsClient() && effect_value < 0 && zone && zone->GetGuildID() == 1 && buffslot >= 0 && buff_from_client)
+					new_bonus->DR += (effect_value / 2); // PvP Servers had 50% bonus to resist debuffs
 				break;
 			}
 
 			case SE_ResistMagic:
 			{
 				new_bonus->MR += effect_value;
+				if (IsClient() && effect_value < 0 && zone && zone->GetGuildID() == 1 && buffslot >= 0 && buff_from_client)
+					new_bonus->MR += (effect_value / 2); // PvP Servers had 50% bonus to resist debuffs
 				break;
 			}
 
@@ -1317,6 +1328,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* ne
 				new_bonus->PR += effect_value;
 				new_bonus->CR += effect_value;
 				new_bonus->FR += effect_value;
+				if (IsClient() && effect_value < 0 && zone && zone->GetGuildID() == 1 && buffslot >= 0 && buff_from_client)
+				{
+					int half_value = effect_value / 2; // PvP Servers had 50% bonus to resist debuffs
+					new_bonus->MR += half_value;
+					new_bonus->DR += half_value;
+					new_bonus->PR += half_value;
+					new_bonus->CR += half_value;
+					new_bonus->FR += half_value;
+				}
 				break;
 			}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -769,6 +769,23 @@ void Client::CompleteConnect()
 		ForceGoToDeath();
 	}
 
+	// Updates the client's Server ruleset flags when it enters a PvP or non-PvP zone.
+	// This causes the client to accurately show a few bonus features like the correct debuff amounts caused by players.
+	auto* rule_sets_app = new EQApplicationPacket(OP_LogServer, sizeof(RuleSets_Struct));
+	RuleSets_Struct* rule_sets = (RuleSets_Struct*)rule_sets_app->pBuffer;
+	if (zone && zone->GetGuildID() == 1)
+		rule_sets->enable_pvp = 2; // 2 is Rallos-like, 4 is Sullon-like (shouldn't use Sullon as it causes a lot of side-affects)
+	else
+		rule_sets->enable_pvp = (RuleI(World, PVPSettings));
+	if (RuleI(World, FVNoDropFlag) == 1 || RuleI(World, FVNoDropFlag) == 2 && Admin() > RuleI(Character, MinStatusForNoDropExemptions))
+		rule_sets->enable_FV = 1;
+	rule_sets->auto_identify = 0;
+	rule_sets->NameGen = 1;
+	rule_sets->Gibberish = 1;
+	rule_sets->test_server = 0;
+	QueuePacket(rule_sets_app);
+	safe_delete(rule_sets_app);
+
 	// Begins the shared bank negotiation with the client. Server sends how many slots are possible, waits to hear what the client supports.
 	// Upon client response, server will (optionally) enable the bank and stream the contents.
 	int shared_bank_bags = RuleI(Quarm, SharedBankBags);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -221,7 +221,7 @@ public:
 	void ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* newbon, uint16 casterID = 0,
 		bool item_bonus = false, int16 instrumentmod = 10, uint32 ticsremaining = 0, int buffslot = -1,
 		bool IsAISpellEffect = false, uint16 effect_id = 0, int32 se_base = 0, int32 se_limit = 0, int32 se_max = 0,
-		bool is_tap_recourse = false);
+		bool is_tap_recourse = false, bool buff_from_client = false);
 	virtual float GetActSpellRange(uint16 spell_id, float range, std::string& item_name) { return range;}
 	virtual float GetSpellRange(uint16 spell_id, float range) { return range; }
 	virtual int32 GetActSpellDamage(uint16 spell_id, int32 value, Mob* target = nullptr) { return value; }


### PR DESCRIPTION
- In PvP, resist debuffs against players are now correctly 50 more effective.
  - This is the authentic client behavior in PvP, and natively supported by the client (see below).
- The client stats page will properly reflect this value as well.
  - The server now sends the pvp flag on zone-in, telling the client it is on a PvP Ruleset while in a PvP Zone, enabling the correct UI/stats to show.