### PR TITLE
[CT 2.0] 'a gyrating mass' should drop legacy loot: Sorrowsong Boots

### DIFF
--- a/utils/sql/git/content/2025_09_07_Add_Legacy_Sorrowong_Boots_CT2.sql
+++ b/utils/sql/git/content/2025_09_07_Add_Legacy_Sorrowong_Boots_CT2.sql
@@ -1,0 +1,9 @@
+INSERT INTO lootdrop (name,                          min_expansion, max_expansion)
+VALUES               ('a_gyrating_mass_legacy_loot', 3,             99);
+SET @a_gyrating_mass_legacy_loot_lootdrop_id = LAST_INSERT_ID();
+
+INSERT INTO lootdrop_entries (lootdrop_id,                              item_id, item_charges, equip_item, chance, minlevel, maxlevel, multiplier, disabled_chance, min_expansion, max_expansion, min_looter_level, item_loot_lockout_timer) 
+VALUES                       (@a_gyrating_mass_legacy_loot_lootdrop_id, 27846,   1,            1,          50,     0,        255,      1,          0,               3,             99,            50,               2629800);
+
+INSERT INTO loottable_entries (loottable_id, lootdrop_id,                              multiplier, probability, droplimit, mindrop, multiplier_min) 
+VALUES                        (96777,        @a_gyrating_mass_legacy_loot_lootdrop_id, 1,          100,         0,         0,      1);


### PR DESCRIPTION
- [CT 2.0] 'a gyrating mass' (rare spawn) can now drop the legacy item 'Sorrowsong Boots' at 50% rate, like other legacay items from CT 2.0.

Saw this mentioned in a bug report.

This legacy drop existed the first 1-2 months when CT 2.0 originally went live, but then stopped dropping. The spawn & drop rate matches the Boots of Flowing Slime, which seems in line with other drops here.

- NPC https://www.pqdi.cc/npc/48335
- Item https://www.pqdi.cc/item/27846
- https://everquest.allakhazam.com/db/item.html?item=10311 (external)

