### PR TITLE
Remove duplicate Guild 1 raid declarations

### DIFF
--- a/zone/zone.h
+++ b/zone/zone.h
@@ -318,9 +318,6 @@ public:
 	bool	IsWaterZone(float z);
 	bool	ZoneWillNotIdle() { return newzone_data.never_idle; };
 	bool	IsIdling() { return (idle || (numclients <= 0 && ZoneWillNotIdle())); };
-	bool	GuildOneTimedRaidSpawnsEnabled();
-	int guild_one_raid_tier = -1;
-	uint32 guild_one_raid_tier_refresh = 0;
 	inline	bool BuffTimersSuspended() const { return newzone_data.SuspendBuffs != 0; };
 
 	std::vector<GridRepository::Grid> grids;


### PR DESCRIPTION
## What changed

- Removes duplicate Guild 1 raid declarations from `zone/zone.h`.
- Keeps the declarations grouped with `GuildOneRaidWindowOpen()`.

## Why

The duplicates were introduced while resolving conflicts for #402 and would prevent the server from compiling.

## How tested

- Compared the merged #402 code against the original branch.
- Confirmed the remaining declarations match the original implementation.
- `git diff --check` passed.

## Dependencies

- None. This is a follow-up fix for #402.