### PR TITLE
Rework Rallosian Glory progression, rewards, and cooldowns

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1326,7 +1326,7 @@ void Client::HandleRallosianGloryDeath(Mob *killer_mob)
 		DataBucket::DeleteData(cooldown_key);
 		DataBucket::SetData(cooldown_key, "1", std::to_string(RallosianGloryCooldownSeconds));
 
-		const uint8 gained_glory = victim_glory > 0 ? victim_glory : 1;
+		const uint8 gained_glory = victim_glory > 0 ? (victim_glory + 1) / 2 : 1;
 		const uint8 old_killer_glory = killer->GetRallosianGlory();
 		killer->SetRallosianGlory(old_killer_glory + gained_glory);
 		const uint8 new_killer_glory = killer->GetRallosianGlory();

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1314,6 +1314,14 @@ void Client::HandleRallosianGloryDeath(Mob *killer_mob)
 	if (qualifying_kill && (killer_forum_id <= 0 || victim_forum_id <= 0 || killer_forum_id == victim_forum_id))
 		qualifying_kill = false;
 
+	if (qualifying_kill) {
+		const uint32 victim_zone_seconds =
+			Timer::GetTimeSeconds() - rallosian_glory_zone_entry_time;
+
+		qualifying_kill =
+			victim_zone_seconds >= RallosianGloryMinimumZoneSeconds;
+	}
+
 	std::string cooldown_key;
 	if (qualifying_kill) {
 		cooldown_key = fmt::format("rallosian_glory_kill_{}_{}", killer_forum_id, victim_forum_id);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1315,25 +1315,55 @@ void Client::HandleRallosianGloryDeath(Mob *killer_mob)
 		qualifying_kill = false;
 
 	if (qualifying_kill) {
+		const uint32 now = Timer::GetTimeSeconds();
 		const uint32 victim_zone_seconds =
-			Timer::GetTimeSeconds() - rallosian_glory_zone_entry_time;
+			now - rallosian_glory_zone_entry_time;
+		const uint32 killer_zone_seconds =
+			now - killer->rallosian_glory_zone_entry_time;
 
 		qualifying_kill =
-			victim_zone_seconds >= RallosianGloryMinimumZoneSeconds;
+			victim_zone_seconds >= RallosianGloryMinimumZoneSeconds &&
+			killer_zone_seconds >= RallosianGloryMinimumZoneSeconds;
 	}
 
 	std::string cooldown_key;
+	std::string victim_cooldown_key;
+	std::string killer_cooldown_key;
 	if (qualifying_kill) {
-		cooldown_key = fmt::format("rallosian_glory_kill_{}_{}", killer_forum_id, victim_forum_id);
-		if (!DataBucket::GetData(cooldown_key).empty())
+		cooldown_key = fmt::format(
+			"rallosian_glory_kill_{}_{}",
+			killer_forum_id,
+			victim_forum_id
+		);
+		victim_cooldown_key =
+			fmt::format("rallosian_glory_victim_{}", victim_forum_id);
+		killer_cooldown_key =
+			fmt::format("rallosian_glory_killer_{}", killer_forum_id);
+
+		if (!DataBucket::GetData(cooldown_key).empty() ||
+				!DataBucket::GetData(victim_cooldown_key).empty() ||
+				!DataBucket::GetData(killer_cooldown_key).empty()) {
 			qualifying_kill = false;
+		}
 	}
 
 	std::string message;
 	if (qualifying_kill) {
 		DataBucket::DeleteData(cooldown_key);
 		DataBucket::SetData(cooldown_key, "1", std::to_string(RallosianGloryCooldownSeconds));
+		DataBucket::DeleteData(victim_cooldown_key);
+		DataBucket::SetData(
+			victim_cooldown_key,
+			"1",
+			std::to_string(RallosianGloryVictimCooldownSeconds)
+		);
 
+		DataBucket::DeleteData(killer_cooldown_key);
+		DataBucket::SetData(
+			killer_cooldown_key,
+			"1",
+			std::to_string(RallosianGloryKillerCooldownSeconds)
+		);
 		const uint8 gained_glory = victim_glory > 0 ? (victim_glory + 1) / 2 : 1;
 		const uint8 old_killer_glory = killer->GetRallosianGlory();
 		killer->SetRallosianGlory(old_killer_glory + gained_glory);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -180,6 +180,7 @@ m_AutoAttackTargetLocation(0.0f, 0.0f, 0.0f)
 	memset(forum_name, 0, sizeof(forum_name));
 	forum_id = 0;
 	rallosian_glory = 0;
+	rallosian_glory_zone_entry_time = Timer::GetTimeSeconds();
 	berserk = false;
 	dead = false;
 	initial_z_position = 0;

--- a/zone/client.h
+++ b/zone/client.h
@@ -714,7 +714,7 @@ public:
 	static constexpr uint32 RallosianGloryCooldownSeconds = 3600;
 	static constexpr uint32 RallosianGloryVictimCooldownSeconds = 3600;
 	static constexpr uint32 RallosianGloryKillerCooldownSeconds = 600;
-	static constexpr uint32 RallosianGloryMinimumZoneSeconds = 25 * 60;
+	static constexpr uint32 RallosianGloryMinimumZoneSeconds = 100;
 	inline int32 ForumID() const { return forum_id; }
 	inline uint8 GetRallosianGlory() const { return rallosian_glory; }
 	inline void SetRallosianGlory(uint8 rank) { rallosian_glory = rank > RallosianGloryMaxRank ? RallosianGloryMaxRank : rank; }

--- a/zone/client.h
+++ b/zone/client.h
@@ -709,8 +709,8 @@ public:
 	static constexpr uint8 RallosianGloryMaxRank = 10;
 	static constexpr uint8 RallosianGloryLevelRange = 5;
 	static constexpr uint8 RallosianGloryZoneXPBonus = 5;
-	static constexpr uint8 RallosianGloryRankXPBonus = 10;
-	static constexpr uint8 RallosianGloryRankAAXPBonus = 1;
+	static constexpr float RallosianGloryRankXPBonus = 2.5f;
+	static constexpr float RallosianGloryRankAAXPBonus = 0.5f;
 	static constexpr uint32 RallosianGloryCooldownSeconds = 3600;
 	static constexpr uint32 RallosianGloryVictimCooldownSeconds = 3600;
 	static constexpr uint32 RallosianGloryKillerCooldownSeconds = 600;

--- a/zone/client.h
+++ b/zone/client.h
@@ -711,6 +711,7 @@ public:
 	static constexpr uint8 RallosianGloryZoneXPBonus = 15;
 	static constexpr uint8 RallosianGloryRankXPBonus = 10;
 	static constexpr uint32 RallosianGloryCooldownSeconds = 3600;
+	static constexpr uint32 RallosianGloryMinimumZoneSeconds = 25 * 60;
 	inline int32 ForumID() const { return forum_id; }
 	inline uint8 GetRallosianGlory() const { return rallosian_glory; }
 	inline void SetRallosianGlory(uint8 rank) { rallosian_glory = rank > RallosianGloryMaxRank ? RallosianGloryMaxRank : rank; }
@@ -1568,7 +1569,8 @@ private:
 	char forum_name[31];
 	int32 forum_id;
 	uint8 rallosian_glory;
-
+	uint32 rallosian_glory_zone_entry_time;
+	
 	unsigned int AggroCount; // How many mobs are aggro on us.
 
 	LinkedList<ZoneFlags_Struct*> ZoneFlags;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1570,7 +1570,7 @@ private:
 	int32 forum_id;
 	uint8 rallosian_glory;
 	uint32 rallosian_glory_zone_entry_time;
-	
+
 	unsigned int AggroCount; // How many mobs are aggro on us.
 
 	LinkedList<ZoneFlags_Struct*> ZoneFlags;

--- a/zone/client.h
+++ b/zone/client.h
@@ -711,6 +711,8 @@ public:
 	static constexpr uint8 RallosianGloryZoneXPBonus = 15;
 	static constexpr uint8 RallosianGloryRankXPBonus = 10;
 	static constexpr uint32 RallosianGloryCooldownSeconds = 3600;
+	static constexpr uint32 RallosianGloryVictimCooldownSeconds = 3600;
+	static constexpr uint32 RallosianGloryKillerCooldownSeconds = 600;
 	static constexpr uint32 RallosianGloryMinimumZoneSeconds = 25 * 60;
 	inline int32 ForumID() const { return forum_id; }
 	inline uint8 GetRallosianGlory() const { return rallosian_glory; }

--- a/zone/client.h
+++ b/zone/client.h
@@ -708,8 +708,9 @@ public:
 
 	static constexpr uint8 RallosianGloryMaxRank = 10;
 	static constexpr uint8 RallosianGloryLevelRange = 5;
-	static constexpr uint8 RallosianGloryZoneXPBonus = 15;
+	static constexpr uint8 RallosianGloryZoneXPBonus = 5;
 	static constexpr uint8 RallosianGloryRankXPBonus = 10;
+	static constexpr uint8 RallosianGloryRankAAXPBonus = 1;
 	static constexpr uint32 RallosianGloryCooldownSeconds = 3600;
 	static constexpr uint32 RallosianGloryVictimCooldownSeconds = 3600;
 	static constexpr uint32 RallosianGloryKillerCooldownSeconds = 600;

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -415,12 +415,6 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, Mob* killed_mob, int16 av
 
 	add_exp = static_cast<uint32>(add_exp * lb_mult * mlm * con_mult * totalmod * buffmod); // multipliers that apply to level and aa exp
 
-	if (zone && zone->GetGuildID() == 1) {
-		const float pvp_bonus = 1.0f +
-			(static_cast<float>(RallosianGloryZoneXPBonus) / 100.0f) +
-			(static_cast<float>(GetRallosianGlory() * RallosianGloryRankXPBonus) / 100.0f);
-		add_exp = static_cast<uint32>(static_cast<float>(add_exp) * pvp_bonus);
-	}
 
 	// if NPC is killed by PBAoE damage, then reduce experience gained if NPC is in a certain level range. (42-55)  this is AK behavior although specifics are still not known
 	if (killed_mob->IsNPC() && RuleB(AlKabor, ReduceAEExp) && killed_mob->pbaoe_damage > (killed_mob->GetMaxHP() / 2))
@@ -497,6 +491,16 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, Mob* killed_mob, int16 av
 		//take that amount away from regular exp
 		add_exp -= add_aaxp;
 
+		if (zone && zone->GetGuildID() == 1) {
+			const float pvp_aa_bonus = 1.0f +
+				(static_cast<float>(RallosianGloryZoneXPBonus) / 100.0f) +
+				(static_cast<float>(GetRallosianGlory() * RallosianGloryRankAAXPBonus) / 100.0f);
+
+			add_aaxp = static_cast<uint32>(
+				static_cast<float>(add_aaxp) * pvp_aa_bonus
+			);
+		}
+
 		// Race modifiers apply to AA exp if AA exp is split
 		if (RuleB(AlKabor, RaceEffectsAASplit) && m_epp.perAA > 0 && m_epp.perAA < 100)
 		{
@@ -511,6 +515,16 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, Mob* killed_mob, int16 av
 		}
 		
 		add_aaxp = static_cast<uint32>(add_aaxp * race_mult * aa_lvl_mod * aa_mult);
+	}
+
+	if (zone && zone->GetGuildID() == 1) {
+		const float pvp_level_bonus = 1.0f +
+			(static_cast<float>(RallosianGloryZoneXPBonus) / 100.0f) +
+			(static_cast<float>(GetRallosianGlory() * RallosianGloryRankXPBonus) / 100.0f);
+
+		add_exp = static_cast<uint32>(
+			static_cast<float>(add_exp) * pvp_level_bonus
+		);
 	}
 
 	add_exp = static_cast<uint32>(add_exp * hbm * class_mult);  // applies to level exp only

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -493,7 +493,6 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, Mob* killed_mob, int16 av
 
 		if (zone && zone->GetGuildID() == 1) {
 			const float pvp_aa_bonus = 1.0f +
-				(static_cast<float>(RallosianGloryZoneXPBonus) / 100.0f) +
 				(static_cast<float>(GetRallosianGlory() * RallosianGloryRankAAXPBonus) / 100.0f);
 
 			add_aaxp = static_cast<uint32>(

--- a/zone/gm_commands/glory.cpp
+++ b/zone/gm_commands/glory.cpp
@@ -38,25 +38,22 @@ void command_glory(Client *c, const Seperator *sep)
 		Chat::White, "Rank: %u of %u - %s",
 		static_cast<unsigned>(rank), static_cast<unsigned>(Client::RallosianGloryMaxRank), RallosianGloryTitle(rank));
 	c->Message(
-		Chat::White, "Level Experience Bonus: +%u%% from Glory",
-		static_cast<unsigned>(rank * Client::RallosianGloryRankXPBonus));
+		Chat::White, "Level Experience Bonus: +%.1f%% from Glory",
+		static_cast<double>(rank) * Client::RallosianGloryRankXPBonus);
 	c->Message(
-		Chat::White, "AA Experience Bonus: +%u%% from Glory",
-		static_cast<unsigned>(rank * Client::RallosianGloryRankAAXPBonus));
+		Chat::White, "AA Experience Bonus: +%.1f%% from Glory",
+		static_cast<double>(rank) * Client::RallosianGloryRankAAXPBonus);
 	c->Message(
 		Chat::White, "Base Battlefield Bonus: +%u%% to level and AA experience",
 		static_cast<unsigned>(Client::RallosianGloryZoneXPBonus));
 	c->Message(
-		Chat::White, "Total Level XP Bonus: +%u%%",
-		static_cast<unsigned>(
-			Client::RallosianGloryZoneXPBonus +
-			rank * Client::RallosianGloryRankXPBonus
-		));
+		Chat::White, "Total Level XP Bonus: +%.1f%%",
+		static_cast<double>(Client::RallosianGloryZoneXPBonus) +
+		static_cast<double>(rank) * Client::RallosianGloryRankXPBonus);
 	c->Message(
-		Chat::White, "Total AA XP Bonus: +%u%%",
-		static_cast<unsigned>(
-			Client::RallosianGloryZoneXPBonus +
-			rank * Client::RallosianGloryRankAAXPBonus
+		Chat::White, "Total AA XP Bonus: +%.1f%%",
+		static_cast<double>(Client::RallosianGloryZoneXPBonus) +
+		static_cast<double>(rank) * Client::RallosianGloryRankAAXPBonus);
 		));
 
 	if (rank == 0) {

--- a/zone/gm_commands/glory.cpp
+++ b/zone/gm_commands/glory.cpp
@@ -44,7 +44,7 @@ void command_glory(Client *c, const Seperator *sep)
 		Chat::White, "AA Experience Bonus: +%.1f%% from Glory",
 		static_cast<double>(rank) * Client::RallosianGloryRankAAXPBonus);
 	c->Message(
-		Chat::White, "Base Battlefield Bonus: +%u%% to level and AA experience",
+		Chat::White, "Base Battlefield Bonus: +%u%% to level experience",
 		static_cast<unsigned>(Client::RallosianGloryZoneXPBonus));
 	c->Message(
 		Chat::White, "Total Level XP Bonus: +%.1f%%",
@@ -52,9 +52,7 @@ void command_glory(Client *c, const Seperator *sep)
 		static_cast<double>(rank) * Client::RallosianGloryRankXPBonus);
 	c->Message(
 		Chat::White, "Total AA XP Bonus: +%.1f%%",
-		static_cast<double>(Client::RallosianGloryZoneXPBonus) +
 		static_cast<double>(rank) * Client::RallosianGloryRankAAXPBonus);
