### PR TITLE
Update mob rampage message to include target

### DIFF
--- a/utils/UI/eqstr_en.txt
+++ b/utils/UI/eqstr_en.txt
@@ -540,7 +540,7 @@ EQST0002
 1041 %1 fails to cast the gate spell due to a translocational disruption.
 1042 %1 has become ENRAGED.
 1043 %1 is no longer enraged.
-1044 %1 goes on a RAMPAGE!
+1044 %1 goes on a RAMPAGE against %2!
 1045 %1 executes a FLURRY of attacks on %2!
 1046 %1 executes an amazing attack sequence.
 1047 %1 shouts, 'Guards! Guards! Stop that thief!!'

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2877,10 +2877,7 @@ bool Mob::Rampage(int range, int damagePct)
 	if (IsCharmedPet())
 		return false;
 
-	if (!IsPet())
-		entity_list.MessageClose_StringID(this, true, 200, Chat::NPCRampage, StringID::NPC_RAMPAGE, GetCleanName());
-	else
-		entity_list.MessageClose_StringID(this, true, 200, Chat::PetFlurry, StringID::NPC_RAMPAGE, GetCleanName());
+	bool rampage_valid_target = false;
 
 	for (int i = 0; i < RampageArray.size(); i++)
 	{
@@ -2904,6 +2901,13 @@ bool Mob::Rampage(int range, int damagePct)
 			if (DistanceSquared(m_Position, m_target->GetPosition()) > (range * range))
 				continue;
 
+			rampage_valid_target = true;
+
+			if (!IsPet())
+				entity_list.MessageClose_StringID(this, true, 200, Chat::NPCRampage, StringID::NPC_RAMPAGE, GetCleanName(), m_target->GetCleanName());
+			else
+				entity_list.MessageClose_StringID(this, true, 200, Chat::PetFlurry, StringID::NPC_RAMPAGE, GetCleanName(), m_target->GetCleanName());
+
 			DoMainHandRound(m_target, damagePct);
 			if (IsDualWielding())
 				DoOffHandRound(m_target, damagePct);
@@ -2918,6 +2922,15 @@ bool Mob::Rampage(int range, int damagePct)
 			}
 			break;
 		}
+	}
+
+	if (!rampage_valid_target)
+	{
+		static const char* NPC_RAMPAGE_MSG_SUFFIX = "goes on a RAMPAGE!";
+		if (!IsPet())
+			entity_list.MessageClose_StringID(this, true, 200, Chat::NPCRampage, StringID::GENERIC_EMOTE, GetCleanName(), NPC_RAMPAGE_MSG_SUFFIX);
+		else
+			entity_list.MessageClose_StringID(this, true, 200, Chat::PetFlurry, StringID::GENERIC_EMOTE, GetCleanName(), NPC_RAMPAGE_MSG_SUFFIX);
 	}
 
 	// rampages always kick/bash/backstab the target

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2879,6 +2879,8 @@ bool Mob::Rampage(int range, int damagePct)
 
 	bool rampage_valid_target = false;
 
+	uint32 rampage_message_type = IsPet() ? Chat::PetFlurry : Chat::NPCRampage;
+
 	for (int i = 0; i < RampageArray.size(); i++)
 	{
 		if (!RampageArray[i])
@@ -2903,10 +2905,7 @@ bool Mob::Rampage(int range, int damagePct)
 
 			rampage_valid_target = true;
 
-			if (!IsPet())
-				entity_list.MessageClose_StringID(this, true, 200, Chat::NPCRampage, StringID::NPC_RAMPAGE, GetCleanName(), m_target->GetCleanName());
-			else
-				entity_list.MessageClose_StringID(this, true, 200, Chat::PetFlurry, StringID::NPC_RAMPAGE, GetCleanName(), m_target->GetCleanName());
+			entity_list.MessageClose_StringID(this, true, 200, rampage_message_type, StringID::NPC_RAMPAGE, GetCleanName(), m_target->GetCleanName());
 
 			DoMainHandRound(m_target, damagePct);
 			if (IsDualWielding())
@@ -2925,13 +2924,7 @@ bool Mob::Rampage(int range, int damagePct)
 	}
 
 	if (!rampage_valid_target)
-	{
-		static const char* NPC_RAMPAGE_MSG_SUFFIX = "goes on a RAMPAGE!";
-		if (!IsPet())
-			entity_list.MessageClose_StringID(this, true, 200, Chat::NPCRampage, StringID::GENERIC_EMOTE, GetCleanName(), NPC_RAMPAGE_MSG_SUFFIX);
-		else
-			entity_list.MessageClose_StringID(this, true, 200, Chat::PetFlurry, StringID::GENERIC_EMOTE, GetCleanName(), NPC_RAMPAGE_MSG_SUFFIX);
-	}
+		entity_list.MessageClose_StringID(this, true, 200, rampage_message_type, StringID::GENERIC_EMOTE, GetCleanName(), "goes on a RAMPAGE!");
 
 	// rampages always kick/bash/backstab the target
 	if (IsNPC())

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -225,7 +225,7 @@ namespace StringID {
 	const uint16 OTHER_CRIT_BLAST               = 1040; //%1 delivers a critical blast! (%2)
 	const uint16 NPC_ENRAGE_START               = 1042; //%1 has become ENRAGED.
 	const uint16 NPC_ENRAGE_END                 = 1043; //%1 is no longer enraged.
-	const uint16 NPC_RAMPAGE                    = 1044; //%1 goes on a RAMPAGE!
+	const uint16 NPC_RAMPAGE                    = 1044; //%1 goes on a RAMPAGE against %2!
 	const uint16 NPC_FLURRY                     = 1045; //%1 executes a FLURRY of attacks on %2!
 	const uint16 DISCIPLINE_AGRESSIVE           = 1048; //%1 assumes an aggressive fighting style.
 	const uint16 DISCIPLINE_PRECISION           = 1049; //%1 assumes a highly precise fighting style.


### PR DESCRIPTION
Updates Mob::Rampage() to also send the Rampage Target.

Requires eqstr_en.txt to be updated on the client end to see the full message, but doesn't affect clients without the change.