### PR TITLE
Add missing Planes of Power launch drops

### DIFF
--- a/utils/sql/git/content/2026_09_07_Plane_of_Time_Phase_Three_Ossein.sql
+++ b/utils/sql/git/content/2026_09_07_Plane_of_Time_Phase_Three_Ossein.sql
@@ -1,0 +1,42 @@
+INSERT INTO lootdrop_entries (
+    lootdrop_id,
+    item_id,
+    item_charges,
+    equip_item,
+    chance,
+    minlevel,
+    maxlevel,
+    multiplier,
+    disabled_chance,
+    min_expansion,
+    max_expansion,
+    min_looter_level,
+    item_loot_lockout_timer,
+    content_flags_disabled,
+    content_flags
+)
+SELECT
+    source.lootdrop_id,
+    32605,
+    source.item_charges,
+    source.equip_item,
+    source.chance,
+    source.minlevel,
+    source.maxlevel,
+    source.multiplier,
+    source.disabled_chance,
+    source.min_expansion,
+    source.max_expansion,
+    source.min_looter_level,
+    source.item_loot_lockout_timer,
+    source.content_flags_disabled,
+    source.content_flags
+FROM lootdrop_entries AS source
+WHERE source.lootdrop_id = 22799
+  AND source.item_id = 26789
+  AND NOT EXISTS (
+      SELECT 1
+      FROM lootdrop_entries AS existing
+      WHERE existing.lootdrop_id = source.lootdrop_id
+        AND existing.item_id = 32605
+  );

--- a/utils/sql/git/content/2026_09_09_PoP_Missing_Launch_Drops.sql
+++ b/utils/sql/git/content/2026_09_09_PoP_Missing_Launch_Drops.sql
@@ -1,0 +1,53 @@
+-- Add missing Plane of Power launch-era drops as independent 10% drops.
+
+INSERT INTO lootdrop (
+    id,
+    name,
+    min_expansion,
+    max_expansion,
+    content_flags,
+    content_flags_disabled
+)
+VALUES
+    (6150535, 'PoTime_Cazic_Thule_Bo_Staff_of_Transcendence', -1, -1, NULL, NULL),
+    (6150536, 'Mujaki_Recurved_Wormwood_Bow', -1, -1, NULL, NULL),
+    (6150537, 'Avatar_of_Smoke_Alabaster_Hilted_Wind_Bow', -1, -1, NULL, NULL),
+    (6150538, 'Krziik_Ornate_Abalone_Recurve_Bow', -1, -1, NULL, NULL);
+
+INSERT INTO lootdrop_entries (
+    lootdrop_id,
+    item_id,
+    item_charges,
+    equip_item,
+    chance,
+    minlevel,
+    maxlevel,
+    multiplier,
+    disabled_chance,
+    min_expansion,
+    max_expansion,
+    min_looter_level,
+    item_loot_lockout_timer,
+    content_flags_disabled,
+    content_flags
+)
+VALUES
+    (6150535, 25225, 1, 0, 100, 0, 255, 1, 0, -1, -1, 0, 0, NULL, NULL),
+    (6150536, 27700, 1, 0, 100, 0, 255, 1, 0, -1, -1, 0, 0, NULL, NULL),
+    (6150537, 27986, 1, 0, 100, 0, 255, 1, 0, -1, -1, 0, 0, NULL, NULL),
+    (6150538, 27646, 1, 0, 100, 0, 255, 1, 0, -1, -1, 0, 0, NULL, NULL);
+
+INSERT INTO loottable_entries (
+    loottable_id,
+    lootdrop_id,
+    multiplier,
+    probability,
+    droplimit,
+    mindrop,
+    multiplier_min
+)
+VALUES
+    (4453,  6150535, 1, 10, 0, 0, 0), -- Cazic Thule
+    (2064,  6150536, 1, 10, 0, 0, 0), -- Mujaki the Devourer
+    (87587, 6150537, 1, 10, 0, 0, 0), -- Avatar of Smoke
+    (6222,  6150538, 1, 10, 0, 0, 0); -- Krziik the Mighty


### PR DESCRIPTION
## What

Adds five missing Plane of Power launch-era item drops.

- Adds Ossein of Limitless Time to the established shared Phase 3 loot pool used by the 16 intended Phase 3 NPCs.
- Adds Bo Staff of Transcendence to Phase 5 Cazic Thule at an independent 10% probability.
- Adds Recurved Wormwood Bow to Mujaki the Devourer at an independent 10% probability.
- Adds Alabaster Hilted Wind Bow to Avatar of Smoke at an independent 10% probability.
- Adds Ornate Abalone Recurve Bow to Krziik the Mighty at an independent 10% probability.

## Why

These launch-era drops were absent from their intended Plane of Power encounters.

Ossein follows the existing Phase 3 shared loot structure. The other four items use dedicated lootdrops so their addition does not alter existing guaranteed loot pools or expose the items through shared lootdrops used by unrelated NPCs.

## Testing

- Verified Ossein’s shared lootdrop resolves to exactly the intended 16 Phase 3 NPCs.
- Verified the other four items resolve only to their intended NPCs.
- Confirmed each dedicated drop uses a 10% parent probability and a 100% single-item entry.
- Confirmed the staged changes contain only the two intended SQL migrations.
- `git diff --cached --check` passes.

## Dependency

None.