### PR TITLE
Only extend self cast illusions don't reapply them when recasting existing buf - QoL Rogs/Necs etc in raids due to needing reshrink

### DIFF
--- a/zone/buffstacking.cpp
+++ b/zone/buffstacking.cpp
@@ -1263,6 +1263,18 @@ bool Mob::AssignBuffSlot(Mob *caster, uint16 spell_id, int &buffslot, int &caste
 			return false;
 		}
 
+		// Self player illusion refresh: update duration only, avoid OP_Action and buff field reset
+		if (caster == this && IsPlayerIllusionSpell(spell_id)
+		    && buffs[slot].spellid == spell_id && buffs[slot].casterid == caster->GetID())
+		{
+			buffslot = slot;
+			buffs[slot].casterlevel = caster_level;
+			buffs[slot].realcasterlevel = caster->GetLevel();
+			buffs[slot].ticsremaining = duration + 1;
+			CalcBonuses();
+			return true;
+		}
+
 		// FindAffectSlot removes the buff it's overwriting in the buffs[] array but doesn't send a packet to the client.
 		// The expectation is that our FindAffectSlot behaves identically to the client so that the slot number we just computed
 		// is where the client will put the buff when we send the action packet to it.

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1335,6 +1335,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 #endif
 				if (buffslot < 0)
 					break;
+				if (current_buff_refresh && caster == this && IsPlayerIllusionSpell(spell_id))
+					break;
 				ApplyIllusion(spell, i, caster);
 
 				for (int x = EQ::textures::textureBegin; x <= EQ::textures::LastTintableTexture; x++)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3445,7 +3445,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob* spelltar, bool reflect, bool use_r
 		CastToClient()->ApplyDurationFocus(spell_id, buffslot, spelltar, isrecourse ? recourse_spell_level : caster_spell_level);
 	}
 
-	if (IsClient() && IsSpecialDurationSpell(spell_id))
+	if (IsClient() && (IsSpecialDurationSpell(spell_id) || (current_buff_refresh && IsPlayerIllusionSpell(spell_id))))
 	{
 		int buff_count = GetMaxTotalSlots();
 		for (int i = 0; i < buff_count; ++i)


### PR DESCRIPTION
Only extend self cast illusions don't reapply them when recasting existing buf - QoL Rogs/Necs etc in raids due to needing reshrink
