### PR TITLE
cross zone raid invite commands

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -125,6 +125,11 @@
 #define ServerOP_RaidAddLooter		0x0115
 #define ServerOP_RemoveRaidLooter	0x0116
 
+// cross-zone raid invites
+#define ServerOP_RaidInvite			0x0117
+#define ServerOP_RaidInviteResponse	0x0118
+#define ServerOP_RaidInviteFailure	0x0119
+
 #define ServerOP_WhoAll				0x0210
 #define ServerOP_FriendsWho			0x0211
 #define ServerOP_LFGMatches			0x0212
@@ -380,6 +385,24 @@ struct ServerGroupFollowAck_Struct {
 	char Name[64];
 	uint32 charid;
 	uint32 groupid;
+};
+
+// raid invite data passed between zones
+struct ServerRaidInvite_Struct {
+	char inviter_name[64];
+	char invitee_name[64];
+	uint32 rid;
+	uint32 invite_id;
+	ChallengeRules::RuleSet raid_ruleset;
+	bool is_acceptance;
+};
+
+// raid invite failure notification
+struct ServerRaidInviteFailure_Struct {
+	char inviter_name[64];
+	char invitee_name[64];
+	char failure_message[256];
+	bool notify_inviter;
 };
 
 struct ServerChannelMessage_Struct {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6462,6 +6462,17 @@ void Client::ClearGroupInvite()
 	safe_delete(outapp);
 }
 
+void Client::SetPendingCrossZoneRaidInvite(const char* inviter_name, ChallengeRules::RuleSet ruleset)
+{
+	PendingCrossZoneRaidInviter = inviter_name;
+	PendingCrossZoneRaidRuleset = ruleset;
+}
+
+void Client::ClearPendingCrossZoneRaidInvite()
+{
+	PendingCrossZoneRaidInviter.clear();
+	PendingCrossZoneRaidRuleset = ChallengeRules::RuleSet::NORMAL;
+}
 
 void Client::WarCry(uint8 rank)
 {

--- a/zone/client.h
+++ b/zone/client.h
@@ -1246,6 +1246,13 @@ public:
 	bool camp_desktop;
 	void ClearGroupInvite();
 	void ClearTimersOnDeath();
+	
+	// Pending raid invite methods
+	void SetPendingCrossZoneRaidInvite(const char* inviter_name, ChallengeRules::RuleSet ruleset);
+	void ClearPendingCrossZoneRaidInvite();
+	bool HasPendingCrossZoneRaidInvite() const { return !PendingCrossZoneRaidInviter.empty(); }
+	const std::string& GetPendingCrossZoneRaidInviter() const { return PendingCrossZoneRaidInviter; }
+	ChallengeRules::RuleSet GetPendingCrossZoneRaidRuleset() const { return PendingCrossZoneRaidRuleset; }
 	void UpdateLFG(bool value = false, bool ignoresender = false);
 	uint16 poison_spell_id; // rogue apply poison
 	bool ShowHelm() { return m_pp.showhelm; }
@@ -1582,6 +1589,11 @@ private:
 
 	uint8 HideCorpseMode;
 	bool PendingGuildInvitation;
+	
+	// Pending raid invite state
+	std::string PendingCrossZoneRaidInviter;
+	ChallengeRules::RuleSet PendingCrossZoneRaidRuleset;
+	
 	int PendingRezzXP;
 	uint32 PendingRezzDBID;
 	uint32 PendingRezzZoneID;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -293,6 +293,10 @@ int command_init(void)
 		command_add("qtest", "QueryServ testing command.", AccountStatus::GMTester, command_qtest) ||
 		command_add("quaketrigger", "- [type_num (1 = Normal, 2 = PVP)] Triggers an earthquake manually", AccountStatus::GMImpossible, command_quaketrigger) ||
 
+		command_add("ra", "[playername] - Alias for #raidaccept.", AccountStatus::Player, command_raidaccept) ||
+		command_add("raidaccept", "- Accept a pending cross-zone raid invite (use when Accept button doesn't work).", AccountStatus::Player, command_raidaccept) ||
+		command_add("raidinvite", "[playername] - Invite a player to your raid. Use #raidaccept for cross-zone invites.", AccountStatus::Player, command_raidinvite) ||
+		command_add("ri", "[playername] - Alias for #raidinvite.", AccountStatus::Player, command_raidinvite) ||
 		command_add("raidloot", "LEADER|GROUPLEADER|SELECTED|ALL - Sets your raid loot settings if you have permission to do so.", 1, command_raidloot) ||
 		command_add("randtest", "Perform a sampling of random number generation", AccountStatus::GMImpossible, command_randtest) ||
 		command_add("randomfeatures", "Temporarily randomizes the Facial Features of your target.", AccountStatus::GMCoder, command_randomfeatures) ||
@@ -1011,6 +1015,8 @@ void command_clearsaylink(Client *c, const Seperator *sep) {
 #include "gm_commands/push.cpp"
 #include "gm_commands/qtest.cpp"
 #include "gm_commands/quaketrigger.cpp"
+#include "gm_commands/raidaccept.cpp"
+#include "gm_commands/raidinvite.cpp"
 #include "gm_commands/raidloot.cpp"
 #include "gm_commands/randomfeatures.cpp"
 #include "gm_commands/randtest.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -177,6 +177,8 @@ void command_profanity(Client* c, const Seperator* sep);
 void command_push(Client* c, const Seperator* sep);
 void command_qtest(Client* c, const Seperator* sep);
 void command_quaketrigger(Client* c, const Seperator* sep);
+void command_raidaccept(Client* c, const Seperator* sep);
+void command_raidinvite(Client* c, const Seperator* sep);
 void command_raidloot(Client* c, const Seperator* sep);
 void command_randomfeatures(Client* c, const Seperator* sep);
 void command_randtest(Client*, const Seperator* sep);


### PR DESCRIPTION
# Cross-Zone Raid Invite

These commands are intended for two primary use cases:
1. Guild Leader/Officers inviting guild members who are in a different zone so they can enter an instance for a quest turn in.
2. Raid Leaders inviting guild members to a raid without having to zone out.

This is not intended to replace /raidinvite. It is only meant to address these two major pain points expressed by raid leaders.

## Commands

| Command | Alias | Description |
|---------|-------|-------------|
| `#raidinvite [name]` | `#ri` | Send a raid invite to a player |
| `#raidaccept` | `#ra` | Accept a pending raid invite |

## Usage

**Inviter:**
```
#raidinvite PlayerName
```

**Invitee:**
```
#raidaccept
```

## Requirements

### To Send an Invite (#raidinvite)

- Must be in a guild with raids enabled (`raid_enabled = 1`)
- Must be a guild officer or leader
- If **in** a raid: must be the raid leader
- 2 second cooldown between invites

### To Accept an Invite (#raidaccept)

- Must not be in a group
- Must not be in a raid
- Challenge mode must match

## Behavior

- Invited players join the raid without a group
- Pending invite is cleared if player zones before accepting
- Only one pending invite per player (new invite overwrites old)

