### PR TITLE
Show NPC hate lists containing a targeted player

### DIFF
--- a/zone/gm_commands/show/hatelist.cpp
+++ b/zone/gm_commands/show/hatelist.cpp
@@ -2,12 +2,42 @@
 
 void ShowHateList(Client* c, const Seperator* sep)
 {
-	if (!c->GetTarget() || !c->GetTarget()->IsNPC()) {
-		c->Message(Chat::White, "You must target an NPC to use this command.");
+	if (!c->GetTarget()) {
+		c->Message(Chat::White, "You must target an NPC or player to use this command.");
 		return;
 	}
 
 	const auto t = c->GetTarget();
+	if (t->IsNPC()) {
+		t->PrintHateListToClient(c);
+		return;
+	}
 
-	t->PrintHateListToClient(c);
+	if (!t->IsClient()) {
+		c->Message(Chat::White, "You must target an NPC or player to use this command.");
+		return;
+	}
+
+	uint32 count = 0;
+	for (const auto &[entity_id, npc] : entity_list.GetNPCList()) {
+		if (!npc || !npc->IsOnHatelist(t)) {
+			continue;
+		}
+
+		c->Message(
+			Chat::White,
+			"%s (Entity ID: %u, NPC Type ID: %u)",
+			npc->GetCleanName(),
+			entity_id,
+			npc->GetNPCTypeID()
+		);
+		count++;
+	}
+
+	if (count == 0) {
+		c->Message(Chat::White, "%s is not on any NPC hate lists in this zone.", t->GetCleanName());
+	}
+	else {
+		c->Message(Chat::White, "%u NPC%s currently have %s on their hate list.", count, count == 1 ? "" : "s", t->GetCleanName());
+	}
 }


### PR DESCRIPTION
Summary
- Extends `#show hatelist` to support a targeted player.
- Lists NPCs that currently have that player on their hate lists.

Why
- Staff need a direct way to diagnose lingering aggro, leash failures, and encounters that have not properly reset.

Behavior
- When an NPC is targeted, the existing NPC hate-list behavior remains available.
- When a player is targeted, the command finds NPCs currently holding hate for that player.
- Results include enough NPC information for staff to identify the affected encounter.

Validation
- Server Docker build passed.
- Player-targeted NPC hate-list reporting was confirmed in gameplay.
- Existing command behavior was retained.
- git diff --check passed.

Deployment dependency
- None.