### PR TITLE
Restrict Plane of Air raid spawnpoints to instances

### DIFF
--- a/utils/sql/git/content/2026_09_02_Plane_Of_Air_Instance_Only.sql
+++ b/utils/sql/git/content/2026_09_02_Plane_Of_Air_Instance_Only.sql
@@ -1,0 +1,15 @@
+-- Keep the confirmed Plane of Air raid targets out of the open world.
+-- Preserve enabled spawnpoints, existing timers, and loot lockouts.
+-- Requires the companion poair/script_init.lua change to block scripted rings.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `zone` = 'poair'
+  AND `id` IN (
+    365638, -- Baltaldor the Cursed
+    367322, -- Gakamenial Fir`Disralsi
+    366074, -- Queen Silandria
+    366212, -- Rinturion Windblade
+    365346, -- Xegony the Queen of Air
+    365750, -- Arch Mage Alchtonion
+    366131  -- Sigismond Windwalker
+  );


### PR DESCRIPTION
## What changed

Marks these seven Plane of Air raid spawnpoints for guild-instance handling:

- Baltaldor the Cursed
- Gakamenial Fir'Disralsi
- Queen Silandria
- Rinturion Windblade
- Xegony the Queen of Air
- Arch Mage Alchtonion
- Sigismond Windwalker

The migration leaves the spawnpoints enabled and preserves their existing respawn timers and loot lockouts.

## Why

- Keeps the confirmed static Plane of Air raid targets out of normal open-world spawning.
- Preserves the existing encounter timing and loot behavior inside guild instances.
- Works with the matching Quest change that applies the same raid-window rules to scripted ring encounters.

## How we tested

- Verified the migration is restricted to the `poair` zone.
- Verified it targets only the seven intended static raid spawnpoints.
- Verified it changes only the raid-target marker and does not alter enabled state, respawn time, variance, or loot lockouts.
- `git diff --check` passed.

## Dependencies

- Requires EQMacEmu PR #376 for Guild 1 earthquake-based raid handling.
- EQMacEmu PR #402 is required for optional `#pvpzone` timed raid windows.
- Requires the matching `quest/poair-progression` PR for complete handling of the scripted Plane of Air ring encounters.