### PR TITLE
Enable AllowClickCastFromBag for ClientUnknown

### DIFF
--- a/common/eq_limits.cpp
+++ b/common/eq_limits.cpp
@@ -37,7 +37,7 @@ static const EQ::inventory::LookupEntry inventory_lookup_entries[EQ::versions::M
 		ClientUnknown::INULL,
 
 		false, 
-		false, 
+		true, 
 		false, 
 		false
 	},


### PR DESCRIPTION
Enables Click Casting from bags with a future Zeal update.

The Zeal draft PR is here https://github.com/CoastalRedwood/Zeal/pull/164 pending approval from Secrets.