### PR TITLE
Make Saryrn and Keeper encounters instance-only

### DIFF
--- a/utils/sql/git/content/2026_08_20_Plane_of_Torment_Raid_Encounters.sql
+++ b/utils/sql/git/content/2026_08_20_Plane_of_Torment_Raid_Encounters.sql
@@ -1,0 +1,2 @@
+UPDATE spawn2 SET raid_target_spawnpoint = 1 WHERE id = 346762;
+UPDATE spawn2 SET raid_target_spawnpoint = 1 WHERE id = 346764;


### PR DESCRIPTION
What changed

- Marks the intended Saryrn spawnpoints as raid targets.
- Keeps those encounters out of normal open-world spawning while preserving them for guild-instance handling.

Why

- Places the Plane of Torment raid encounters in the intended guild-instance progression path.

How we tested

- Confirmed the Plane of Torment raid encounters appeared in the tested guild instance.
- Verified the migration changes only the two intended spawnpoints.
- Confirmed no unrelated Avatar spawnpoint change is included.
- `git diff --check` passed.

Dependency

- Requires EQMacEmu PR #376 for the intended Guild 1 quake and timed-raid behavior.