### PR TITLE
Reduce Plane of Storms miniboss respawn timers

### DIFF
--- a/utils/sql/git/content/2026_08_31_PoStorms_Respawn_Timers.sql
+++ b/utils/sql/git/content/2026_08_31_PoStorms_Respawn_Timers.sql
@@ -1,0 +1,15 @@
+-- Make secondary medallion bosses available every 90 minutes.
+UPDATE `spawn2` AS `s2`
+JOIN `spawnentry` AS `se`
+  ON `se`.`spawngroupID` = `s2`.`spawngroupID`
+SET
+  `s2`.`respawntime` = 5400,
+  `s2`.`variance` = 0
+WHERE `se`.`npcID` IN (
+  210026, -- Laruken the Rigid
+  210027, -- Zertuken the Unyielding
+  210028, -- Paruek the Strong
+  210029, -- Faruek the Bold
+  210032, -- Pendubk the Turbulent
+  210033  -- Solnebk the Unruly
+);


### PR DESCRIPTION
What changed

- Sets Laruken, Zertuken, Paruek, Faruek, Pendubk, and Solnebk to 90-minute open-world respawns.
- Removes variance from those six respawn timers.

Why

- Makes the secondary medallion bosses available more consistently and reduces the open-world progression bottleneck.

How we tested

- Verified the migration targets only the six intended secondary medallion bosses.
- Verified the configured respawn is exactly 5,400 seconds with zero variance.
- `git diff --check` passed.