### PR TITLE
Fixing "Fake Shei" engage_notice

### DIFF
--- a/utils/sql/git/content/2026_01_17_Remove_Fake_Shei_Engage_Notice.sql
+++ b/utils/sql/git/content/2026_01_17_Remove_Fake_Shei_Engage_Notice.sql
@@ -1,0 +1,2 @@
+-- Fixing broadcast announcement to not trigger on death of Fake Shei
+UPDATE npc_types nt SET engage_notice = 0 WHERE nt.id = 179032; -- fake shei


### PR DESCRIPTION
Kill Annoucement was triggering on death of Fake Shei which looked wrong, since only the 2nd phase should have an announcement.

See Also
- https://github.com/SecretsOTheP/quests/pull/94
- Fixes Shei to have PvP Double Loot