### PR TITLE
Keep Terris Thule out of open-world Nightmare

### DIFF
--- a/utils/sql/git/content/2026_08_21_Plane_of_Nightmare_Terris_Thule.sql
+++ b/utils/sql/git/content/2026_08_21_Plane_of_Nightmare_Terris_Thule.sql
@@ -1,0 +1,1 @@
+UPDATE spawn2 SET raid_target_spawnpoint = 1 WHERE id = 365941;


### PR DESCRIPTION
What changed
- Marked Terris Thule spawnpoint 365941 as a raid target.
- This places her under the guild raid-window spawning rules.

Why
- Terris Thule should be fought through the intended guild raid access rather than spawning normally in open-world Plane of Nightmare.

How we tested
- Confirmed the migration changes only Terris Thule’s spawnpoint.
- Tested the Terris Thule encounter in the intended guild instance.
- Ran git diff --check successfully.

Requires EQMacEmu PR #376 for the Guild 1 raid-spawnpoint behavior.