### PR TITLE
Fix spawn status filtering and timer reporting

### DIFF
--- a/zone/gm_commands/show/spawn_status.cpp
+++ b/zone/gm_commands/show/spawn_status.cpp
@@ -2,16 +2,31 @@
 
 void ShowSpawnStatus(Client* c, const Seperator* sep)
 {
-	if (sep->IsNumber(1))
+	// command_show passes the full command: #show spawn_status [filter].
+	if (!sep->arg[2][0])
+	{
+		zone->SpawnStatus(c, 'u');
+	}
+	else if (sep->IsNumber(2) && atoi(sep->arg[2]) > 0)
 	{
 		// show spawn status by spawn2 id
-		zone->SpawnStatus(c, 'a', atoi(sep->arg[1]));
+		zone->SpawnStatus(c, 'a', atoi(sep->arg[2]));
 	}
-	else if (strcmp(sep->arg[1], "help") == 0)
+	else if (Strings::EqualFold(sep->arg[2], "help"))
 	{
-		c->Message(Chat::White, "Usage: #spawnstatus <[a]ll (default) | [u]nspawned | [s]pawned | [d]isabled | [e]nabled | {Spawn2 ID}>");
+		c->Message(Chat::White, "Usage: #show spawn_status <[u]nspawned (default) | [a]ll | [s]pawned | [d]isabled | [e]nabled | {Spawn2 ID}>");
 	}
 	else {
-		zone->SpawnStatus(c, sep->arg[1][0]);
+		const std::string filter = Strings::ToLower(sep->arg[2]);
+		if (filter == "all" || filter == "a" ||
+			filter == "unspawned" || filter == "u" ||
+			filter == "spawned" || filter == "s" ||
+			filter == "disabled" || filter == "d" ||
+			filter == "enabled" || filter == "e") {
+			zone->SpawnStatus(c, filter[0]);
+		}
+		else {
+			c->Message(Chat::White, "Unknown spawn filter. Use #show spawn_status help.");
+		}
 	}
 }

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2365,20 +2365,37 @@ void Zone::SpawnStatus(Mob* client, char filter, uint32 spawnid)
 			continue;
 		}
 
+		std::string display_name = npc ? npc->GetCleanName() : "(unspawned - name unavailable)";
+		if (!npc && iterator.GetData()->CurrentNPCID() != 0) {
+			const auto npc_type = npctable.find(iterator.GetData()->CurrentNPCID());
+			if (npc_type != npctable.end() && npc_type->second) {
+				char clean_name[sizeof(npc_type->second->name)] = {};
+				CleanMobName(npc_type->second->name, clean_name);
+				display_name = clean_name;
+			}
+		}
+
 		remaining = iterator.GetData()->timer.GetRemainingTime();
 		if (remaining == 0xFFFFFFFF)
 		{
-			remaining = 0;
-			sec = -1;
+			client->Message(Chat::White, "  %d: %s%s - NPC Type ID: %u - X:%1.1f, Y:%1.1f, Z:%1.1f - No active respawn timer",
+				iterator.GetData()->GetID(),
+				!iterator.GetData()->Enabled() ? "(disabled) " : "", display_name.c_str(),
+				iterator.GetData()->CurrentNPCID(),
+				iterator.GetData()->GetX(), iterator.GetData()->GetY(), iterator.GetData()->GetZ());
+
+			x++;
+			iterator.Advance();
+			continue;
 		}
-		else
-			sec = (remaining / 1000) % 60;
+
+		sec = (remaining / 1000) % 60;
 
 		remaining /= 1000;
 
 		client->Message(Chat::White, "  %d: %s%s - NPC Type ID: %u - X:%1.1f, Y:%1.1f, Z:%1.1f - Spawn Timer: %u hrs %u mins %i sec",
 			iterator.GetData()->GetID(),
-			!iterator.GetData()->Enabled() ? "(disabled) " : "", npc ? npc->GetCleanName() : "(unspawned)",
+			!iterator.GetData()->Enabled() ? "(disabled) " : "", display_name.c_str(),
 			iterator.GetData()->CurrentNPCID(),
 			iterator.GetData()->GetX(), iterator.GetData()->GetY(), iterator.GetData()->GetZ(), 
 			remaining / (60 * 60), (remaining / 60) % 60, sec);


### PR DESCRIPTION
Summary
- Corrects spawn-status filtering and reporting.
- Provides useful information for unspawned entries whose NPC name is unavailable.

Why
- Dormant scripted or gated spawnpoints were being presented like active respawn timers.
- Filtering could omit the spawnpoint staff were attempting to inspect.

Behavior
- Correctly filters spawn-status results by the requested spawn identifier.
- Displays the NPC name when it can be resolved.
- Uses a clear fallback when no NPC name is currently available.
- Distinguishes an active countdown from a spawnpoint with no active respawn timer.
- Keeps the command available through `#show spawn_status`.

Validation
- Server Docker build passed.
- Active timers, zero timers, dormant spawns, and missing-name entries were confirmed in gameplay.
- Spawn-ID filtering returned the requested entries correctly.
- git diff --check passed.

Deployment dependency
- None.