### PR TITLE
Update Bastion Agnarr gating, lockouts, and key loot

### DIFF
--- a/utils/sql/git/content/2026_08_22_Bastion_of_Thunder_Agnarr_Instance_Only.sql
+++ b/utils/sql/git/content/2026_08_22_Bastion_of_Thunder_Agnarr_Instance_Only.sql
@@ -1,0 +1,47 @@
+-- Keep the complete Agnarr tower event out of open-world Bastion of Thunder.
+-- Scripted lieutenants, temporary adds, later Askr incarnations, and Karana
+-- have no independent spawn points and can only be created by this event.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `id` IN (
+    -- Tower entrance
+    360600, -- Askr the Lost
+
+    -- First level: Evynd Firestorm
+    360330, -- storm guardian
+    360331, -- storm guardian
+    360332, -- storm guardian
+    360333, -- firestorm portal
+    360334, -- firestorm portal
+    360335, -- firestorm portal
+    360414, -- firestorm elemental
+    360517, -- firestorm elemental
+    360602, -- Evynd Firestorm
+
+    -- Second level: Emmerik Skyfury
+    360313, -- celestial portal
+    360322, -- storm guardian
+    360323, -- storm guardian
+    360324, -- storm guardian
+    360326, -- celestial portal
+    360327, -- celestial portal
+    360601, -- Emmerik Skyfury
+
+    -- Third level: Agnarr the Storm Lord
+    360317, -- untargetable storm portal
+    360318, -- storm portal
+    360319, -- storm portal
+    360320, -- storm portal
+    360321, -- storm portal
+    360265, -- Agnarr the Storm Lord
+
+    -- Post-event Karana controllers
+    360277, -- event timer
+    360611  -- Karana trigger
+);
+
+-- Classify the four Lua-spawned lieutenants as raid loot without giving that status
+-- to portals, guardians, or temporary trash.
+UPDATE `npc_types`
+SET `raid_target` = 1
+WHERE `id` IN (209142, 209146, 209147, 209148);

--- a/utils/sql/git/content/2026_08_30_BoT_Agnarr_Progression_Lockouts.sql
+++ b/utils/sql/git/content/2026_08_30_BoT_Agnarr_Progression_Lockouts.sql
@@ -1,0 +1,4 @@
+-- Apply a 2-day, 18-hour raid lockout to the Bastion of Thunder progression bosses.
+UPDATE `npc_types`
+SET `loot_lockout` = 237600
+WHERE `id` IN (209054, 209053, 209026);

--- a/utils/sql/git/content/2026_08_30_BoT_Progression_Loot.sql
+++ b/utils/sql/git/content/2026_08_30_BoT_Progression_Loot.sql
@@ -1,0 +1,29 @@
+-- Award Bastion of Thunder key progression loot through Lua so loot modifiers
+-- cannot duplicate key components.
+DELETE FROM `loottable_entries`
+WHERE `lootdrop_id` IN (
+    115507, -- Sandstorm Gem
+    22963,  -- Lightning Gem
+    23008,  -- Blizzard Gem
+    22970,  -- Tornado Gem
+    22965,  -- Sandstorm Sphere
+    22961,  -- Lightning Sphere
+    22968,  -- Blizzard Sphere
+    22969,  -- Tornado Sphere
+    22768,  -- Ring of Torden
+    22767   -- Unadorned Symbol of Torden
+);
+
+DELETE FROM `lootdrop_entries`
+WHERE `lootdrop_id` IN (
+    115507, 22963, 23008, 22970,
+    22965, 22961, 22968, 22969,
+    22768, 22767
+);
+
+DELETE FROM `lootdrop`
+WHERE `id` IN (
+    115507, 22963, 23008, 22970,
+    22965, 22961, 22968, 22969,
+    22768, 22767
+);

--- a/utils/sql/git/content/2026_08_30_BoT_Remove_Old_PvP_Teleporter.sql
+++ b/utils/sql/git/content/2026_08_30_BoT_Remove_Old_PvP_Teleporter.sql
@@ -1,0 +1,5 @@
+-- Remove the obsolete PvP event teleporter/book from Bastion of Thunder.
+DELETE FROM `doors`
+WHERE `id` = 50964
+  AND `zone` = "bothunder"
+  AND `dest_zone` = "ecommons";


### PR DESCRIPTION
Summary
- Keeps the complete Agnarr tower event out of open-world Bastion of Thunder.
- Adds 66-hour lockouts to the three progression bosses.
- Removes database key-component drops that are replaced by the paired Quest PR.
- Removes the obsolete Bastion-to-East Commons PvP teleporter.

Why
- The entrance, tower levels, Agnarr, and post-event Karana controllers must follow the same Guild 1 raid-window state.
- Key components should be awarded once through Lua instead of being duplicated by loot modifiers.
- The old PvP teleporter is no longer used.

Behavior
- Marks the Askr entrance, all three tower levels, Agnarr, and the post-event Karana controllers as raid spawnpoints.
- Marks only the four Lua-spawned tower lieutenants as raid-loot NPCs.
- Sets a 237,600-second lockout on Agnarr, Karana, and Askr the Lost.
- Removes the database drops for the four gems, four spheres, Ring of Torden, and Unadorned Symbol of Torden.
- Removes door 50964, the obsolete Bastion portal to East Commons.
- Does not classify temporary portals, guardians, or tower trash as raid-loot NPCs.

Validation
- All affected spawnpoint, NPC, lootdrop, and door IDs were reviewed.
- The 237,600-second lockout equals 2 days and 18 hours.
- Bastion instance and progression behavior were tested in the combined realm.
- git diff --check passed.

Deployment dependency
- Requires EQMacEmu PR #376 for Guild 1 raid-spawnpoint behavior.
- Deploy with the matching `quest/bothunder-progression` PR in the same release because that Quest PR supplies the removed progression drops.