### PR TITLE
Allow ungrouped players to form a raid

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -7524,7 +7524,7 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket *app)
 					return;
 				}
 
-				if (g == lg)
+				if (g && g == lg)
 				{
 					i->Message(Chat::Red, "Invite failed, you cannot invite yourself to your own raid group.");
 					return;


### PR DESCRIPTION
A previous change to fix a crash from inviting someone in your own group when forming a raid
    blocks two ungrouped players from forming a raid
  - Based on the red error message, that appears unintentional
 
This slows down local development by forcing an additional client to test raid functionality. It restores the functionality at server creation and tested on the local server that the two raid members are blocked from inviting each other.