### PR TITLE
Group Invite Command & Cross-Zone Raid Invite Command Improvements

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -395,6 +395,7 @@ struct ServerRaidInvite_Struct {
 	uint32 invite_id;
 	ChallengeRules::RuleSet raid_ruleset;
 	bool is_acceptance;
+	uint32 requested_group;  // 0xFFFFFFFF = ungrouped, 0-11 = group 1-12 (as group leader)
 };
 
 // raid invite failure notification

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6462,16 +6462,18 @@ void Client::ClearGroupInvite()
 	safe_delete(outapp);
 }
 
-void Client::SetPendingCrossZoneRaidInvite(const char* inviter_name, ChallengeRules::RuleSet ruleset)
+void Client::SetPendingCrossZoneRaidInvite(const char* inviter_name, ChallengeRules::RuleSet ruleset, uint32 group_number)
 {
 	PendingCrossZoneRaidInviter = inviter_name;
 	PendingCrossZoneRaidRuleset = ruleset;
+	PendingCrossZoneRaidGroupNumber = group_number;
 }
 
 void Client::ClearPendingCrossZoneRaidInvite()
 {
 	PendingCrossZoneRaidInviter.clear();
 	PendingCrossZoneRaidRuleset = ChallengeRules::RuleSet::NORMAL;
+	PendingCrossZoneRaidGroupNumber = 0xFFFFFFFF;
 }
 
 void Client::WarCry(uint8 rank)

--- a/zone/client.h
+++ b/zone/client.h
@@ -1248,11 +1248,12 @@ public:
 	void ClearTimersOnDeath();
 	
 	// Pending raid invite methods
-	void SetPendingCrossZoneRaidInvite(const char* inviter_name, ChallengeRules::RuleSet ruleset);
+	void SetPendingCrossZoneRaidInvite(const char* inviter_name, ChallengeRules::RuleSet ruleset, uint32 group_number = 0xFFFFFFFF);
 	void ClearPendingCrossZoneRaidInvite();
 	bool HasPendingCrossZoneRaidInvite() const { return !PendingCrossZoneRaidInviter.empty(); }
 	const std::string& GetPendingCrossZoneRaidInviter() const { return PendingCrossZoneRaidInviter; }
 	ChallengeRules::RuleSet GetPendingCrossZoneRaidRuleset() const { return PendingCrossZoneRaidRuleset; }
+	uint32 GetPendingCrossZoneRaidGroupNumber() const { return PendingCrossZoneRaidGroupNumber; }
 	void UpdateLFG(bool value = false, bool ignoresender = false);
 	uint16 poison_spell_id; // rogue apply poison
 	bool ShowHelm() { return m_pp.showhelm; }
@@ -1593,6 +1594,7 @@ private:
 	// Pending raid invite state
 	std::string PendingCrossZoneRaidInviter;
 	ChallengeRules::RuleSet PendingCrossZoneRaidRuleset;
+	uint32 PendingCrossZoneRaidGroupNumber;
 	
 	int PendingRezzXP;
 	uint32 PendingRezzDBID;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -231,6 +231,8 @@ int command_init(void)
 		command_add("interrogateinv", "use [help] argument for available options.", AccountStatus::GMLeadAdmin, command_interrogateinv) ||
 		command_add("interrogatelegacy", "Interrogates legacy items of your current target", AccountStatus::GMAdmin, command_interrogatelegacy) ||		
 		command_add("interrupt", "[message id] [color] - Interrupt your casting. Arguments are optional.", AccountStatus::EQSupport, command_interrupt) ||
+		command_add("inv", "[playername] - Alias for #invite.", AccountStatus::Player, command_invite) ||
+		command_add("invite", "[playername] - Send a group invite by name (no target required).", AccountStatus::Player, command_invite) ||
 		command_add("ipban", "[IP address] - Ban IP by character name.", AccountStatus::GMMgmt, command_ipban) ||
 		command_add("ipexemption", "[accountname] [exemption] - Set IP exemption amount for accountname by amount. Accounts default to 1.", AccountStatus::GMAdmin, command_ipexemption) ||
 	
