### PR TITLE
Fix ClientProcess to send HP update after DoT damage is applied (if any)

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1364,7 +1364,7 @@ private:
 	int32 CalcBaseHP(bool unbuffed = false);
 	int32 CalcHPRegen();
 	int32 CalcManaRegen(bool meditate = false);
-	void DoHPRegen();
+	void DoHPRegen(bool send_hp_update = true);
 	void DoManaRegen();
 
 	uint8 playeraction;


### PR DESCRIPTION
- Server tick was sending HP Update *before* DoT damage was applied, rather than after it.
- The SendHpUpdate is now deferred until after regen and dots are applied, giving the client the correct amount.
- Without this fix, the client was always seeing HP values one tic behind what their actual HP was, unless they take damage from another source.

### Example (Before)

- Client HP: 100
- Regen +40
- SendHpUpdate(140)
- DOTS -100
- Desync. Client sees that they gained 40 health (140 hp), but actually they now have 40 hp, and will die next tic.

### Example (After)

- Client HP: 100
- Regen +40
- DOTS -100
- SendHpUpdate(40)
- Client and Server both show 40 hp.



