### PR TITLE
Instance boot 0 hp bug fix

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2605,8 +2605,13 @@ void Mob::AddToHateList(Mob* other, int32 hate, int32 damage, bool bFrenzy, bool
 			{
 				if (lootLockoutItr->second.HasLockout(Timer::GetTimeSeconds()))
 				{
-					other->CastToClient()->Message(Chat::Red, "You were locked out of %s. Sending you out.", GetCleanName() );
-					other->CastToClient()->BootFromGuildInstance(true);
+					// WORKAROUND: This HP check prevents a bug where you could be booted after a mob is already dead.
+					// This could happen if the mob is hit by a spell or arrow at almost the exact time it dies.
+					if(GetHP() > 0)
+					{
+						other->CastToClient()->Message(Chat::Red, "You were locked out of %s. Sending you out.", GetCleanName() );
+						other->CastToClient()->BootFromGuildInstance(true);
+					}
 				}
 			}
 		}
@@ -2686,8 +2691,13 @@ void Mob::AddToHateList(Mob* other, int32 hate, int32 damage, bool bFrenzy, bool
 					memcpy(&record.lockout, &lootLockoutItr->second, sizeof(LootLockout));
 					if (zone && zone->GetGuildID() != GUILD_NONE && zone->GetGuildID() != 1 && lootLockoutItr->second.HasLockout(Timer::GetTimeSeconds()))
 					{
-						petowner->CastToClient()->Message(Chat::Red, "You were locked out of %s. Sending you out.", GetCleanName());
-						petowner->CastToClient()->BootFromGuildInstance(true);
+						// WORKAROUND: This HP check prevents a bug where you could be booted after a mob is already dead.
+						// I am unsure if this bug affected pets, but it's simple enough to cover for the possibility.
+						if(GetHP() > 0)
+						{
+							petowner->CastToClient()->Message(Chat::Red, "You were locked out of %s. Sending you out.", GetCleanName());
+							petowner->CastToClient()->BootFromGuildInstance(true);
+						}
 					}
 				}
 				m_EngagedClientNames.emplace(petowner->GetCleanName(), record);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2691,13 +2691,8 @@ void Mob::AddToHateList(Mob* other, int32 hate, int32 damage, bool bFrenzy, bool
 					memcpy(&record.lockout, &lootLockoutItr->second, sizeof(LootLockout));
 					if (zone && zone->GetGuildID() != GUILD_NONE && zone->GetGuildID() != 1 && lootLockoutItr->second.HasLockout(Timer::GetTimeSeconds()))
 					{
-						// WORKAROUND: This HP check prevents a bug where you could be booted after a mob is already dead.
-						// I am unsure if this bug affected pets, but it's simple enough to cover for the possibility.
-						if(GetHP() > 0)
-						{
-							petowner->CastToClient()->Message(Chat::Red, "You were locked out of %s. Sending you out.", GetCleanName());
-							petowner->CastToClient()->BootFromGuildInstance(true);
-						}
+						petowner->CastToClient()->Message(Chat::Red, "You were locked out of %s. Sending you out.", GetCleanName());
+						petowner->CastToClient()->BootFromGuildInstance(true);
 					}
 				}
 				m_EngagedClientNames.emplace(petowner->GetCleanName(), record);


### PR DESCRIPTION
There is a bug where sometimes you are able to hit a mob immediately upon death, after a fresh lockout is applied. This is a long-standing bug; I have logs of this happening a few different ways (damage shield kill via riposte, landing an offensive spell exactly as a mob dies, arrows hitting a mob after it is dead).

This has become a large issue for Rangers with the increased use of archery. I would estimate this happens on nearly 10% of boss deaths where an arrow is in-flight as the boss dies. I opened a bug in the PQ discord called "Kicked from zone on boss death - Archery" for this issue a couple weeks ago and decided I would try to find a fix myself.

This code adds an HP check around the client instance boot and only boots if the mob HP is greater than 0 i.e. not already dead. I can provide screeshots/logs if necessary.