### PR TITLE
Add #timelockout Plane of Time status command

### DIFF
--- a/utils/sql/git/content/2026_09_07_Plane_of_Time_Scripted_Lockouts.sql
+++ b/utils/sql/git/content/2026_09_07_Plane_of_Time_Scripted_Lockouts.sql
@@ -1,0 +1,16 @@
+-- Plane of Time manages defeated bosses and lootless repeats in its instance
+-- controller. Generic NPC loot lockouts can eject players who must repeat a
+-- completed encounter while recovering a partially finished phase.
+-- Keep generic lockouts disabled and let the controller own Time progression.
+UPDATE `npc_types`
+SET `loot_lockout` = 0
+WHERE `id` IN (
+    223018, 223029, 223032, 223037, 223044,
+    223072, 223073, 223074, 223075, 223076,
+    223083, 223084, 223090, 223091, 223096, 223097,
+    223101, 223105, 223108, 223109, 223115, 223116,
+    223123, 223124, 223131, 223132, 223133, 223134,
+    223000, 223001, 223002, 223003,
+    223004, 223005, 223006, 223007,
+    223008
+);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -365,6 +365,7 @@ int command_init(void)
 		command_add("showlootlockouts", "Shows your currently active loot lockouts. These do not apply to earthquake creatures.", AccountStatus::Player, command_showlootlockouts) ||
 		command_add("showquake", "Shows current earthquake timer. Requires you to be a guild officer or leader.", AccountStatus::Player, command_showquake) ||
 		command_add("takemoney", "[pp] [gp] [sp] [cp] [reason] - Takes specified amount of money from the target player.", AccountStatus::GMLeadAdmin, command_takemoney) ||
+           command_add("timelockout", "[phase 1-6] - Shows your Plane of Time timeline and encounter availability.", AccountStatus::Player, command_timelockout) ||
 		command_add("testcommand", "Template for temporary commands as needed. Don't delete.", AccountStatus::GMImpossible, command_testcommand) ||
 		command_add("testspawn", "[memloc] [value] - spawns a NPC for you only, with the specified values set in the spawn struct.", AccountStatus::GMCoder, command_testspawn) ||
 		command_add("togglepvp", "Toggles PVP for a client.", AccountStatus::Player, command_togglepvp) ||
