### PR TITLE
Set Bertox event trash respawn override

### DIFF
--- a/utils/sql/git/content/2026_08_21_CodeCay_Bertox_Respawn.sql
+++ b/utils/sql/git/content/2026_08_21_CodeCay_Bertox_Respawn.sql
@@ -1,0 +1,5 @@
+-- Bertoxxulous event trash must bypass the guild-instance minimum respawn
+-- so the encounter's scripted waves can spawn on the 3-minute-50-second cadence.
+UPDATE `npc_types`
+SET `instance_spawn_timer_override` = 230000
+WHERE `id` IN (200236, 200237, 200238, 200247, 200251, 200268);


### PR DESCRIPTION
Summary
- Adds an instance respawn override for six Bertoxxulous event-trash NPC types.

Why
- The normal guild-instance minimum respawn prevents the scripted waves from following their intended recovery cadence.

Behavior
- Sets `instance_spawn_timer_override` to 230,000 milliseconds for NPC types 200236, 200237, 200238, 200247, 200251, and 200268.
- This allows those NPCs to respawn on the event’s 3-minute-50-second cadence.
- Boss timing and the normal number of event waves are unchanged.

Validation
- The six affected NPC IDs and 230,000 ms timer were reviewed.
- The combined CodeCay event retained its normal wave counts.
- git diff --check passed.

Deployment dependency
- Deploy with the matching `quest/codecay-bertox` recovery-timing PR.