### PR TITLE
Make Plane of Tactics raid targets instance-only

### DIFF
--- a/utils/sql/git/content/2026_08_30_PoTactics_Instance_Only_Raid_Targets.sql
+++ b/utils/sql/git/content/2026_08_30_PoTactics_Instance_Only_Raid_Targets.sql
@@ -1,0 +1,9 @@
+-- Keep Plane of Tactics raid encounters out of the open world while
+-- preserving their spawnpoints for guild-instance encounter scripts.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `id` IN (
+    361379, -- Rallos Zek encounter trigger
+    361403, -- Tallon Zek
+    369265  -- Vallon Zek
+);


### PR DESCRIPTION
What changed

- Marks the Rallos Zek encounter trigger, Tallon Zek, and Vallon Zek spawnpoints as raid targets.
- Keeps their spawnpoints available for guild-instance encounter handling while suppressing them from normal open-world spawning.

Why

- Keeps the Plane of Tactics raid encounters in the intended guild-instance progression path.

How we tested

- Confirmed the Tactics raid targets appeared in the guild instance during raid-window testing.
- Verified the migration targets only the three intended spawnpoints.
- `git diff --check` passed.

Dependency

- Requires EQMacEmu PR #376 for the intended Guild 1 quake and timed-raid behavior.