### PR TITLE
Gate Aerin`Dar and ease Valor globe bottlenecks

### DIFF
--- a/utils/sql/git/content/2026_08_22_Plane_of_Valor_Aerin_Dar_Instance_Only.sql
+++ b/utils/sql/git/content/2026_08_22_Plane_of_Valor_Aerin_Dar_Instance_Only.sql
@@ -1,0 +1,5 @@
+-- Keep Aerin`Dar out of open-world Plane of Valor while preserving the
+-- encounter in raid instances.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `id` = 347257;

--- a/utils/sql/git/content/2026_09_03_Valor_Luminii_Crawler_Spawn_Chance.sql
+++ b/utils/sql/git/content/2026_09_03_Valor_Luminii_Crawler_Spawn_Chance.sql
@@ -1,0 +1,10 @@
+-- Modestly improve access to crystalline globe piece 25798.
+-- Keep the crawler's guaranteed item drop and existing respawn timers unchanged.
+-- Spawn group 208004 is shared by eleven Plane of Valor spawnpoints.
+UPDATE `spawnentry`
+SET `chance` = CASE `npcID`
+    WHEN 208006 THEN 10 -- A Luminii Crawler: previously 5
+    WHEN 208004 THEN 90 -- Common spawn: previously 95
+END
+WHERE `spawngroupID` = 208004
+  AND `npcID` IN (208006, 208004);

--- a/utils/sql/git/content/2026_09_03_Valor_Terrick_Globe_Drop.sql
+++ b/utils/sql/git/content/2026_09_03_Valor_Terrick_Globe_Drop.sql
@@ -1,0 +1,8 @@
+-- Guarantee crystalline globe piece 25797 from Sergeant Terrick Burns.
+-- Lootdrop 22761 contains only this item, already at 100% internally.
+-- Raise its loot-table roll from 15% to 100% for Terrick only.
+-- Leave the Undead Vassal loot table (4989) at its existing 5% chance.
+UPDATE `loottable_entries`
+SET `probability` = 100
+WHERE `loottable_id` = 96945
+  AND `lootdrop_id` = 22761;


### PR DESCRIPTION
What changed
- Marked Aerin`Dar spawnpoint 347257 as a raid target so the encounter does not spawn normally in open world.
- Increased the Luminii Crawler chance from 5% to 10% in its shared spawn group.
- Made Sergeant Terrick Burns’ crystalline globe piece guaranteed instead of a 15% loot-table roll.
- Left existing respawn timers, heart drops, and the Undead Vassal drop chance unchanged.

Why
- Aerin`Dar should follow guild raid access.
- The two crystalline globe pieces were unnecessary bottlenecks in the Valor key progression.

How we tested
- Confirmed the three migrations affect only the intended spawnpoint, spawn group, and Terrick loot entry.
- Confirmed the crawler’s normal guaranteed item and respawn timing are unchanged.
- Confirmed heart drops and the Undead Vassal loot table are not modified.
- Ran git diff --check successfully.

Requires EQMacEmu PR #376 for the Guild 1 raid-spawnpoint behavior.