### PR TITLE
Update raidhealth fanout with from messages

### DIFF
--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1883,12 +1883,14 @@ void Raid::SendHPPacketsFrom(Mob *m)
 		gid = this->GetGroup(m->CastToClient());
 	EQApplicationPacket hpapp;
 
+	bool raidHealthUpdate = RuleB(Raid, RaidHealthUpdates);
 	m->CreateHPPacket(&hpapp);
 	for(int x = 0; x < MAX_RAID_MEMBERS; x++)
 	{
 		if(members[x].member && members[x].member->Connected())
 		{
-			if(!m->IsClient() || ((members[x].member != m->CastToClient()) && (members[x].GroupNumber == gid)))
+			if(!m->IsClient() || ((members[x].member != m->CastToClient()) &&
+			  (raidHealthUpdate || members[x].GroupNumber == gid)))
 			{
 				members[x].member->QueuePacket(&hpapp, true);
 			}


### PR DESCRIPTION
- Include rule gated fanout of hp updates to all raid members in the Raid::SendHPPacketsFrom() method in addition to the existing one in Raid::SendPacketsTo() method

The existing SendPacketsTo() is used to broadcast from existing raid members to a new member that joins, but the SendPacketsFrom() is more useful for raid health bars as it routes from a member when their HP changs.