### PR TITLE
Increase Aerin'Dar key piece drop rate

### DIFF
--- a/utils/sql/git/content/2026_09_09_PoValor_Aerin_Dar_Key_Drop.sql
+++ b/utils/sql/git/content/2026_09_09_PoValor_Aerin_Dar_Key_Drop.sql
@@ -1,0 +1,7 @@
+-- Increase the Piece of the Crystalline Globe drop probability
+-- from an Undead Vassal from 5% to 10%.
+UPDATE loottable_entries
+SET probability = 10
+WHERE loottable_id = 4989
+  AND lootdrop_id = 22761
+  AND probability = 5;


### PR DESCRIPTION
## What

Increases the Piece of the Crystalline Globe drop probability from an Undead Vassal from 5% to 10%.

## Why

Sergeant Terrick Burns guarantees the key piece but is a rare spawn. Undead Vassals are more common, but their existing 5% probability makes the alternate path unnecessarily restrictive.

## Testing

- Verified the Vassal uses loottable `4989` and lootdrop `22761`.
- Confirmed the live database probability is 10%.
- The migration changes only the Vassal’s parent loottable probability.
- `git diff --cached --check` passes.

## Dependency

None.