### PR TITLE
Increase Visions of Argan teleport radius

### DIFF
--- a/utils/sql/git/content/2026_08_21_Plane_of_Torment_Argan_Port_Radius.sql
+++ b/utils/sql/git/content/2026_08_21_Plane_of_Torment_Argan_Port_Radius.sql
@@ -1,0 +1,2 @@
+-- Increase the Visions of Argan teleport radius so nearby raid members are not left behind.
+UPDATE spells_new SET aoerange = 250 WHERE id = 1135;


### PR DESCRIPTION
What changed

- Increases the area radius of Visions of Argan to 250.

Why

- Helps prevent nearby raid members from being left behind when the encounter teleports the group.

How we tested

- Verified the migration changes only spell ID 1135.
- Verified the configured area radius is 250.
- `git diff --check` passed.

Dependencies

-None