### PR TITLE
Move Plane of Water raids into guild instances

### DIFF
--- a/utils/sql/git/content/2026_09_03_Plane_Of_Water_Instance_Progression.sql
+++ b/utils/sql/git/content/2026_09_03_Plane_Of_Water_Instance_Progression.sql
@@ -1,0 +1,48 @@
+-- Keep Plane of Water raid targets out of the open world and Guild 1 outside
+-- active quakes while preserving Fishlord quests, traps, and ordinary spawns.
+UPDATE `spawn2`
+SET `raid_target_spawnpoint` = 1,
+    `respawntime` = 237600,
+    `variance` = 0
+WHERE `id` IN (
+    365647, -- Coirnav the Avatar of Water
+    366321, -- Guardian of Coirnav
+    366616, -- Ofossaa the Enlightened
+    367443, -- Krziik the Mighty
+    366444, -- Grioihin the Wise
+    365909  -- Hydrotha
+);
+
+-- Two days, eighteen hours for Water raid loot and guild-instance respawns.
+UPDATE `npc_types`
+SET `loot_lockout` = 237600,
+    `instance_spawn_timer_override` = 237600000
+WHERE `id` IN (
+    216048, -- Coirnav the Avatar of Water
+    216053, -- Guardian of Coirnav
+    216040, -- Ofossaa the Enlightened
+    216041, -- Krziik the Mighty
+    216042, -- Grioihin the Wise
+    216043  -- Hydrotha
+);
+
+-- Grioihin is a guaranteed spawn and returns every eighteen hours.
+UPDATE `spawn2`
+SET `respawntime` = 64800
+WHERE `id` = 366444;
+
+UPDATE `npc_types`
+SET `loot_lockout` = 64800,
+    `instance_spawn_timer_override` = 64800000
+WHERE `id` = 216042;
+
+-- Raise Lute of the Flowing Waters from 5% to 10% per loot-table roll while
+-- retaining two rolls and keeping the lootdrop weights at a total of 100.
+UPDATE `lootdrop_entries`
+SET `chance` = CASE `item_id`
+    WHEN 10945 THEN 40 -- Ring of Algae
+    WHEN 16605 THEN 40 -- Seaweed Woven Leggings
+    WHEN 27994 THEN 20 -- Lute of the Flowing Waters
+END
+WHERE `lootdrop_id` = 8503
+  AND `item_id` IN (10945, 16605, 27994);


### PR DESCRIPTION
## What changed

- Marks six Plane of Water raid spawnpoints for guild-instance handling:
  - Coirnav the Avatar of Water
  - Guardian of Coirnav
  - Ofossaa the Enlightened
  - Krziik the Mighty
  - Grioihin the Wise
  - Hydrotha
- Sets those six spawnpoints to 66-hour respawns with no variance.
- Applies matching 66-hour loot lockouts and guild-instance respawns.
- Overrides Grioihin with an 18-hour respawn, instance timer, and loot lockout.
- Keeps Grioihin as a guaranteed spawn.
- Raises Lute of the Flowing Waters from 5% to 10% per loot-table roll while retaining two rolls.
- Rebalances the Ring of Algae, Seaweed Woven Leggings, and Lute weights to remain at a total of 100.
- Leaves Fishlord quests, traps, and ordinary Plane of Water spawns unchanged.

## Why

- Keeps the Plane of Water raid encounters in guild instances.
- Gives most Water raid targets a consistent 66-hour progression schedule.
- Preserves Grioihin as the shorter, repeatable 18-hour encounter.
- Improves the Lute opportunity without increasing the total lootdrop weight or changing unrelated loot.

## How we tested

- Verified the migration marks only the six intended raid spawnpoints.
- Verified the normal raid schedule uses 237,600 seconds and 237,600,000 milliseconds, which are exactly 66 hours.
- Verified Grioihin uses 64,800 seconds and 64,800,000 milliseconds, which are exactly 18 hours.
- Verified Grioihin remains a guaranteed spawn.
- Verified the Lute has a 20% share of each 50% loot-table roll, producing a 10% chance per roll while retaining two rolls.
- Verified the three adjusted lootdrop weights total 100.
- Verified Fishlord quests, traps, and ordinary spawnpoints are not changed.
- `git diff --check` passed.
- The complete 18-hour and 66-hour expirations were not tested in real time.

## Dependencies

- Requires EQMacEmu PR #376 for Guild 1 earthquake-based raid handling.
- EQMacEmu PR #402 is required for optional `#pvpzone` timed raid windows.