### PR TITLE
Teleporters in same zone use Guild ID

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -437,7 +437,8 @@ void Doors::HandleClick(Client* sender, uint8 trigger, bool floor_port)
 			}
 			if (zoneid == zone->GetZoneID())
 			{
-				sender->MovePCGuildID(zone->GetZoneID(), zoneguildid, m_destination.x, m_destination.y, m_destination.z, m_destination.w);
+				bool is_same_zone = strncmp(destination_zone_name, zone_name, strlen(zone_name)) == 0;
+				sender->MovePCGuildID(zone->GetZoneID(), is_same_zone ? zone->GetGuildID() : zoneguildid, m_destination.x, m_destination.y, m_destination.z, m_destination.w);
 			}
 			else
 			{
@@ -449,7 +450,8 @@ void Doors::HandleClick(Client* sender, uint8 trigger, bool floor_port)
 		{
 			if(zoneid == zone->GetZoneID())
 			{
-				sender->MovePCGuildID(zone->GetZoneID(), zoneguildid, m_destination.x, m_destination.y, m_destination.z, m_destination.w);
+				bool is_same_zone = strncmp(destination_zone_name, zone_name, strlen(zone_name)) == 0;
+				sender->MovePCGuildID(zone->GetZoneID(), is_same_zone ? zone->GetGuildID() : zoneguildid, m_destination.x, m_destination.y, m_destination.z, m_destination.w);
 			}
 			else
 			{


### PR DESCRIPTION
Use the Guild ID in the MovePCGuildID function if the destination is the same zone.

This update uses the same strncmp method of comparing destination zones as the preceding code path, just expanded to two additional else if blocks.

Previously, these paths would lead you to the default zoneguildid = GUILD_NONE rather than maintaining your guild instance ID.