### PR TITLE
Apply Plane of Tactics raid lockouts

### DIFF
--- a/utils/sql/git/content/2026_08_31_PoTactics_Raid_Lockouts.sql
+++ b/utils/sql/git/content/2026_08_31_PoTactics_Raid_Lockouts.sql
@@ -1,0 +1,8 @@
+-- Apply a 2-day, 18-hour raid lockout to Plane of Tactics progression bosses.
+UPDATE `npc_types`
+SET `loot_lockout` = 237600
+WHERE `id` IN (
+  214026, -- Tallon Zek
+  214317, -- Vallon Zek final real form
+  214312  -- Rallos Zek the Warlord
+);


### PR DESCRIPTION
What changed

- Applies a 66-hour loot lockout to Tallon Zek, Vallon Zek's final real form (NON-SCRIPTED BROTHERS), and Rallos Zek the Warlord.

Why

- Gives the three Plane of Tactics progression bosses a consistent raid loot lockout.

How we tested

- Verified the migration targets only the three intended NPC types.
- Verified that 237,600 seconds is exactly 66 hours.
- `git diff --check` passed.
- The full 66-hour expiration was not tested in real time.