### PR TITLE
Add temporary per-zone bard kite limits

### DIFF
--- a/utils/sql/git/content/2026_09_03_Bard_Kite_Summon_Direction.sql
+++ b/utils/sql/git/content/2026_09_03_Bard_Kite_Summon_Direction.sql
@@ -1,0 +1,6 @@
+-- Temporary bard kite limits can be used during server or zone congestion
+-- to prevent a single player from monopolizing large numbers of NPCs.
+-- Over-limit NPCs should summon the bard rather than teleport to the bard.
+UPDATE `rule_values`
+SET `rule_value` = 'false'
+WHERE `rule_name` = 'Quarm:BardInstagibReverseSummon';

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -327,6 +327,7 @@ int command_init(void)
 		command_add("revoke", "[charname] [1/0] - Makes charname unable to talk on OOC.", AccountStatus::GMStaff, command_revoke) ||
 		command_add("rewind", "Rewind to the previous location", AccountStatus::Player, command_rewind) ||
 		command_add("rules", "(subcommand) - Manage server rules.", AccountStatus::GMImpossible, command_rules) ||
+		command_add("bardlimit", "Manage per-zone bard kite summon limits.", AccountStatus::GMAdmin, command_bardlimit) ||
 
 		command_add("save", "Force your player or player corpse target to be saved to the database.", AccountStatus::GMLeadAdmin, command_save) ||
 		command_add("scribespell", "[spellid] - Scribe specified spell in your target's spell book.", AccountStatus::GMAreas, command_scribespell) ||
