### PR TITLE
Fix VP Zone Out Ports

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -426,8 +426,15 @@ void Doors::HandleClick(Client* sender, uint8 trigger, bool floor_port)
 			{
 				sender->KeyRingAdd(playerkey);
 			}
-			bool is_same_zone = strncmp(destination_zone_name, zone_name, strlen(zone_name)) == 0;
-			sender->MovePCGuildID(zone->GetZoneID(), is_same_zone ? zone->GetGuildID() : zoneguildid, m_destination.x, m_destination.y, m_destination.z, m_destination.w);
+			if (zoneid == zone->GetZoneID())
+			{
+				sender->MovePCGuildID(zone->GetZoneID(), zone->GetGuildID(), m_destination.x, m_destination.y, m_destination.z, m_destination.w);
+			}
+			else
+			{
+				zone->ApplyRandomLoc(zoneid, temp_x, temp_y);
+				sender->MovePCGuildID(zoneid, zoneguildid, temp_x, temp_y, m_destination.z, m_destination.w);
+			}
 		}
 		else if ((!IsDoorOpen() || open_type == 58 || floor_port) && (keyneeded && ((keyneeded == playerkey) || sender->GetGM())))
 		{
@@ -437,8 +444,7 @@ void Doors::HandleClick(Client* sender, uint8 trigger, bool floor_port)
 			}
 			if (zoneid == zone->GetZoneID())
 			{
-				bool is_same_zone = strncmp(destination_zone_name, zone_name, strlen(zone_name)) == 0;
-				sender->MovePCGuildID(zone->GetZoneID(), is_same_zone ? zone->GetGuildID() : zoneguildid, m_destination.x, m_destination.y, m_destination.z, m_destination.w);
+				sender->MovePCGuildID(zone->GetZoneID(), zone->GetGuildID(), m_destination.x, m_destination.y, m_destination.z, m_destination.w);
 			}
 			else
 			{
@@ -450,8 +456,7 @@ void Doors::HandleClick(Client* sender, uint8 trigger, bool floor_port)
 		{
 			if(zoneid == zone->GetZoneID())
 			{
-				bool is_same_zone = strncmp(destination_zone_name, zone_name, strlen(zone_name)) == 0;
-				sender->MovePCGuildID(zone->GetZoneID(), is_same_zone ? zone->GetGuildID() : zoneguildid, m_destination.x, m_destination.y, m_destination.z, m_destination.w);
+				sender->MovePCGuildID(zone->GetZoneID(), zone->GetGuildID(), m_destination.x, m_destination.y, m_destination.z, m_destination.w);
 			}
 			else
 			{


### PR DESCRIPTION
This fixes an issue with the zone out pads from VP -> Freeport, PoSky, etc.

These ports previously relied on the "double zone" bug to work because the first "if" check did not have code to handle same vs different destination zones. Therefore they were broken by commit e71744e.

The issue is the first if only sent to destination zone->GetZoneID() and did not have functionality to send to a different zone. VP zone outs hit this check. I believe they are the only ports to work this way (opentype 57 not requiring a manual click, different destination zone).

This commit adds same vs different zone checks to that if branch and also does a minor refactor to remove local bool is_same_zone strncmp as it is redundant with zone id == zone->GetZoneID()