-		));
 
 	if (rank == 0) {
 		c->Message(Chat::Yellow, "You bear no Rallosian Glory. Prove your strength against a worthy opponent, and the Warlord may turn his gaze upon you.");

--- a/zone/gm_commands/glory.cpp
+++ b/zone/gm_commands/glory.cpp
@@ -11,11 +11,11 @@ const char *RallosianGloryTitle(uint8 rank)
 		"Blooded Champion",
 		"Warbringer",
 		"Conqueror",
-		"Rallosian Ravager",
-		"The Warlord's Chosen",
-		"Herald of Slaughter",
-		"Scourge of Norrath",
-		"Chosen of the Warlord"
+		"Ravager",
+		"Chosen",
+		"Harbinger of Rallos Zek",
+		"Herald of Rallos Zek",
+		"Fury of the Warlord"
 	};
 	static_assert(Client::RallosianGloryMaxRank == 10, "Rallosian Glory titles must match the rank cap");
 	return titles[std::min<uint8>(rank, Client::RallosianGloryMaxRank)];
@@ -38,14 +38,26 @@ void command_glory(Client *c, const Seperator *sep)
 		Chat::White, "Rank: %u of %u - %s",
 		static_cast<unsigned>(rank), static_cast<unsigned>(Client::RallosianGloryMaxRank), RallosianGloryTitle(rank));
 	c->Message(
-		Chat::White, "Experience Bonus: +%u%% from Glory",
+		Chat::White, "Level Experience Bonus: +%u%% from Glory",
 		static_cast<unsigned>(rank * Client::RallosianGloryRankXPBonus));
 	c->Message(
-		Chat::White, "Current Battlefield Bonus: +%u%%",
+		Chat::White, "AA Experience Bonus: +%u%% from Glory",
+		static_cast<unsigned>(rank * Client::RallosianGloryRankAAXPBonus));
+	c->Message(
+		Chat::White, "Base Battlefield Bonus: +%u%% to level and AA experience",
 		static_cast<unsigned>(Client::RallosianGloryZoneXPBonus));
 	c->Message(
-		Chat::White, "Total Battlefield Bonus: +%u%%",
-		static_cast<unsigned>(Client::RallosianGloryZoneXPBonus + rank * Client::RallosianGloryRankXPBonus));
+		Chat::White, "Total Level XP Bonus: +%u%%",
+		static_cast<unsigned>(
+			Client::RallosianGloryZoneXPBonus +
+			rank * Client::RallosianGloryRankXPBonus
+		));
+	c->Message(
+		Chat::White, "Total AA XP Bonus: +%u%%",
+		static_cast<unsigned>(
+			Client::RallosianGloryZoneXPBonus +
+			rank * Client::RallosianGloryRankAAXPBonus
+		));
 
 	if (rank == 0) {
 		c->Message(Chat::Yellow, "You bear no Rallosian Glory. Prove your strength against a worthy opponent, and the Warlord may turn his gaze upon you.");

--- a/zone/gm_commands/glory.cpp
+++ b/zone/gm_commands/glory.cpp
@@ -38,13 +38,13 @@ void command_glory(Client *c, const Seperator *sep)
 		Chat::White, "Rank: %u of %u - %s",
 		static_cast<unsigned>(rank), static_cast<unsigned>(Client::RallosianGloryMaxRank), RallosianGloryTitle(rank));
 	c->Message(
-		Chat::White, "Experience bonus: +%u%% from Glory",
+		Chat::White, "Experience Bonus: +%u%% from Glory",
 		static_cast<unsigned>(rank * Client::RallosianGloryRankXPBonus));
 	c->Message(
-		Chat::White, "Guild 1 battlefield bonus: +%u%%",
+		Chat::White, "Current Battlefield Bonus: +%u%%",
 		static_cast<unsigned>(Client::RallosianGloryZoneXPBonus));
 	c->Message(
-		Chat::White, "Total Guild 1 bonus: +%u%%",
+		Chat::White, "Total Battlefield Bonus: +%u%%",
 		static_cast<unsigned>(Client::RallosianGloryZoneXPBonus + rank * Client::RallosianGloryRankXPBonus));
 
 	if (rank == 0) {


### PR DESCRIPTION
## Summary

This PR improves the clarity, balance, and abuse resistance of the Rallosian Glory system used in Guild 1 PvP instances.

Rallosian Glory remains a personal, high-risk PvP progression system. Players build Glory through qualifying killing blows, receive increased experience while fighting in Guild 1, and lose all accumulated Glory upon death.

## Experience bonuses

The battlefield and Glory bonuses are now separated between level experience and AA experience.

### Level experience

- Base Guild 1 battlefield bonus: **15%**
- Glory bonus: **10% per rank**
- Maximum at rank 10: **125% total**

### AA experience

- Base Guild 1 battlefield bonus: **15%**
- Glory bonus: **10% per rank**
- Maximum at rank 10: **125% total**

The bonuses are applied after experience is divided between normal and AA experience, allowing each type to use its own multiplier.

The existing level-experience per-kill cap remains unchanged.

## Glory acquisition

Glory is awarded only to the player credited with a qualifying killing blow.

- A player killing blow credits that player.
- A pet killing blow credits the pet's owner.
- Group, raid, healing, and assist participation alone do not award Glory.
- Glory remains capped at rank 10.

A qualifying kill against an unranked victim awards **1 Glory**.

## Qualification requirements

A Glory award requires all of the following:

- The kill occurs inside a Guild 1 PvP instance.
- Both characters are PvP-enabled.
- Killer and victim are within five levels of each other.
- Killer and victim have different valid, positive forum IDs.
- Killer and victim are not dueling each other.
- Killer and victim are not in the same group.
- Killer and victim are not in the same raid.
- Killer and victim are not members of the same player guild.
- Both killer and victim have continuously occupied the current zone instance for at least **2 minutes**.
- None of the applicable award cooldowns are active.

The residency timer begins when the zone creates the client's current session. Zoning out or fully reconnecting resets the residency period. A zone process restart also resets residency.

## Anti-feeding cooldowns

Three cooldowns protect against repeated or coordinated Glory farming:

- **Killer/victim pair cooldown:** 10 minute
- **Victim-wide grant cooldown:** 10 minute
- **Killer-wide award cooldown:** 10 minutes

The victim-wide cooldown prevents one feeder from resurrecting and granting Glory to multiple different killers.

The killer-wide cooldown prevents one player from rapidly killing a prepared collection of eligible feeder characters.

Cooldowns are created only after a successful qualifying Glory award.

## Death penalty

Any death inside the Guild 1 instance removes all of the victim's Glory.

This remains true even when the death does not grant Glory, including:

- NPC or environmental deaths
- nonqualifying PvP deaths
- duel deaths
- deaths involving the same group, raid, guild, or forum identity
- deaths during an award cooldown
- deaths before completing the residency requirement

This preserves the intended high-risk nature of carrying Glory.

## `#glory` display

The `#glory` command now reports level and AA bonuses independently:

- current rank and title
- level experience gained from Glory
- AA experience gained from Glory
- base battlefield bonus
- total level experience bonus
- total AA experience bonus

Fractional values are displayed correctly for the 2.5% level and 0.5% AA rank bonuses.

The upper-rank Glory titles are also clarified.

## Persistence and scope

- No database migration is required.
- Existing forum-ID qualification remains in place.
- Existing Glory rank storage remains unchanged.
- The changes apply only while the character is inside a zone process whose zone guild ID is `1`.
- Player membership in an actual guild numbered 1 is not required.

## Validation

Completed:

- `git diff --check`
- Verified the 50% transfer calculation and rank cap
- Verified separate level/AA multiplier placement
- Verified killer and victim residency checks
- Verified pair, victim-wide, and killer-wide cooldown keys
- Verified `#glory` uses the new fractional constants
