### PR TITLE
Mark Disease and Decay raid spawnpoints

### DIFF
--- a/utils/sql/git/content/2026_08_19_Disease_and_Crypt_of_Decay_Raid_Targets.sql
+++ b/utils/sql/git/content/2026_08_19_Disease_and_Crypt_of_Decay_Raid_Targets.sql
@@ -1,0 +1,3 @@
+UPDATE spawn2 SET raid_target_spawnpoint = 1 WHERE id = 344762;
+UPDATE spawn2 SET raid_target_spawnpoint = 1 WHERE id = 360642;
+UPDATE spawn2 SET raid_target_spawnpoint = 1 WHERE id = 360643;


### PR DESCRIPTION
What changed
- Marked spawnpoints 344762, 360642, and 360643 in Plane of Disease and Crypt of Decay as raid targets.
- This keeps those encounters out of normal open-world spawning and places them under the Guild 1 raid-window rules.

Why
- These bosses should be available through their intended instance or Guild 1 raid window, not on the normal open-world spawn cycle.

How we tested
- Confirmed the migration changes only the three intended spawnpoints.
- Reviewed the resulting raid-target classifications in the combined test database.
- Ran git diff --check successfully.

This depends on EQMacEmu PR #376