### PR TITLE
Set minimum levels for Plane of Power zones

### DIFF
--- a/utils/sql/git/content/2026_09_03_Planes_Of_Power_Minimum_Level.sql
+++ b/utils/sql/git/content/2026_09_03_Planes_Of_Power_Minimum_Level.sql
@@ -1,0 +1,8 @@
+-- Require level 46 for Planes of Power gameplay zones.
+-- Plane of Knowledge remains available as the public hub, while existing
+-- requirements above level 46 (Plane of Time) are preserved.
+UPDATE `zone`
+SET `min_level` = 46
+WHERE `zoneidnumber` BETWEEN 200 AND 223
+  AND `zoneidnumber` <> 202
+  AND `min_level` < 46;


### PR DESCRIPTION
Summary
- Sets the minimum level for Plane of Power gameplay zones to 46.
- Leaves public hub access unchanged.

Why
- Plane of Power combat and progression zones need a consistent minimum-level requirement.

Behavior
- Gameplay Plane of Power zones receive a minimum level of 46.
- Plane of Knowledge remains publicly accessible.
- Zones already requiring a level above 46 are not lowered.
- The change is provided as a content SQL migration.

Validation
- The affected zone list and resulting minimum levels were reviewed.
- Existing higher minimum-level requirements remain intact.
- git diff --check passed.

Deployment dependency
- Apply the included content SQL migration.