### PR TITLE
Block AA activation below level 51

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2159,6 +2159,20 @@ void Client::Handle_OP_AAAction(const EQApplicationPacket *app)
 		return;
 	}
 
+	if (GetLevel() < 51)
+	{
+		Message(Chat::Yellow, "You must be level 51 or higher to use Alternate Abilities.");
+		if (m_epp.perAA > 0u)
+		{
+			// Ensure their AA exp% is reset to 0% when below 51.
+			Message_StringID(Chat::White, StringID::AA_OFF); //OFF
+			m_epp.perAA = 0u;
+		}
+		SendAAStats();
+		SendAATable();
+		return;
+	}
+
 	if (strncmp((char *)app->pBuffer, "on ", 3) == 0)
 	{
 		if (m_epp.perAA == 0)

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -621,6 +621,7 @@ void Client::ClearPlayerInfoAndGrantStartingItems(bool goto_death)
 	RefundAA();
 	SetAAPoints(0);
 	m_pp.aapoints_spent = 0;
+	m_epp.perAA = 0u;
 	
 	//Remove all factions.
 	database.RemoveAllFactions(this);

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -717,6 +717,9 @@ void Client::ResetPlayerForNewGamePlus(uint8 in_level, uint8 in_level2, bool res
 	if (new_level < old_level) {
 		SetLevel(new_level, true);
 	}
+	if (new_level < 51) {
+		m_epp.perAA = 0u;
+	}
 
 	// Do additional skill cleanup if level2 was lowered
 	uint8 old_level2 = GetLevel2();


### PR DESCRIPTION
- Resets AA Exp split back to 0% during NG+
- Prevents using AA Abilities until level 51 (like Dire Charm)