### PR TITLE
Support guild-specific Plane of Time instances

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -1111,6 +1111,7 @@ struct CZClientSignal_Struct {
 
 struct CZNPCSignal_Struct {
 	uint32 npctype_id;
+	uint32 guild_id;
 	int num;
 	char data[0];
 };

--- a/utils/sql/git/content/2026_09_04_Plane_of_Time_Instance_Tome.sql
+++ b/utils/sql/git/content/2026_09_04_Plane_of_Time_Instance_Tome.sql
@@ -1,0 +1,32 @@
+-- Add a guild-instance tome near the Plane of Time portal in Plane of Tranquility.
+INSERT INTO `doors` (
+    `id`,
+    `doorid`,
+    `zone`,
+    `name`,
+    `pos_y`,
+    `pos_x`,
+    `pos_z`,
+    `heading`,
+    `opentype`,
+    `dest_zone`,
+    `guild_zone_door`
+) VALUES (
+    6108354,
+    109,
+    'potranquility',
+    'POKTELE500',
+    -2194.97,
+    1126.11,
+    -914.22,
+    176,
+    58,
+    'potimea',
+    1
+) ON DUPLICATE KEY UPDATE
+    `pos_y` = VALUES(`pos_y`),
+    `pos_x` = VALUES(`pos_x`),
+    `pos_z` = VALUES(`pos_z`),
+    `heading` = VALUES(`heading`),
+    `dest_zone` = VALUES(`dest_zone`),
+    `guild_zone_door` = VALUES(`guild_zone_door`);

--- a/utils/sql/git/content/2026_09_05_Plane_of_Time_Loot_Lockouts.sql
+++ b/utils/sql/git/content/2026_09_05_Plane_of_Time_Loot_Lockouts.sql
@@ -1,0 +1,15 @@
+-- Plane of Time bosses share the 2 day 18 hour progression lockout.
+-- Controllers, event adds, the fake Vallon Zek, Zebuxoruk, and projections
+-- are intentionally excluded.
+UPDATE `npc_types`
+SET `loot_lockout` = 237600
+WHERE `id` IN (
+    223018, 223029, 223032, 223037, 223044,
+    223072, 223073, 223074, 223075, 223076,
+    223083, 223084, 223090, 223091, 223096, 223097,
+    223101, 223105, 223108, 223109, 223115, 223116,
+    223123, 223124, 223131, 223132, 223133, 223134,
+    223000, 223001, 223002, 223003,
+    223004, 223005, 223006, 223007,
+    223008
+);

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1578,9 +1578,12 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet& p) {
 	case ServerOP_CZSignalNPC: {
 		auto s = (CZNPCSignal_Struct*)pack->pBuffer;
 		uint32 zone_id = s->npctype_id / 1000u;						// NPC IDs have the zone IDs in them.  who cares about pets
-		ZoneServer* zs = zoneserver_list.FindByZoneID(zone_id, GUILD_NONE);
-		if (zs)
+		ZoneServer* zs = zoneserver_list.FindByZoneID(zone_id, s->guild_id);
+		if (zs) {
 			zs->SendPacket(pack);
+		} else {
+			zoneserver_list.TriggerBootup(zone_id, s->guild_id);
+		}
 		break;
 	}
 		case ServerOP_CZSetEntityVariableByNPCTypeID: {

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -397,6 +397,11 @@ void Lua_Client::MovePC(int zone_id, float x, float y, float z, float heading) {
 	self->MovePCQuest(zone_id, x, y, z, heading);
 }
 
+void Lua_Client::MovePCGuildID(int zone_id, uint32 guild_id, float x, float y, float z, float heading) {
+	Lua_Safe_Call_Void();
+	self->MovePCGuildID(zone_id, guild_id, x, y, z, heading);
+}
+
 void Lua_Client::ChangeLastName(const char *in) {
 	Lua_Safe_Call_Void();
 	self->ChangeLastName(in);
@@ -1538,6 +1543,7 @@ luabind::scope lua_register_client() {
 		.def("GetBindZoneID", (uint32(Lua_Client::*)(int))&Lua_Client::GetBindZoneID)
 		.def("GetTimesRebirthed", (uint32(Lua_Client::*)(void))&Lua_Client::GetTimesRebirthed)
 		.def("MovePC", (void(Lua_Client::*)(int,float,float,float,float))&Lua_Client::MovePC)
+		.def("MovePCGuildID", (void(Lua_Client::*)(int,uint32,float,float,float,float))&Lua_Client::MovePCGuildID)
 		.def("ChangeLastName", (void(Lua_Client::*)(const char *in))&Lua_Client::ChangeLastName)
 		.def("GetFactionLevel", (int(Lua_Client::*)(uint32,uint32,uint32,uint32,uint32,Lua_NPC))&Lua_Client::GetFactionLevel)
 		.def("GetFactionValue", (int(Lua_Client::*)(Lua_NPC))&Lua_Client::GetFactionValue)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -104,6 +104,7 @@ public:
 	uint32 GetBindZoneID(int index);
 	uint32 GetTimesRebirthed();
 	void MovePC(int zone, float x, float y, float z, float heading);
+	void MovePCGuildID(int zone, uint32 guild_id, float x, float y, float z, float heading);
 	void ChangeLastName(const char *in);
 	int GetFactionLevel(uint32 char_id, uint32 race, uint32 class_, uint32 deity, uint32 faction, Lua_NPC npc);
 	int GetFactionValue(Lua_NPC npc);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -752,6 +752,10 @@ void lua_cross_zone_signal_client_by_char_id(uint32 player_id, int signal) {
 	quest_manager.CrossZoneSignalPlayerByCharID(player_id, signal);
 }
 
+void lua_cross_zone_signal_npc_by_npc_type_id(uint32 npc_id, uint32 guild_id, int signal, const char *data) {
+	quest_manager.CrossZoneSignalNPCByNPCTypeID(npc_id, guild_id, signal, data);
+}
+
 void lua_cross_zone_signal_client_by_name(const char *player, int signal) {
 	quest_manager.CrossZoneSignalPlayerByName(player, signal);
 }
@@ -1568,6 +1572,7 @@ luabind::scope lua_register_general() {
 		luabind::def("remove_title", &lua_remove_title),
 		luabind::def("wear_change", &lua_wear_change),
 		luabind::def("cross_zone_signal_client_by_char_id", &lua_cross_zone_signal_client_by_char_id),
+		luabind::def("cross_zone_signal_npc_by_npc_type_id", &lua_cross_zone_signal_npc_by_npc_type_id),
 		luabind::def("cross_zone_signal_client_by_name", &lua_cross_zone_signal_client_by_name),
 		luabind::def("cross_zone_message_player_by_name", &lua_cross_zone_message_player_by_name),
 		luabind::def("get_qglobals", (luabind::adl::object(*)(lua_State*,Lua_NPC,Lua_Client))&lua_get_qglobals),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2346,10 +2346,15 @@ const char* QuestManager::GetZoneLongName(const char *zone) {
 }
 
 void QuestManager::CrossZoneSignalNPCByNPCTypeID(uint32 npctype_id, int num, const char* data){
+	CrossZoneSignalNPCByNPCTypeID(npctype_id, GUILD_NONE, num, data);
+}
+
+void QuestManager::CrossZoneSignalNPCByNPCTypeID(uint32 npctype_id, uint32 guild_id, int num, const char* data){
 	uint32 data_len = data ? strlen(data) + 1 : 1;
 	auto pack = new ServerPacket(ServerOP_CZSignalNPC, sizeof(CZNPCSignal_Struct) + data_len);
 	CZNPCSignal_Struct* CZSN = (CZNPCSignal_Struct*)pack->pBuffer;
 	CZSN->npctype_id = npctype_id;
+	CZSN->guild_id = guild_id;
 	CZSN->num = num;
 	strcpy(CZSN->data, data ? data : "");
 	worldserver.SendPacket(pack);

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -217,6 +217,7 @@ public:
     const char *GetZoneLongName(const char *zone);
 	void CrossZoneSignalPlayerByCharID(int charid, uint32 data);
 	void CrossZoneSignalNPCByNPCTypeID(uint32 npctype_id, int num, const char* data = nullptr);
+	void CrossZoneSignalNPCByNPCTypeID(uint32 npctype_id, uint32 guild_id, int num, const char* data);
 	void CrossZoneSignalPlayerByName(const char *CharName, uint32 data);
 	void CrossZoneSetEntityVariableByNPCTypeID(uint32 npctype_id, const char *id, const char *m_var);
 	void CrossZoneMessagePlayerByName(uint32 Type, const char *CharName, const char *Message);


### PR DESCRIPTION
## What changed

- Adds a guild-instance Plane of Time entry tome in Plane of Tranquility.
- Adds a Lua function for moving players into the destination zone under their guild instance ID.
- Adds guild-aware cross-zone NPC signals so Plane of Time scripts can contact the correct guild's copy of a zone.
- Starts the requested guild zone when it is not already running.
- Applies a 66-hour loot lockout to the 37 intended Plane of Time bosses.
- Excludes event controllers, temporary adds, projections, the fake Vallon Zek, and Zebuxoruk from the boss lockout.

## Why

Plane of Time uses multiple connected zones. Player movement and event signals need to retain the guild ID so one guild's progression cannot affect another guild's instance.

The loot lockouts are applied only to the actual raid bosses instead of event-control or temporary NPCs.

## How we tested

- The Server Docker build passed.
- Tested the paired Plane of Time flow with two guilds and confirmed they entered separate guild copies of Plane of Time B.
- Confirmed the entry tome routes players using their guild instance ID.
- Confirmed the SQL applies a 237,600-second lockout to the intended 37 boss NPC types.
- The complete 66-hour expiration was not tested in real time.

## Dependencies

- None for this Server PR itself.
- The matching QuarmQuests Plane of Time PR must merge after this PR because it uses the new Lua movement and guild-targeted signal functions.
- The matching QuarmQuests PR also requires EQMacEmu PR #402, and therefore its #376 raid-respawn foundation, for the Guild 1 raid-window restrictions.