@@ -1093,6 +1094,7 @@ void command_clearsaylink(Client *c, const Seperator *sep) {
 #include "gm_commands/suspend.cpp"
 #include "gm_commands/synctod.cpp"
 #include "gm_commands/takemoney.cpp"
+#include "gm_commands/timelockout.cpp"
 #include "gm_commands/testcommand.cpp"
 #include "gm_commands/testspawn.cpp"
 #include "gm_commands/togglepvp.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -237,6 +237,7 @@ void command_summonitem(Client* c, const Seperator* sep);
 void command_suspend(Client* c, const Seperator* sep);
 void command_synctod(Client* c, const Seperator* sep);
 void command_takemoney(Client* c, const Seperator* sep);
+void command_timelockout(Client* c, const Seperator* sep);
 void command_testcommand(Client* c, const Seperator* sep);
 void command_testspawn(Client* c, const Seperator* sep);
 void command_togglepvp(Client* c, const Seperator* sep);

--- a/zone/gm_commands/timelockout.cpp
+++ b/zone/gm_commands/timelockout.cpp
@@ -1,0 +1,269 @@
+#include "../client.h"
+
+#include "../../common/strings.h"
+
+#include <array>
+#include <ctime>
+#include <string>
+#include <vector>
+
+namespace {
+constexpr uint32 TimeControllerNPCTypeID = 223077;
+constexpr uint32 TimeBZoneID = 223;
+constexpr uint8 TimePhaseCount = 6;
+
+const std::array<std::vector<const char *>, TimePhaseCount> TimeBosses = {{
+	{"Terlok of Earth", "Neimon of Air", "Rythor of the Undead", "Anar of Water", "Kazrok of Fire"},
+	{"Windshapen Warlord of Air", "Earthen Overseer", "Ralthos Enrok", "War Shapen Emissary", "Gutripping War Beast"},
+	{
+		"A Ferocious Warboar", "Deathbringer Blackheart", "Xeroan Xi`Geruonask", "Kraksmaal Fir`Dethsin",
+		"A Deadly Warboar", "Deathbringer Skullsmash", "Herlsoakian", "Sinrunal Gorgedreal",
+		"Deathbringer Rianit", "A Needletusk Warboar", "Xerskel Gerodnsal", "Dersool Fal`Giersnaol",
+		"Undead Squad Leader", "Dark Knight of Terris", "Champion of Torment", "Dreamwarp",
+		"Avatar of the Elements", "Supernatural Guardian"
+	},
+	{"Saryrn", "Terris Thule", "Tallon Zek", "Vallon Zek"},
+	{"Cazic Thule", "Bertoxxulous", "Rallos Zek", "Innoruuk"},
+	{"Quarm"}
+}};
+
+uint8 TimeTimerIndex(uint8 phase, size_t boss_index)
+{
+	if (phase <= 3) {
+		return phase - 1;
+	}
+	if (phase == 4) {
+		return static_cast<uint8>(boss_index + 3);
+	}
+	if (phase == 5) {
+		return static_cast<uint8>(boss_index + 7);
+	}
+	return 11;
+}
+
+uint64 TimeDeadline(const std::vector<std::string> &timers, uint8 phase, size_t boss_index)
+{
+	const auto timer_index = TimeTimerIndex(phase, boss_index);
+	if (timer_index >= timers.size()) {
+		return 0;
+	}
+	return Strings::ToUnsignedBigInt(timers[timer_index]) * 100;
+}
+
+bool TimeBossAvailable(
+	const std::vector<std::string> &kills,
+	const std::vector<std::string> &timers,
+	uint8 phase,
+	size_t boss_index,
+	uint64 now
+)
+{
+	if (phase == 0 || phase > kills.size() || boss_index >= kills[phase - 1].size()) {
+		return false;
+	}
+	if (kills[phase - 1][boss_index] != '1') {
+		return true;
+	}
+	const auto deadline = TimeDeadline(timers, phase, boss_index);
+	return deadline == 0 || deadline <= now;
+}
+
+std::string TimeRemaining(uint64 deadline, uint64 now)
+{
+	if (deadline <= now) {
+		return "now";
+	}
+	return Strings::SecondsToTime(static_cast<int>(deadline - now));
+}
+
+uint8 TimeCurrentPhase(
+	const std::vector<std::string> &kills,
+	const std::vector<std::string> &timers,
+	uint64 now
+)
+{
+	for (uint8 phase = 1; phase <= TimePhaseCount; ++phase) {
+		for (size_t boss = 0; boss < TimeBosses[phase - 1].size(); ++boss) {
+			if (TimeBossAvailable(kills, timers, phase, boss, now)) {
+				return phase;
+			}
+		}
+	}
+	return 0;
+}
+}
+
+void command_timelockout(Client *c, const Seperator *sep)
+{
+	if (!c) {
+		return;
+	}
+
+	uint8 requested_phase = 0;
+	if (sep->argnum >= 1) {
+		if (!sep->IsNumber(1)) {
+			c->Message(Chat::White, "Usage: #timelockout [phase 1-6]");
+			return;
+		}
+		const auto parsed_phase = Strings::ToUnsignedInt(sep->arg[1]);
+		if (parsed_phase < 1 || parsed_phase > TimePhaseCount) {
+			c->Message(Chat::Red, "Plane of Time phases are numbered 1 through 6.");
+			return;
+		}
+		requested_phase = static_cast<uint8>(parsed_phase);
+	}
+
+	auto player_save = database.QueryDatabase(fmt::format(
+		"SELECT `name`, `value`, `expdate` FROM `quest_globals` "
+		"WHERE `charid` = {} AND `npcid` = 0 AND `zoneid` = 0 "
+		"AND `name` IN ('time_instance', 'time_instance_guild')",
+		c->CharacterID()
+	));
+	if (!player_save.Success()) {
+		c->Message(Chat::Red, "Your Plane of Time timeline could not be read. Please try again.");
+		return;
+	}
+
+	uint32 instance_id = 0;
+	uint32 saved_guild_id = 0;
+	uint64 player_expiration = 0;
+	for (auto row : player_save) {
+		const std::string name = row[0] ? row[0] : "";
+		if (name == "time_instance") {
+			instance_id = Strings::ToUnsignedInt(row[1] ? row[1] : "0");
+			player_expiration = Strings::ToUnsignedBigInt(row[2] ? row[2] : "0");
+		} else if (name == "time_instance_guild") {
+			saved_guild_id = Strings::ToUnsignedInt(row[1] ? row[1] : "0");
+		}
+	}
+
+	const uint64 now = static_cast<uint64>(std::time(nullptr));
+	if (instance_id == 0 || (player_expiration > 0 && player_expiration <= now)) {
+		c->Message(Chat::Yellow, "You are not currently bound to a Plane of Time timeline.");
+		return;
+	}
+
+	auto timeline = database.QueryDatabase(fmt::format(
+		"SELECT `name`, `value`, `expdate` FROM `quest_globals` "
+		"WHERE `charid` = 0 AND `npcid` = {} AND `zoneid` = {} "
+		"AND `name` IN ('time_kills_{}', 'time_timers_{}', 'time_guild_{}', 'time_expires_{}')",
+		TimeControllerNPCTypeID,
+		TimeBZoneID,
+		instance_id,
+		instance_id,
+		instance_id,
+		instance_id
+	));
+	if (!timeline.Success()) {
+		c->Message(Chat::Red, "Your Plane of Time timeline could not be read. Please try again.");
+		return;
+	}
+
+	std::string kill_data;
+	std::string timer_data;
+	uint32 owner_guild_id = 0;
+	uint64 timeline_expiration = 0;
+	uint64 retirement_deadline = 0;
+	for (auto row : timeline) {
+		const std::string name = row[0] ? row[0] : "";
+		if (name == fmt::format("time_kills_{}", instance_id)) {
+			kill_data = row[1] ? row[1] : "";
+			timeline_expiration = Strings::ToUnsignedBigInt(row[2] ? row[2] : "0");
+		} else if (name == fmt::format("time_timers_{}", instance_id)) {
+			timer_data = row[1] ? row[1] : "";
+		} else if (name == fmt::format("time_guild_{}", instance_id)) {
+			owner_guild_id = Strings::ToUnsignedInt(row[1] ? row[1] : "0");
+		} else if (name == fmt::format("time_expires_{}", instance_id)) {
+			retirement_deadline = Strings::ToUnsignedBigInt(row[1] ? row[1] : "0");
+		}
+	}
+
+	if (kill_data.empty() || timer_data.empty()) {
+		c->Message(Chat::Red, "Your saved thread of time has faded and can no longer be restored.");
+		return;
+	}
+
+	const auto kills = Strings::Split(kill_data, ';');
+	const auto timers = Strings::Split(timer_data, ';');
+	if (kills.size() != TimePhaseCount || timers.size() != 12) {
+		c->Message(Chat::Red, "Your Plane of Time timeline is damaged. Please contact support.");
+		return;
+	}
+	for (uint8 phase = 1; phase <= TimePhaseCount; ++phase) {
+		if (kills[phase - 1].size() != TimeBosses[phase - 1].size()) {
+			c->Message(Chat::Red, "Your Plane of Time timeline is damaged. Please contact support.");
+			return;
+		}
+	}
+
+	if (owner_guild_id == 0) {
+		owner_guild_id = saved_guild_id;
+	}
+	const auto current_phase = TimeCurrentPhase(kills, timers, now);
+
+	c->Message(Chat::Lime, "=== Plane of Time Timeline ===");
+	c->Message(Chat::White, "Timeline: %u", instance_id);
+	if (owner_guild_id > 0) {
+		c->Message(Chat::White, "Guild instance: %u", owner_guild_id);
+		if (saved_guild_id > 0 && saved_guild_id != owner_guild_id) {
+			c->Message(Chat::Red, "Warning: Your character is bound to a different guild's copy of this timeline.");
+		}
+	} else {
+		c->Message(Chat::Yellow, "Guild instance: Legacy save; ownership will be recorded when restored.");
+	}
+	if (retirement_deadline > now) {
+		c->Message(Chat::White, "Timeline retires in: %s", TimeRemaining(retirement_deadline, now).c_str());
+	} else if (retirement_deadline > 0) {
+		c->Message(Chat::Yellow, "This timeline will retire after the active run ends. Your next entry will begin a fresh timeline.");
+	} else if (timeline_expiration > now) {
+		c->Message(Chat::White, "Timeline record expires in: %s", TimeRemaining(timeline_expiration, now).c_str());
+	}
+
+	if (requested_phase > 0) {
+		c->Message(Chat::Yellow, "Phase %u encounter status:", requested_phase);
+		for (size_t boss = 0; boss < TimeBosses[requested_phase - 1].size(); ++boss) {
+			if (current_phase > 0 && requested_phase > current_phase) {
+				c->Message(Chat::White, "%s: Not yet accessible", TimeBosses[requested_phase - 1][boss]);
+				continue;
+			}
+			if (TimeBossAvailable(kills, timers, requested_phase, boss, now)) {
+				c->Message(Chat::Lime, "%s: Available", TimeBosses[requested_phase - 1][boss]);
+				continue;
+			}
+			const auto deadline = TimeDeadline(timers, requested_phase, boss);
+			c->Message(
+				Chat::Yellow,
+				"%s: Defeated - available again in %s",
+				TimeBosses[requested_phase - 1][boss],
+				TimeRemaining(deadline, now).c_str()
+			);
+		}
+		return;
+	}
+
+	for (uint8 phase = 1; phase <= TimePhaseCount; ++phase) {
+		uint32 available = 0;
+		uint64 next_deadline = 0;
+		for (size_t boss = 0; boss < TimeBosses[phase - 1].size(); ++boss) {
+			if (TimeBossAvailable(kills, timers, phase, boss, now)) {
+				++available;
+			} else {
+				const auto deadline = TimeDeadline(timers, phase, boss);
+				if (next_deadline == 0 || deadline < next_deadline) {
+					next_deadline = deadline;
+				}
+			}
+		}
+
+		if (current_phase > 0 && phase > current_phase) {
+			c->Message(Chat::White, "Phase %u: Not yet accessible", phase);
+		} else if (available > 0) {
+			c->Message(Chat::Lime, "Phase %u: %u of %zu encounters available", phase, available, TimeBosses[phase - 1].size());
+		} else if (next_deadline > now) {
+			c->Message(Chat::Yellow, "Phase %u: Complete - first encounter returns in %s", phase, TimeRemaining(next_deadline, now).c_str());
+		} else {
+			c->Message(Chat::Yellow, "Phase %u: Complete", phase);
+		}
+	}
+	c->Message(Chat::White, "Use #timelockout <1-6> to list a phase's encounters.");
+}


### PR DESCRIPTION
#418 and #131: “Merge together: Plane of Time timeline behavior and #timelockout status support.”

## What changed

- Adds the player-accessible `#timelockout [phase 1-6]` command.
- Displays the character's Plane of Time timeline ID and guild ownership.
- Displays timeline retirement or record-expiration time.
- Shows the first currently accessible phase.
- Shows encounter availability and remaining lockout time by phase.
- Warns when character and timeline guild ownership disagree.
- Detects missing or malformed timeline state.
- Disables generic NPC loot lockouts for scripted Plane of Time encounters.

## Why

Plane of Time now persists encounter kills, timers, guild ownership, and timeline retirement through quest globals.

Generic NPC loot lockouts conflict with the scripted system because previously defeated Phase 1 encounters may need to run as lootless repeats when restoring a partially completed timeline. The Time controller must remain the authoritative source for encounter availability.

The new command makes this state visible to players and provides a practical way to verify continuation across raid reformations, zone shutdowns, and full server restarts.

## Testing
- Used `#timelockout` on active Guild 2 and Guild 3 timelines.
- Verified separate timeline and guild IDs.
- Verified phase summaries and detailed encounter listings.
- Verified defeated encounters display remaining lockout time.
- Verified later phases remain inaccessible until prior progression is complete.
- Verified timeline retirement time is displayed.
- Verified operation across Zone and full Compose restarts.
- `git diff --check` passed.
- 
## Dependencies

- Companion to SecretsOTheP/quests#131.
- The scripted-lockout SQL and the Plane of Time Lua timeline controller should be merged and deployed together.
- Deploying the SQL alone would disable generic Time boss loot lockouts before the scripted controller becomes authoritative.