### PR TITLE
Gate the Behemoth event and protect Innovation Giwin

### DIFF
--- a/utils/sql/git/content/2026_08_22_Plane_of_Innovation_Behemoth_Instance_Only.sql
+++ b/utils/sql/git/content/2026_08_22_Plane_of_Innovation_Behemoth_Instance_Only.sql
@@ -1,0 +1,9 @@
+-- Keep the scripted Manaetic Behemoth/Nitram event out of open-world
+-- Plane of Innovation. These static controllers remain available in raids.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `id` IN (
+    345224, -- Weapon_Event_Master
+    345273, -- Manaetic Behemoth
+    345275  -- Nitram Anizok
+);

--- a/utils/sql/git/content/2026_09_02_Protect_Innovation_Giwin.sql
+++ b/utils/sql/git/content/2026_09_02_Protect_Innovation_Giwin.sql
@@ -1,0 +1,33 @@
+-- Protect both Plane of Innovation versions of Giwin Mirakon.
+-- Preserve existing abilities, including #Giwin's corpse-camper flag.
+-- The Plane of Tactics version (214014) is deliberately unchanged.
+
+-- Melee immunity.
+UPDATE `npc_types`
+SET `special_abilities` = CONCAT_WS('^', NULLIF(`special_abilities`, ''), '19,1')
+WHERE `id` IN (206038, 206203)
+  AND CONCAT('^', COALESCE(`special_abilities`, '')) NOT LIKE '%^19,%';
+
+-- Magic immunity.
+UPDATE `npc_types`
+SET `special_abilities` = CONCAT_WS('^', NULLIF(`special_abilities`, ''), '20,1')
+WHERE `id` IN (206038, 206203)
+  AND CONCAT('^', COALESCE(`special_abilities`, '')) NOT LIKE '%^20,%';
+
+-- Does not initiate aggro.
+UPDATE `npc_types`
+SET `special_abilities` = CONCAT_WS('^', NULLIF(`special_abilities`, ''), '24,1')
+WHERE `id` IN (206038, 206203)
+  AND CONCAT('^', COALESCE(`special_abilities`, '')) NOT LIKE '%^24,%';
+
+-- Cannot be aggroed by nearby NPCs.
+UPDATE `npc_types`
+SET `special_abilities` = CONCAT_WS('^', NULLIF(`special_abilities`, ''), '25,1')
+WHERE `id` IN (206038, 206203)
+  AND CONCAT('^', COALESCE(`special_abilities`, '')) NOT LIKE '%^25,%';
+
+-- Immune to harm from players.
+UPDATE `npc_types`
+SET `special_abilities` = CONCAT_WS('^', NULLIF(`special_abilities`, ''), '35,1')
+WHERE `id` IN (206038, 206203)
+  AND CONCAT('^', COALESCE(`special_abilities`, '')) NOT LIKE '%^35,%';


### PR DESCRIPTION
What changed
- Marked the Weapon Event Master, Manaetic Behemoth, and Nitram Anizok spawnpoints as raid targets.
- Added melee, magic, aggro, NPC-aggro, and player-harm protection to both Plane of Innovation versions of Giwin Mirakon.
- Preserved Giwin’s existing special abilities.
- Left the Plane of Tactics Giwin unchanged.

Why
- The Behemoth and Nitram event should not run in open-world Plane of Innovation.
- Giwin is an event and progression NPC and should not be killed or pulled into combat.

How we tested
- Confirmed the migration changes only the three intended spawnpoints and two Innovation Giwin NPC types.
- Confirmed the existing special abilities are preserved instead of overwritten.
- Tested the Behemoth and Nitram event in the combined realm.
- Ran git diff --check successfully.

Requires EQMacEmu PR #376 for the Guild 1 raid-spawnpoint behavior.