### PR TITLE
Invisibility no longer kills non-charmed pets

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6898,6 +6898,12 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 	if (mypet->GetPetType() == petFamiliar && pet->command != PET_GETLOST)
 		return;
 
+	// If invisible/hidden/etc, only allow "/pet get lost"
+	if (pet->command != PET_GETLOST && (invisible || invisible_undead || invisible_animals || hidden || improved_hidden)) {
+		Message_StringID(Chat::MyPet, StringID::GENERIC_SAY, mypet->GetCleanName(), "Master, I can't see you!");
+		return;
+	}
+
 	uint32 PetCommand = pet->command;
 
 	switch (PetCommand)

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -485,11 +485,22 @@ void Mob::SetInvisible(uint8 state, bool showInvis, bool skipSelf)
 		SendAppearancePacket(AppearanceType::Invisibility, state, true, skipSelf);
 	}
 
-	// Invis and hide breaks charms
-	if (GetPet() && state != INVIS_OFF)
+	Mob* pet = GetPet();
+	// Invis and hide pet actions
+	if (pet && state != INVIS_OFF)
 	{
-		if (GetPet() && GetPet()->IsCharmedPet())
+		// Break charmed pets
+		if (pet && pet->IsCharmedPet())
 			FadePetCharmBuff();
+		// Disengage regular player pets
+		else if (IsClient()) {
+			pet->InterruptSpell();
+			pet->WipeHateList();
+			pet->SetTarget(nullptr);
+			pet->SetPetOrder(SPO_Follow);
+			Message_StringID(Chat::MyPet, StringID::GENERIC_SAY, pet->GetCleanName(), "Master, where did you go?");
+		}
+		// Kill other pets
 		else
 			DepopPet();
 	}


### PR DESCRIPTION
Changes the player invisibility / pet interaction so that regular pets are no longer killed. Includes IVU / hide / etc

- When invisibility lands on a player, their pet will back off and be set to a passive state
- While invisible, pets will be uncontrollable (excluding get lost)
- Pets will still defend themselves and the player after the invisibility initially lands
- Charmed pets will still break as before
- Any other type of pet will depop as before
