### PR TITLE
Add Guild 1 quake and tiered raid respawn foundation

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -103,7 +103,7 @@ uint32 Spawn2::resetTimer(bool quake_repop)
 	// Guild 1 raid targets are repopped by the quake system. Keep defeated
 	// targets dormant between quakes while preserving normal guild-instance
 	// overrides for Guild 2 and above.
-	if (!quake_repop && zone && zone->GetGuildID() == 1 && raid_target_spawnpoint)
+	if (!quake_repop && zone && zone->GetGuildID() == 1 && raid_target_spawnpoint && !zone->GuildOneTimedRaidSpawnsEnabled())
 	{
 		return UINT_MAX;
 	}
@@ -197,7 +197,7 @@ bool Spawn2::Process() {
 		return true;
 	}
 
-	if (!RuleB(Quarm, EnableQuakes) && raid_target_spawnpoint && zone->GetGuildID() == 1) {
+	if (!RuleB(Quarm, EnableQuakes) && raid_target_spawnpoint && zone->GetGuildID() == 1 && !zone->GuildOneTimedRaidSpawnsEnabled()) {
 		return true;
 	}
 
@@ -270,7 +270,7 @@ bool Spawn2::Process() {
 			return true;
 		}
 
-		if (!RuleB(Quarm, EnableQuakes) && raid_target_spawnpoint && zone->GetGuildID() == 1) {
+		if (!RuleB(Quarm, EnableQuakes) && raid_target_spawnpoint && zone->GetGuildID() == 1 && !zone->GuildOneTimedRaidSpawnsEnabled()) {
 			timer.Start(60000);	//don't yield quake mobs when they're disabled.
 			return true;
 		}

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -87,7 +87,7 @@ Spawn2::Spawn2(uint32 in_spawn2_id, uint32 spawngroup_id,
 
 		//no timeleft at all, reset to
 		if (cur == 0)
-			cur = resetTimer();
+			cur = resetTimer(true);
 
 		timer.Start(cur);
 		timer.Trigger();
@@ -98,8 +98,16 @@ Spawn2::~Spawn2()
 {
 }
 
-uint32 Spawn2::resetTimer()
+uint32 Spawn2::resetTimer(bool quake_repop)
 {
+	// Guild 1 raid targets are repopped by the quake system. Keep defeated
+	// targets dormant between quakes while preserving normal guild-instance
+	// overrides for Guild 2 and above.
+	if (!quake_repop && zone && zone->GetGuildID() == 1 && raid_target_spawnpoint)
+	{
+		return UINT_MAX;
+	}
+
 	uint32 rspawn = respawn_ * 1000;
 
 	if (variance_ != 0) {
@@ -549,7 +557,7 @@ void Spawn2::DeathReset(bool realdeath)
 void Spawn2::QuakeReset()
 {
 	//get our reset based on variance etc and store it locally
-	uint32 cur = resetTimer();
+	uint32 cur = resetTimer(true);
 	//set our timer to our reset local
 	timer.Start(cur);
 

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -81,7 +81,7 @@ protected:
 private:
 	uint32	spawn2_id;
 	uint32	respawn_;
-	uint32	resetTimer();
+	uint32	resetTimer(bool quake_repop = false);
 	uint32	despawnTimer(uint32 despawn_timer);
 
 	uint32	spawngroup_id_;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -53,6 +53,7 @@
 #include "water_map.h"
 #include "worldserver.h"
 #include "zone.h"
+#include "data_bucket.h"
 #include "zone_config.h"
 #include "zone_reload.h"
 #include "../common/repositories/criteria/content_filter_criteria.h"
@@ -1946,6 +1947,31 @@ void Zone::RepopClose(const glm::vec4& client_position, uint32 repop_distance)
 		Log(Logs::General, Logs::None, "Error in Zone::Repop: database.PopulateZoneSpawnList failed");
 
 	entity_list.UpdateAllTraps(true, true);
+}
+
+bool Zone::GuildOneTimedRaidSpawnsEnabled()
+{
+	if (GetGuildID() != 1) {
+		return false;
+	}
+
+	const uint32 now = Timer::GetTimeSeconds();
+	if (guild_one_raid_tier_refresh == 0 || now >= guild_one_raid_tier_refresh) {
+		const auto tier = Strings::ToLower(DataBucket::GetData("pvpzone_raid_spawn_tier"));
+		if (tier == "pop") {
+			guild_one_raid_tier = static_cast<int>(Expansion::ExpansionNumber::ThePlanesOfPower);
+		} else if (tier == "luclin") {
+			guild_one_raid_tier = static_cast<int>(Expansion::ExpansionNumber::TheShadowsOfLuclin);
+		} else {
+			guild_one_raid_tier = -1;
+		}
+		guild_one_raid_tier_refresh = now + 5;
+	}
+
+	const int zone_expansion = static_cast<int>(GetZoneExpansion());
+	return guild_one_raid_tier >= 0
+		&& zone_expansion >= static_cast<int>(Expansion::ExpansionNumber::Classic)
+		&& zone_expansion <= guild_one_raid_tier;
 }
 
 bool Zone::ResetEngageNotificationTargets(uint32 in_respawn_timer, bool update_respawn_in_db)

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -313,6 +313,9 @@ public:
 	bool	IsWaterZone(float z);
 	bool	ZoneWillNotIdle() { return newzone_data.never_idle; };
 	bool	IsIdling() { return (idle || (numclients <= 0 && ZoneWillNotIdle())); };
+	bool	GuildOneTimedRaidSpawnsEnabled();
+	int guild_one_raid_tier = -1;
+	uint32 guild_one_raid_tier_refresh = 0;
 	inline	bool BuffTimersSuspended() const { return newzone_data.SuspendBuffs != 0; };
 
 	std::vector<GridRepository::Grid> grids;


### PR DESCRIPTION
What changed

- Raid bosses designated for Guild 1 stay dead after they are killed instead of returning on their normal timers.
- An earthquake brings those bosses back.
- Staff can optionally allow normal timed respawns for bosses from Luclin and earlier or from Plane of Power and earlier.
- Restarting or repopping a Guild 1 zone does not bring back a defeated boss while its raid window is closed.
- Open-world zones, Guild 2 and higher instances, and ordinary NPCs keep their existing behavior.

Why

- Guild 1 raid bosses are intended to return through earthquakes unless staff temporarily enables timed raid respawns.
- Later content updates designate additional bosses for this system, so the underlying behavior needs to be added first.

How we tested

- The Server Docker build passed, including the source verification check.
- Confirmed Luclin-and-earlier bosses began using their normal timers when the Luclin option was enabled.
- Confirmed Plane of Power bosses stayed dead when only the Luclin option was enabled.
- Confirmed an earthquake brought eligible Guild 1 raid bosses back.
- Confirmed restarting and repopping zones did not bypass a closed raid window.
- `git diff --check` passed.

Dependencies

- None.

Deployment order

- This must merge before the final PvP controls PR.
- It must also merge before deploying content PRs that designate additional Guild 1 raid bosses.