### PR TITLE
Revised Ramp List Addition Methodology

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2821,6 +2821,12 @@ bool Mob::AddRampage(Mob *mob)
 	if (!GetSpecialAbility(SpecialAbility::Rampage))
 		return false;
 
+	if (RampageArray.size() < 256)
+	{
+		RampageArray.push_back(mob->GetID());
+		return true;
+	}
+
 	int firsthole = -1;
 	for (int i = 0; i < RampageArray.size(); i++) {
 		// in case entity isn't removed from list when it should be


### PR DESCRIPTION
This revised rampage system always puts new hate-generating mobs at the bottom of the ramp list, except when there are already equal to or more than 256 entrants (seemed a reasonable number, not a limit imposed by data sizes), whereupon it will execute the code as previously written.  This is to prevent a potential, though highly unlikely, situation where a person or group could add so many entries that the vector consumes enough memory to crash the server.  This potential issue already exists in the code, but is mitigated by needing that many unique entrants, as opposed to a few entrants constantly creating new entries of themselves.

Please accept this change for the enjoyment and mild de-stressing of the Quarm raiding community.  People keep dying from ramp when they shouldn't be anywhere near the top of the list and we've run out of ways to reliably mitigate the weirdness.  The clerics are threatening to revolt, or maybe it was, they're threatening to retire.