### PR TITLE
Prevent NPCs equipping player-handed utility items

### DIFF
--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -290,6 +290,21 @@ void NPC::AddLootDrop(
 		return;
 	}
 
+	// Player hand-ins request an immediate wear change. Bows and utility items should
+	// remain in NPC inventory without entering equipment or sending a bogus
+	// weapon-slot appearance packet. Native database equipment does not use
+	// this wear-change path and remains unaffected.
+	const bool is_utility_torch =
+		item2->ItemType == EQ::item::ItemTypeLight ||
+		(item2->ItemType == EQ::item::ItemTypeMisc && item2->Damage == 0 &&
+			!strcasecmp(item2->IDFile, "IT36"));
+	if (wearchange && (is_utility_torch ||
+		item2->ItemType == EQ::item::ItemTypeFishingPole ||
+		item2->ItemType == EQ::item::ItemTypeBow)) {
+		equipit = false;
+		wearchange = false;
+	}
+
 	auto item = new LootItem;
 
 	if (LogSys.log_settings[Logs::Loot].is_category_enabled == 1) {


### PR DESCRIPTION
Summary
- Prevents NPCs from equipping player-handed bows, light sources, torch-model utility items, and fishing poles.

Why
- These utility items can occupy weapon slots and create misleading weapon appearances or combat behavior when handed to NPCs.

Behavior
- Affected player-handed items remain in NPC inventory without entering an equipment slot.
- No false weapon appearance update is sent.
- Normal one-handed and two-handed weapons, shields, instruments, and armor continue to equip normally.
- Native database equipment and loot remain unchanged.

Validation
- Server Docker build passed.
- Bows, torches, fishing poles, normal weapons, shields, instruments, armor, and native NPC loadouts were tested.
- Dual-wield and two-handed equipment behavior remained intact.
- git diff --check passed.

Deployment dependency
- None.