### PR TITLE
Make Halls of Honor raid mobs instance-only

### DIFF
--- a/utils/sql/git/content/2026_08_22_Halls_of_Honor_Raid_Mobs_Instance_Only.sql
+++ b/utils/sql/git/content/2026_08_22_Halls_of_Honor_Raid_Mobs_Instance_Only.sql
@@ -1,0 +1,14 @@
+-- Keep Halls of Honor raid-event bosses out of the open world.
+-- These spawn points remain available to raid instances.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `id` IN (
+    360971, -- Rhaliq Trell
+    360859, -- Trydan Faye
+    361021, -- Alekson Garn
+    -- Temple of Marr raid
+    365500, -- Lord Mithaniel Marr
+    367163, -- Ralthazor, Champion of Marr
+    367227, -- Edium, Guardian of Marr
+    366604  -- Halon of Marr
+);


### PR DESCRIPTION
What changed

- Marks Rhaliq Trell, Trydan Faye, and Alekson Garn as raid targets.
- Marks Lord Mithaniel Marr, Ralthazor, Edium, and Halon as raid targets.
- Keeps these spawnpoints available for guild-instance handling while suppressing them from normal open-world spawning.

Why

- Places the Halls of Honor raid encounters in the intended guild-instance progression path.

How we tested

- Confirmed Lord Mithaniel Marr, Ralthazor, Edium, and Halon appeared after repopping an eligible guild instance.
- Verified the migration targets only the seven intended raid spawnpoints.
- `git diff --check` passed.

Dependencies

- Requires EQMacEmu PR #376 for the intended Guild 1 quake and timed-raid behavior.