@@ -924,6 +925,7 @@ void command_clearsaylink(Client *c, const Seperator *sep) {
 #include "gm_commands/allowexport.cpp"
 #include "gm_commands/altactivate.cpp"
 #include "gm_commands/appearance.cpp"
+#include "gm_commands/bardlimit.cpp"
 #include "gm_commands/attack.cpp"
 #include "gm_commands/attackentity.cpp"
 #include "gm_commands/ban.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -200,6 +200,7 @@ void command_resetboat(Client* c, const Seperator* sep);
 void command_revoke(Client* c, const Seperator* sep);
 void command_rewind(Client* c, const Seperator* sep);
 void command_rules(Client* c, const Seperator* sep);
+void command_bardlimit(Client* c, const Seperator* sep);
 void command_save(Client* c, const Seperator* sep);
 void command_scribespell(Client* c, const Seperator* sep);
 void command_scribespells(Client* c, const Seperator* sep);

--- a/zone/gm_commands/bardlimit.cpp
+++ b/zone/gm_commands/bardlimit.cpp
@@ -1,0 +1,87 @@
+#include "../client.h"
+#include "../command.h"
+#include "../data_bucket.h"
+
+#include "../../common/strings.h"
+#include "../../common/rulesys.h"
+
+namespace {
+void BardLimitUsage(Client* c)
+{
+	c->Message(Chat::White, "#bardlimit <shortname> <0-15> - Set the allowed mob count (0 disables)");
+	c->Message(Chat::White, "#bardlimit <shortname> status | default");
+	c->Message(Chat::White, "#bardlimit list");
+}
+}
+
+void command_bardlimit(Client* c, const Seperator* sep)
+{
+	if (!c || sep->argnum < 1 || !strcasecmp(sep->arg[1], "help")) {
+		if (c) BardLimitUsage(c);
+		return;
+	}
+
+	if (!strcasecmp(sep->arg[1], "list")) {
+		auto results = database.QueryDatabase(
+			"SELECT SUBSTRING(`key`, 11), value FROM data_buckets "
+			"WHERE LEFT(`key`, 10) = 'bardlimit_' ORDER BY `key`"
+		);
+		if (!results.Success()) {
+			c->Message(Chat::Red, "Unable to list bard limits.");
+			return;
+		}
+		if (results.RowCount() == 0) {
+			c->Message(Chat::White, "No per-zone bard limits are configured. Global default: %d.", RuleI(Quarm, BardInstagibPullLimit));
+			return;
+		}
+		for (auto row : results) {
+			c->Message(Chat::White, "%s: %s", row[0], !strcmp(row[1], "0") ? "disabled" : StringFormat("%s allowed; summons at %d", row[1], atoi(row[1]) + 1).c_str());
+		}
+		return;
+	}
+
+	const auto short_name = Strings::ToLower(sep->arg[1]);
+	if (database.GetZoneID(short_name.c_str()) == 0) {
+		c->Message(Chat::Red, "Unknown zone short name: %s", short_name.c_str());
+		return;
+	}
+	const auto key = "bardlimit_" + short_name;
+	if (sep->argnum != 2) {
+		BardLimitUsage(c);
+		return;
+	}
+
+	if (!strcasecmp(sep->arg[2], "status")) {
+		const auto value = DataBucket::GetData(key);
+		if (value.empty()) {
+			c->Message(Chat::White, "%s uses the global bard limit: %d allowed; summons at %d.", short_name.c_str(), RuleI(Quarm, BardInstagibPullLimit), RuleI(Quarm, BardInstagibPullLimit) + 1);
+		} else if (value == "0") {
+			c->Message(Chat::White, "%s bard limit is disabled.", short_name.c_str());
+		} else {
+			const int limit = Strings::ToInt(value);
+			c->Message(Chat::White, "%s allows %d mobs; summoning starts at %d.", short_name.c_str(), limit, limit + 1);
+		}
+		return;
+	}
+
+	if (!strcasecmp(sep->arg[2], "default")) {
+		if (DataBucket::DeleteData(key)) {
+			c->Message(Chat::Yellow, "%s now uses the global bard limit of %d.", short_name.c_str(), RuleI(Quarm, BardInstagibPullLimit));
+		} else {
+			c->Message(Chat::Red, "Unable to clear the bard limit for %s.", short_name.c_str());
+		}
+		return;
+	}
+
+	if (!Strings::IsNumber(sep->arg[2])) {
+		BardLimitUsage(c);
+		return;
+	}
+	const int limit = Strings::ToInt(sep->arg[2]);
+	if (limit < 0 || limit > 15) {
+		c->Message(Chat::Red, "Bard limit must be between 0 and 15.");
+		return;
+	}
+	DataBucket::SetData(key, std::to_string(limit));
+	c->Message(Chat::Yellow, limit == 0 ? "%s bard limit disabled." : "%s now allows %d mobs; summoning starts at %d.", short_name.c_str(), limit, limit + 1);
+}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -30,6 +30,7 @@
 #include <limits.h>
 #include <math.h>
 #include <sstream>
+#include <chrono>
 #include "map.h"
 
 extern EntityList entity_list;
@@ -2103,7 +2104,24 @@ bool Mob::CheckBardHateSummon(Mob* summoned) {
 	if(GetHPRatio() >= RuleR(Quarm, BardInstagibHPRatio))
 		return false;
 
-	if (entity_list.GetTopHateCount(summoned) < RuleI(Quarm, BardInstagibPullLimit))
+	static std::string cached_zone;
+	static int configured_limit = RuleI(Quarm, BardInstagibPullLimit);
+	static auto refresh_at = std::chrono::steady_clock::time_point{};
+	const auto now = std::chrono::steady_clock::now();
+	const auto zone_name = Strings::ToLower(zone->GetShortName());
+	if (zone_name != cached_zone || now >= refresh_at) {
+		cached_zone = zone_name;
+		const auto value = DataBucket::GetData("bardlimit_" + zone_name);
+		configured_limit = value.empty() ? RuleI(Quarm, BardInstagibPullLimit) : Strings::ToInt(value);
+		if (configured_limit < 0 || configured_limit > 15) {
+			configured_limit = RuleI(Quarm, BardInstagibPullLimit);
+		}
+		refresh_at = now + std::chrono::seconds(5);
+	}
+
+	// Zero disables this summon behavior for the zone. Otherwise, the value
+	// is the number of mobs allowed; summoning starts with limit + 1.
+	if (configured_limit == 0 || entity_list.GetTopHateCount(summoned) <= configured_limit)
 		return false;
 
 	// now validate the timer


### PR DESCRIPTION
Summary
- Adds a temporary per-zone bard kite limit controlled by staff.
- Adds the associated summon-direction rule migration.

Why
- This gives staff a targeted way to limit oversized bard pulls in specific zones without changing behavior globally.

Behavior
- `#bardlimit <shortname> <0-15>` sets the limit for a zone.
- A value of zero disables the limit.
- When a bard exceeds the configured limit, mobs beyond the limit summon that bard.
- Zones without a configured limit retain their existing behavior.

Validation
- Server Docker build passed.
- Command enable, disable, and over-limit summon behavior were tested.
- git diff --check passed.

Deployment dependency
- None.