### PR TITLE
Suppress The Seventh Hammer in open world

### DIFF
--- a/utils/sql/git/content/2026_08_21_Plane_of_Justice_Seventh_Hammer.sql
+++ b/utils/sql/git/content/2026_08_21_Plane_of_Justice_Seventh_Hammer.sql
@@ -1,0 +1,4 @@
+-- Keep The Seventh Hammer out of the open-world Plane of Justice while
+-- preserving the encounter in guild instances, with a 2.5-day loot lockout.
+UPDATE npc_types SET loot_lockout = 216000 WHERE id = 201074;
+UPDATE spawn2 SET raid_target_spawnpoint = 1 WHERE id = 345320;


### PR DESCRIPTION
What changed
- Marked The Seventh Hammer spawnpoint 345320 as a raid target.
- Added a 216,000-second, or 2.5-day, loot lockout to NPC type 201074.

Why
- The Seventh Hammer should not spawn in the open-world Plane of Justice.
- The encounter should remain available through its intended guild raid window with a defined loot lockout.

How we tested
- Confirmed the migration changes only the intended NPC and spawnpoint.
- Verified the raid-target and lockout values in the combined test database.
- Ran git diff --check successfully.

Requires EQMacEmu PR #376 for the Guild 1 raid-spawnpoint behavior.