### PR TITLE
Add Mithaniel Marr progression lockout

### DIFF
--- a/utils/sql/git/content/2026_08_31_Mithaniel_Marr_Lockout.sql
+++ b/utils/sql/git/content/2026_08_31_Mithaniel_Marr_Lockout.sql
@@ -1,0 +1,4 @@
+-- Apply the standard 60-hour progression lockout to Lord Mithaniel Marr.
+UPDATE `npc_types`
+SET `loot_lockout` = 216000
+WHERE `id` = 220020;


### PR DESCRIPTION
## What changed

- Applies a 60-hour loot lockout to Lord Mithaniel Marr.

## Why

- Gives Mithaniel Marr the intended progression lockout after a successful kill.
- Prevents the encounter from awarding progression loot more often than intended.

## How we tested

- Verified the migration targets only Lord Mithaniel Marr, NPC type 220020.
- Verified that 216,000 seconds is exactly 60 hours.
- Confirmed Mithaniel Marr and the Temple of Marr encounter NPCs spawned correctly after repopping the eligible guild instance.
- `git diff --check` passed.
- The complete 60-hour expiration was not tested in real time.

## Dependencies

- None.