### PR TITLE
Added legacy Earring of Flowing Slime to 'a swirling red mass'

### DIFF
--- a/utils/sql/git/content/2025_09_07_Add_Legacy_EarringOfFlowingSlime_CT2.sql
+++ b/utils/sql/git/content/2025_09_07_Add_Legacy_EarringOfFlowingSlime_CT2.sql
@@ -1,0 +1,9 @@
+INSERT INTO lootdrop (name,                                 min_expansion, max_expansion)
+VALUES               ('a_swirling_red_mass_legacy_earring', 3,             99);
+SET @a_swirling_red_mass_legacy_earring_lootdrop_id = LAST_INSERT_ID();
+
+INSERT INTO lootdrop_entries (lootdrop_id,                                     item_id, item_charges, equip_item, chance, minlevel, maxlevel, multiplier, disabled_chance, min_expansion, max_expansion, min_looter_level, item_loot_lockout_timer) 
+VALUES                       (@a_swirling_red_mass_legacy_earring_lootdrop_id, 27939,   1,            1,          50,     0,        255,      1,          0,               3,             99,            50,               2629800);
+
+INSERT INTO loottable_entries (loottable_id, lootdrop_id,                                     multiplier, probability, droplimit, mindrop, multiplier_min) 
+VALUES                        (96774,        @a_swirling_red_mass_legacy_earring_lootdrop_id, 1,          100,         0,         0,      1);


### PR DESCRIPTION
Another missing legacy item from CT 2.0
- Added to 'a swirling red mass' at 50%
  - https://www.pqdi.cc/item/27939
  - https://www.pqdi.cc/npc/48332