### PR TITLE
Allow pets to bypass bane-only melee immunity

### DIFF
--- a/utils/sql/git/content/2026_09_12_Disable_Vex_Thal_Warders.sql
+++ b/utils/sql/git/content/2026_09_12_Disable_Vex_Thal_Warders.sql
@@ -1,0 +1,6 @@
+-- Disable Akhevan warder spawn points. Keep the rows for a reversible content change.
+UPDATE spawn2 AS s2
+JOIN spawnentry AS se ON se.spawngroupID = s2.spawngroupID
+SET s2.enabled = 0
+WHERE s2.zone = 'vexthal'
+  AND se.npcID IN (158393, 158399, 158405, 158409, 158418);


### PR DESCRIPTION
Allows player pets to bypass NPC bane melee-immunity checks.

This lets pets contribute melee damage against encounters that require a specific bane weapon from players.

Player bane requirements remain unchanged; this affects pet melee handling only.