### PR TITLE
Move Plane of Earth raids into guild instances

### DIFF
--- a/utils/sql/git/content/2026_09_03_Plane_Of_Earth_Instance_Progression.sql
+++ b/utils/sql/git/content/2026_09_03_Plane_Of_Earth_Instance_Progression.sql
@@ -1,0 +1,71 @@
+-- Keep Plane of Earth raid encounters out of the open world while preserving
+-- the ordinary Earth A ring mobs. Ring scripts remain instance-only.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1
+WHERE `id` IN (
+    366256, -- Tantisala Jaggedtooth
+    369376, -- Rathe Councilman
+    369377, -- Rathe Councilman
+    369378, -- Rathe Councilman
+    369379, -- Rathe Councilman
+    369380, -- Rathe Councilman
+    369381, -- Rathe Councilman
+    369382, -- Rathe Councilman
+    369383, -- Rathe Councilman
+    369384, -- Rathe Councilman
+    369385, -- Rathe Councilman
+    369386, -- Rathe Councilman
+    369387, -- Rathe Councilman
+    369493, -- War Chieftan Birak
+    369494, -- War Chieftan Galronar
+    369492, -- War Chieftan Awisano
+    369491  -- Warlord Gintolaken
+);
+
+-- Two days, eighteen hours for the static bosses, four Earth A ring bosses,
+-- and the Rathe Council's Avatar of Earth.
+UPDATE `npc_types`
+SET `loot_lockout` = 237600,
+    `instance_spawn_timer_override` = 237600000
+WHERE `id` IN (
+    218038, -- Tantisala Jaggedtooth
+    218374, -- Peregrin Rockskull (Stone)
+    218360, -- A Monsterous Mudwalker (Mud)
+    218363, -- Derugoak Bloodwalker (Vine)
+    218413, -- A Perfected Warder of Earth (Dust)
+    222035, -- War Chieftan Birak
+    222036, -- War Chieftan Galronar
+    222037, -- War Chieftan Awisano
+    222038, -- Warlord Gintolaken
+    222040  -- Avatar of Earth / Rathe Council
+);
+
+UPDATE `spawn2`
+SET `respawntime` = 237600,
+    `variance` = 0
+WHERE `id` IN (366256, 369493, 369494, 369492, 369491);
+
+-- Give War Drums of the Rathe two independent 10% rolls, matching the
+-- Lute of the Flowing Waters model without affecting Peregrin's other loot.
+DELETE FROM `lootdrop_entries`
+WHERE `lootdrop_id` = 8559
+  AND `item_id` = 27998;
+
+INSERT INTO `lootdrop_entries`
+    (`lootdrop_id`, `item_id`, `item_charges`, `equip_item`, `chance`, `minlevel`, `maxlevel`, `multiplier`, `disabled_chance`, `expansion`, `min_expansion`, `max_expansion`, `min_looter_level`, `item_loot_lockout_timer`, `content_flags_disabled`, `content_flags`)
+VALUES
+    (218374, 27998, 1, 0, 100, 0, 255, 1, 0, 0, -1, -1, 0, 0, NULL, NULL)
+ON DUPLICATE KEY UPDATE
+    `chance` = VALUES(`chance`),
+    `multiplier` = VALUES(`multiplier`);
+
+INSERT INTO `loottable_entries`
+    (`loottable_id`, `lootdrop_id`, `multiplier`, `probability`, `droplimit`, `mindrop`, `multiplier_min`)
+VALUES
+    (4478, 218374, 2, 10, 0, 0, 0)
+ON DUPLICATE KEY UPDATE
+    `multiplier` = VALUES(`multiplier`),
+    `probability` = VALUES(`probability`),
+    `droplimit` = VALUES(`droplimit`),
+    `mindrop` = VALUES(`mindrop`),
+    `multiplier_min` = VALUES(`multiplier_min`);


### PR DESCRIPTION
## What changed

- Marks 17 Plane of Earth raid spawnpoints for guild-instance handling:
  - Tantisala Jaggedtooth
  - Twelve Rathe Councilmen
  - War Chieftan Birak
  - War Chieftan Galronar
  - War Chieftan Awisano
  - Warlord Gintolaken
- Preserves the ordinary Earth A ring mobs outside the scripted raid encounters.
- Applies 66-hour loot lockouts and Guild 2+ instance respawns to:
  - Tantisala Jaggedtooth
  - Peregrin Rockskull
  - A Monsterous Mudwalker
  - Derugoak Bloodwalker
  - A Perfected Warder of Earth
  - The four Earth B war leaders
  - Avatar of Earth
- Sets the static Tantisala and Earth B war-leader spawnpoints to 66-hour respawns with no variance.
- Gives War Drums of the Rathe two independent 10% rolls on Peregrin Rockskull.
- Leaves Peregrin's other loot unchanged.

## Why

- Keeps Plane of Earth raid progression in guild instances while preserving ordinary Earth A activity.
- Gives the raid encounters a consistent 66-hour respawn and loot-lockout schedule.
- Applies the Council lockout to Avatar of Earth, which represents completion of that encounter.
- Improves the War Drums opportunity without increasing Peregrin's unrelated loot.

## How we tested

- Confirmed the Earth ring encounters initialized correctly in Guild 1 during an active raid window.
- Verified the migration marks only the intended Tantisala, Council, and Earth B war-leader spawnpoints.
- Verified the 66-hour lockouts use 237,600 seconds.
- Verified the Guild 2+ instance timers use 237,600,000 milliseconds.
- Verified the five static respawns use 237,600 seconds with zero variance.
- Verified War Drums of the Rathe uses two independent 10% rolls.
- Verified Peregrin's other loot entries are unchanged.
- `git diff --check` passed.
- The complete 66-hour expiration was not tested in real time.

## Dependencies

- Requires EQMacEmu PR #376 for Guild 1 earthquake-based raid handling.
- EQMacEmu PR #402 is required for optional `#pvpzone` timed raid windows.
- Requires the matching `quest/poearth-progression` PR for complete scripted ring and Avatar handling.