### PR TITLE
Move Solusek Ro Tower progression into guild instances

### DIFF
--- a/utils/sql/git/content/2026_09_01_Solusek_Ro_Tower_Instance_Progression.sql
+++ b/utils/sql/git/content/2026_09_01_Solusek_Ro_Tower_Instance_Progression.sql
@@ -1,0 +1,50 @@
+-- Keep the Tower of Solusek Ro progression encounters in guild instances.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `id` IN (
+  367544, -- Arlyxir
+  367545, -- Solusek Ro
+  367546, -- Rizlona encounter trigger
+  367547, -- Jiva
+  367548, -- Xuzl
+  367793, -- Guardian of Dresolik
+  367794, -- Guardian of Dresolik
+  367795, -- Guardian of Dresolik
+  367796  -- Guardian of Dresolik
+);
+
+-- Respawn the five tower progression encounters after 1 day and 18 hours in Guild 2+
+-- instances. Guild 1 raid targets are repopped by the quake system.
+UPDATE `npc_types`
+SET `instance_spawn_timer_override` = 151200000
+WHERE `id` IN (
+  212014, -- Jiva
+  212023, -- Arlyxir
+  212026, -- Rizlona encounter trigger
+  212046, -- Guardian of Dresolik encounter trigger
+  212055  -- Xuzl
+);
+
+-- Respawn Solusek Ro after 2 days and 18 hours in Guild 2+ instances.
+UPDATE `npc_types`
+SET `instance_spawn_timer_override` = 237600000
+WHERE `id` = 212025;
+
+-- Apply 1-day, 18-hour loot lockouts to every loot-bearing stage of the five tower
+-- encounters, including the scripted Rizlona and Dresolik follow-up bosses.
+UPDATE `npc_types`
+SET `loot_lockout` = 151200
+WHERE `id` IN (
+  212014, -- Jiva
+  212023, -- Arlyxir
+  212026, -- Rizlona
+  212046, -- Guardian of Dresolik
+  212055, -- Xuzl
+  212407, -- #Rizlona
+  212408  -- The Protector of Dresolik
+);
+
+-- Apply a 2-day, 18-hour loot lockout to Solusek Ro.
+UPDATE `npc_types`
+SET `loot_lockout` = 237600
+WHERE `id` = 212025;


### PR DESCRIPTION
## What changed

- Marks Arlyxir, Solusek Ro, the Rizlona trigger, Jiva, Xuzl, and the four Guardian of Dresolik spawnpoints as raid targets.
- Gives the five tower progression encounters a 42-hour respawn in Guild 2 and higher instances.
- Gives Solusek Ro a 66-hour respawn in Guild 2 and higher instances.
- Applies a 42-hour loot lockout to Jiva, Arlyxir, Rizlona, Guardian of Dresolik, Xuzl, scripted Rizlona, and the Protector of Dresolik.
- Applies a 66-hour loot lockout to Solusek Ro.
- Leaves Guild 1 raid availability under the earthquake and timed-raid system.

## Why

- Keeps Tower of Solusek Ro progression encounters in guild instances.
- Gives each encounter a consistent respawn and loot-lockout schedule.
- Includes the scripted follow-up forms so Rizlona and Dresolik cannot bypass the encounter lockout.

## How we tested

- Verified the migration marks only the nine intended raid spawnpoints.
- Verified the five tower encounters use 151,200,000 milliseconds, which is exactly 42 hours.
- Verified Solusek Ro uses 237,600,000 milliseconds, which is exactly 66 hours.
- Verified the corresponding loot lockouts use 151,200 and 237,600 seconds.
- Verified the loot-lockout list includes the scripted Rizlona and Dresolik follow-up bosses.
- `git diff --check` passed.
- The complete 42-hour and 66-hour expirations were not tested in real time.

## Dependencies

- Requires EQMacEmu PR #376 for Guild 1 earthquake and timed-raid handling.