### PR TITLE
Lictor the eternal acrylia ore breakdown increases

### DIFF
--- a/utils/sql/git/content/2026_07_13_Acrylia_Ore_Increase_Block_Breakdown.sql
+++ b/utils/sql/git/content/2026_07_13_Acrylia_Ore_Increase_Block_Breakdown.sql
@@ -1,0 +1,2 @@
+/* This Creates a new row in tradeskill_recipe_entries table for the Recipe: Large Brick Of Acrylia Ore (Recipe ID 5113) which will return a second Large Brick Of Acrylia Ore when breaking down a Block of Acrylia Ore */
+INSERT INTO tradeskill_recipe_entries (id, recipe_id, item_id, successcount, failcount, componentcount, iscontainer) VALUES ( DEFAULT, '5113', '10424', '1', '0', '0', '0');

--- a/utils/sql/git/content/2026_07_13_Acrylia_Ore_Increase_Large_Brick_Breakdown.sql
+++ b/utils/sql/git/content/2026_07_13_Acrylia_Ore_Increase_Large_Brick_Breakdown.sql
@@ -1,0 +1,2 @@
+/* This Creates a new row in tradeskill_recipe_entries table for the Recipe: Small Brick Of Acrylia Ore (Recipe ID 6095) which will return a second Small Brick Of Acrylia Ore when breaking down a Large Brick Of Acrylia Ore */
+INSERT INTO tradeskill_recipe_entries (id, recipe_id, item_id, successcount, failcount, componentcount, iscontainer) VALUES ( DEFAULT, '6095', '10423', '1', '0', '0', '0');


### PR DESCRIPTION
Adjustment to increase the amount of large bicks / small bricks returned from breaking down blocks or large bricks from 1 to 2.  This is in line with adjustments for Velium. 