@@ -294,7 +296,7 @@ int command_init(void)
 		command_add("quaketrigger", "- [type_num (1 = Normal, 2 = PVP)] Triggers an earthquake manually", AccountStatus::GMImpossible, command_quaketrigger) ||
 
 		command_add("ra", "[playername] - Alias for #raidaccept.", AccountStatus::Player, command_raidaccept) ||
-		command_add("raidaccept", "- Accept a pending cross-zone raid invite (use when Accept button doesn't work).", AccountStatus::Player, command_raidaccept) ||
+		command_add("raidaccept", "- Accept a pending cross-zone raid invite", AccountStatus::Player, command_raidaccept) ||
 		command_add("raidinvite", "[playername] - Invite a player to your raid. Use #raidaccept for cross-zone invites.", AccountStatus::Player, command_raidinvite) ||
 		command_add("ri", "[playername] - Alias for #raidinvite.", AccountStatus::Player, command_raidinvite) ||
 		command_add("raidloot", "LEADER|GROUPLEADER|SELECTED|ALL - Sets your raid loot settings if you have permission to do so.", 1, command_raidloot) ||
@@ -967,6 +969,7 @@ void command_clearsaylink(Client *c, const Seperator *sep) {
 #include "gm_commands/interrogateinv.cpp"
 #include "gm_commands/interrogatelegacy.cpp"
 #include "gm_commands/interrupt.cpp"
+#include "gm_commands/invite.cpp"
 #include "gm_commands/ipban.cpp"
 #include "gm_commands/ipexemption.cpp"
 #include "gm_commands/iteminfo.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -125,6 +125,7 @@ void command_hotfix(Client* c, const Seperator* sep);
 void command_interrogateinv(Client* c, const Seperator* sep);
 void command_interrogatelegacy(Client* c, const Seperator* sep);
 void command_interrupt(Client* c, const Seperator* sep);
+void command_invite(Client* c, const Seperator* sep);
 void command_ipban(Client* c, const Seperator* sep);
 void command_ipexemption(Client* c, const Seperator* sep);
 void command_iteminfo(Client* c, const Seperator* sep);

--- a/zone/gm_commands/invite.cpp
+++ b/zone/gm_commands/invite.cpp
@@ -1,0 +1,68 @@
+#include "../client.h"
+#include "../../common/eq_packet_structs.h"
+
+// rate limit
+static std::map<uint32, time_t> invite_cooldowns;
+static const int INVITE_COOLDOWN_SECONDS = 2;
+
+void command_invite(Client *c, const Seperator *sep)
+{
+	uint32 char_id = c->CharacterID();
+	time_t now = time(nullptr);
+	auto it = invite_cooldowns.find(char_id);
+	if (it != invite_cooldowns.end()) {
+		time_t elapsed = now - it->second;
+		if (elapsed < INVITE_COOLDOWN_SECONDS) {
+			c->Message(Chat::Red, "Please wait %d second(s) before sending another group invite.",
+				(int)(INVITE_COOLDOWN_SECONDS - elapsed));
+			return;
+		}
+	}
+
+	if (!sep->arg[1][0]) {
+		c->Message(Chat::White, "Usage: #invite [playername]");
+		c->Message(Chat::White, "Sends a group invite to a player in this zone (no target required).");
+		return;
+	}
+
+	Client *localInvitee = entity_list.GetClientByName(sep->arg[1]);
+
+	if (!localInvitee) {
+		c->Message(Chat::Red, "%s is not in this zone.", sep->arg[1]);
+		return;
+	}
+	else if (localInvitee->GetGroup()) {
+		c->Message(Chat::Red, "%s is already in a group.", sep->arg[1]);
+		return;
+	}
+
+	Group *g = c->GetGroup();
+	if (g) {
+		if (!g->IsLeader(c)) {
+			c->Message(Chat::Red, "You must be the group leader to invite others.");
+			return;
+		}
+		if (g->GroupCount() >= MAX_GROUP_MEMBERS) {
+			c->Message(Chat::Red, "Your group is full.");
+			return;
+		}
+	}
+
+	Raid *r = c->GetRaid();
+	if (r && !r->IsGroupLeader(c->GetName())) {
+		c->Message(Chat::Red, "You must be a raid group leader to invite others.");
+		return;
+	}
+
+	auto app = new EQApplicationPacket(OP_GroupInvite, sizeof(GroupInvite_Struct));
+	GroupInvite_Struct* gis = (GroupInvite_Struct*)app->pBuffer;
+	memset(gis, 0, sizeof(GroupInvite_Struct));
+	strn0cpy(gis->inviter_name, c->GetName(), 64);
+	strn0cpy(gis->invitee_name, sep->arg[1], 64);
+
+	c->Handle_OP_GroupInvite(app);
+
+	safe_delete(app);
+	
+	invite_cooldowns[char_id] = now;
+}

--- a/zone/gm_commands/raidaccept.cpp
+++ b/zone/gm_commands/raidaccept.cpp
@@ -14,6 +14,7 @@ void command_raidaccept(Client *c, const Seperator *sep)
 
 	std::string inviter_name = c->GetPendingCrossZoneRaidInviter();
 	ChallengeRules::RuleSet inviter_ruleset = c->GetPendingCrossZoneRaidRuleset();
+	uint32 requested_group = c->GetPendingCrossZoneRaidGroupNumber();
 
 	Group *g = c->GetGroup();
 	if (g) {
@@ -47,6 +48,7 @@ void command_raidaccept(Client *c, const Seperator *sep)
 	sris->invite_id = 0;
 	sris->raid_ruleset = c->GetRuleSet();
 	sris->is_acceptance = true;
+	sris->requested_group = requested_group;
 	worldserver.SendPacket(pack);
 	safe_delete(pack);
 


### PR DESCRIPTION
# Same-Zone Group Invite & Cross-Zone Raid Invite Command Improvements

- The cross-zone raid invite command now takes an optional parameter for raid group leader.
- A new command was added to allow same-zone group invites from anywhere in the zone, without requiring a target. 

## Demo

https://www.youtube.com/watch?v=EX7sHxQa_FE

## Commands

| Command | Alias | Description |
|---------|-------|-------------|
| `#raidinvite [name] [group]` | `#ri` | Send a cross-zone raid invite to a player. Optional group 1-12 to make them leader of that group. |
| `#raidaccept` | `#ra` | Accept a pending raid invite |
| `#invite [name]` | `#inv` | Send a group invite to a player by name (same zone, no target required) |

## Use Cases

1. **Raid Leaders** inviting guild members to a raid as ungrouped without needing to be in the same zone
2. **Raid Leaders** inviting guild members to a raid as a raid group leader without needing to be in the same zone
3. **Raid Group Leaders** inviting players by name to their raid group without needing to target them
4. **Guild Leader/Officers** inviting guild members who are in a different zone for instanced quest turn-ins
5. **Group Leaders** inviting players by name to their group without needing to target them

## Usage

### Raid Invites

**Inviter:**
```
#raidinvite PlayerName          # Invite to ungrouped section
#raidinvite PlayerName 3        # Invite to lead group 3
```

**Invitee:**
```
#raidaccept
```

### Group Invites

**Inviter:**
```
#invite PlayerName
```

**Invitee:** Uses normal `/join` or accept button.

## Requirements

### To Send a Raid Invite (#raidinvite)

- Must be in a guild with raids enabled (`raid_enabled = 1`)
- Must be a guild officer or leader
- If **in** a raid: must be the raid leader
- If specifying a group: that group must be empty
- Cannot invite to group 1 when forming a new raid (raid leader goes to group 1)
- 2 second cooldown between invites

### To Accept a Raid Invite (#raidaccept)

- Must not be in a group
- Must not be in a raid
- Challenge mode must match

### To Send a Group Invite (#invite)

- Invitee must be in the same zone
- 2 second cooldown between invites
- All standard group invite rules apply (solo mode, challenge mode, etc.)

## Behavior

### Raid Invites

- If no group specified: player joins the ungrouped section
- If group specified and empty: player becomes leader of that group
- Pending invite is cleared if player zones before accepting
- Only one pending invite per player (new invite overwrites old)

### Group Invites

- Uses the existing group invite code path
- Invitee uses normal `/join` or accept button to join
- All existing validation applies (solo mode, GM checks, already grouped, etc.)
